### PR TITLE
fix(indexing): keep indexing reschedule from deduping against its own executing job

### DIFF
--- a/lib/pinchflat/fast_indexing/fast_indexing_worker.ex
+++ b/lib/pinchflat/fast_indexing/fast_indexing_worker.ex
@@ -78,7 +78,15 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorker do
   defp reschedule_indexing(source) do
     next_run_in = Source.fast_index_frequency() * 60
 
-    case kickoff_with_task(source, schedule_in: next_run_in) do
+    # The worker dedupes new jobs against the `:incomplete` states, which include
+    # `:executing`, to prevent concurrent indexing of the same source. This reschedule,
+    # however, runs from _inside_ the executing job, so deduping against `:executing`
+    # would treat the still-running job as a duplicate of its own successor and silently
+    # skip rescheduling. Override the insert to dedupe against pending states only so the
+    # next run is always enqueued (while still preventing duplicate pending jobs).
+    unique_opts = [period: :infinity, states: [:available, :scheduled, :retryable]]
+
+    case kickoff_with_task(source, schedule_in: next_run_in, unique: unique_opts) do
       {:ok, task} -> {:ok, task}
       {:error, :duplicate_job} -> {:ok, :job_exists}
     end

--- a/lib/pinchflat/slow_indexing/media_collection_indexing_worker.ex
+++ b/lib/pinchflat/slow_indexing/media_collection_indexing_worker.ex
@@ -115,12 +115,22 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorker do
     next_run_in = source.index_frequency_minutes * 60
 
     %{id: source.id}
-    |> MediaCollectionIndexingWorker.new(schedule_in: next_run_in)
+    |> MediaCollectionIndexingWorker.new(schedule_in: next_run_in, unique: reschedule_unique_opts())
     |> Tasks.create_job_with_task(source)
     |> case do
       {:ok, task} -> {:ok, task}
       {:error, :duplicate_job} -> {:ok, :job_exists}
     end
+  end
+
+  # The worker dedupes new jobs against the `:incomplete` states, which include
+  # `:executing`, to prevent concurrent indexing of the same source. This reschedule,
+  # however, runs from _inside_ the executing job, so deduping against `:executing`
+  # would treat the still-running job as a duplicate of its own successor and silently
+  # skip rescheduling. Override the insert to dedupe against pending states only so the
+  # next run is always enqueued (while still preventing duplicate pending jobs).
+  defp reschedule_unique_opts do
+    [period: :infinity, states: [:available, :scheduled, :retryable]]
   end
 
   defp maybe_enqueue_fast_indexing_task(source) do

--- a/test/pinchflat/fast_indexing/fast_indexing_worker_test.exs
+++ b/test/pinchflat/fast_indexing/fast_indexing_worker_test.exs
@@ -54,6 +54,26 @@ defmodule Pinchflat.FastIndexing.FastIndexingWorkerTest do
       assert [_] = all_enqueued(worker: FastIndexingWorker)
     end
 
+    test "reschedules even though the current job is still executing" do
+      expect(HTTPClientMock, :get, fn _url -> {:ok, ""} end)
+      source = source_fixture(fast_index: true)
+
+      # The worker dedupes against the :incomplete states (which include :executing).
+      # Simulate the real Oban executor by leaving the current job in the :executing
+      # state while perform/1 runs - the reschedule must not see it as a duplicate of
+      # its own successor and silently skip rescheduling.
+      {:ok, job} = Oban.insert(FastIndexingWorker.new(%{id: source.id}))
+      Repo.update!(Ecto.Changeset.change(job, state: "executing"))
+
+      perform_job(FastIndexingWorker, %{id: source.id})
+
+      assert_enqueued(
+        worker: FastIndexingWorker,
+        args: %{"id" => source.id},
+        scheduled_at: now_plus(Source.fast_index_frequency(), :minutes)
+      )
+    end
+
     test "does not call out to Youtube RSS if disabled" do
       expect(HTTPClientMock, :get, 0, fn _url -> {:ok, ""} end)
       source = source_fixture(fast_index: false)

--- a/test/pinchflat/slow_indexing/media_collection_indexing_worker_test.exs
+++ b/test/pinchflat/slow_indexing/media_collection_indexing_worker_test.exs
@@ -203,6 +203,25 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
       )
     end
 
+    test "reschedules even though the current job is still executing" do
+      source = source_fixture(index_frequency_minutes: 10)
+
+      # The worker dedupes against the :incomplete states (which include :executing).
+      # Simulate the real Oban executor by leaving the current job in the :executing
+      # state while perform/1 runs - the reschedule must not see it as a duplicate of
+      # its own successor and silently skip rescheduling.
+      {:ok, job} = Oban.insert(MediaCollectionIndexingWorker.new(%{id: source.id}))
+      Repo.update!(Ecto.Changeset.change(job, state: "executing"))
+
+      perform_job(MediaCollectionIndexingWorker, %{id: source.id})
+
+      assert_enqueued(
+        worker: MediaCollectionIndexingWorker,
+        args: %{"id" => source.id},
+        scheduled_at: now_plus(source.index_frequency_minutes, :minutes)
+      )
+    end
+
     test "creates a task for the rescheduled job" do
       source = source_fixture(index_frequency_minutes: 10)
 


### PR DESCRIPTION
Ports Section 2: Overrides the unique options during fast/slow indexing worker reschedule so they do not dedupe against the currently executing job.