### PR TITLE
fix(nfo): render NFO aired date as plain date and pass force: true to redownloads

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -53,6 +53,7 @@ config :pinchflat, PinchflatWeb.Endpoint,
 
 config :pinchflat, Oban,
   engine: Oban.Engines.Lite,
+  notifier: Oban.Notifiers.PG,
   repo: Pinchflat.Repo
 
 # Configures the mailer

--- a/lib/pinchflat/downloading/downloading_helpers.ex
+++ b/lib/pinchflat/downloading/downloading_helpers.ex
@@ -130,6 +130,8 @@ defmodule Pinchflat.Downloading.DownloadingHelpers do
       )
     )
     |> Repo.all()
-    |> Enum.map(&MediaDownloadWorker.kickoff_with_task/1)
+    # `force: true` is required because these media items have already been downloaded.
+    # Without it the worker's pending-download check fails and the job no-ops.
+    |> Enum.map(&MediaDownloadWorker.kickoff_with_task(&1, %{force: true}))
   end
 end

--- a/lib/pinchflat/metadata/nfo_builder.ex
+++ b/lib/pinchflat/metadata/nfo_builder.ex
@@ -53,7 +53,7 @@ defmodule Pinchflat.Metadata.NfoBuilder do
       <showtitle>#{safe(metadata["uploader"])}</showtitle>
       <uniqueid type="youtube" default="true">#{safe(metadata["id"])}</uniqueid>
       <plot>#{safe(metadata["description"])}</plot>
-      <aired>#{safe(upload_date)}</aired>
+      <aired>#{safe(DateTime.to_date(upload_date))}</aired>
       <season>#{safe(season)}</season>
       <episode>#{episode}</episode>
       <genre>YouTube</genre>

--- a/test/pinchflat/downloading/downloading_helpers_test.exs
+++ b/test/pinchflat/downloading/downloading_helpers_test.exs
@@ -135,7 +135,7 @@ defmodule Pinchflat.Downloading.DownloadingHelpersTest do
 
       assert [{:ok, _}] = DownloadingHelpers.kickoff_redownload_for_existing_media(source)
 
-      assert_enqueued(worker: MediaDownloadWorker, args: %{"id" => media_item.id})
+      assert_enqueued(worker: MediaDownloadWorker, args: %{"id" => media_item.id, "force" => true})
     end
 
     test "doesn't enqueue jobs for media that should be ignored" do

--- a/test/pinchflat/metadata/nfo_builder_test.exs
+++ b/test/pinchflat/metadata/nfo_builder_test.exs
@@ -46,6 +46,21 @@ defmodule Pinchflat.Metadata.NfoBuilderTest do
       assert String.contains?(nfo, "hello&#39; &amp; &lt;world&gt;")
     end
 
+    test "renders the aired date as a plain date with no time or timezone", %{filepath: filepath} do
+      metadata = %{
+        "title" => "title",
+        "uploader" => "uploader",
+        "id" => "id",
+        "description" => "description",
+        "upload_date" => "20210101"
+      }
+
+      result = NfoBuilder.build_and_store_for_media_item(filepath, metadata)
+      nfo = File.read!(result)
+
+      assert String.contains?(nfo, "<aired>2021-01-01</aired>")
+    end
+
     test "uses the season and episode number from the filepath if it can be determined" do
       metadata = %{
         "title" => "title",

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -26,7 +26,7 @@ defmodule PinchflatWeb.ConnCase do
       alias Pinchflat.Repo
 
       use PinchflatWeb, :verified_routes
-      use Oban.Testing, repo: Repo
+      use Oban.Testing, repo: Repo, engine: Oban.Engines.Lite
 
       # Import conveniences for testing with connections
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -21,7 +21,7 @@ defmodule Pinchflat.DataCase do
     quote do
       alias Pinchflat.Repo
 
-      use Oban.Testing, repo: Repo
+      use Oban.Testing, repo: Repo, engine: Oban.Engines.Lite
 
       import Mox
       import Ecto


### PR DESCRIPTION
Ports Section 1 of the upgrade plan: NFO aired date formatting for Jellyfin compatibility, passing force: true to redownloads, and fixing Oban 2.23.0 Postgres notifier test issue.