### PR TITLE
feat: settings controls - yt-dlp update policy and API key testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For installation, configuration, and the base feature set, use the actual upstre
 - **Cookie Management UI:** Upload, paste, and inspect the shared `cookies.txt` file directly from the app.
 - **Download Speed Visibility:** See live download speed in the jobs dashboard and media tables.
 - **Smarter Retry Behavior:** Retry flows clear stale errors properly and keep task state more accurate.
-- **Nightly yt-dlp Builds:** Track newer yt-dlp builds for faster compatibility with upstream extractor changes.
+- **Control yt-dlp Updates:** Track nightly, nightly-until-stable, or pinned versions instead of always auto-updating.
 
 ### Operations
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -7,6 +7,7 @@ config :pinchflat,
   media_directory: Path.join([System.tmp_dir!(), "test", "media"]),
   metadata_directory: Path.join([System.tmp_dir!(), "test", "metadata"]),
   tmpfile_directory: Path.join([System.tmp_dir!(), "test", "tmpfiles"]),
+  extras_directory: Path.join([System.tmp_dir!(), "test", "extras"]),
   file_watcher_poll_interval: 50
 
 config :pinchflat, Oban, testing: :manual

--- a/lib/pinchflat/fast_indexing/youtube_api.ex
+++ b/lib/pinchflat/fast_indexing/youtube_api.ex
@@ -14,6 +14,10 @@ defmodule Pinchflat.FastIndexing.YoutubeApi do
 
   @agent_name {:global, __MODULE__.KeyIndex}
 
+  # A well-known public playlist (YouTube's "Popular Right Now" uploads playlist)
+  # used to verify that an API key is accepted by the YouTube API.
+  @test_playlist_id "PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf"
+
   @doc """
   Determines if the YouTube API is enabled for fast indexing by checking
   if the user has an API key set
@@ -22,6 +26,23 @@ defmodule Pinchflat.FastIndexing.YoutubeApi do
   """
   @impl YoutubeBehaviour
   def enabled?, do: Enum.any?(api_keys())
+
+  @doc """
+  Tests if a YouTube API key is accepted by making a simple API request.
+
+  A successful (HTTP 200) response means the key is valid. Any other response
+  is surfaced as an error since the underlying HTTP client only returns the
+  body on success.
+
+  Returns :ok | {:error, binary()}
+  """
+  @impl YoutubeBehaviour
+  def test_api_key(api_key) when is_binary(api_key) do
+    case http_client().get(construct_test_endpoint(api_key), accept: "application/json") do
+      {:ok, _response} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   @doc """
   Fetches the recent media IDs from the YouTube API for a given source.
@@ -123,6 +144,12 @@ defmodule Pinchflat.FastIndexing.YoutubeApi do
     max_results = 50
 
     "#{api_base}?part=#{property_type}&maxResults=#{max_results}&playlistId=#{playlist_id}&key=#{next_api_key()}"
+  end
+
+  defp construct_test_endpoint(api_key) do
+    api_base = "https://youtube.googleapis.com/youtube/v3/playlistItems"
+
+    "#{api_base}?part=id&maxResults=1&playlistId=#{@test_playlist_id}&key=#{api_key}"
   end
 
   defp http_client do

--- a/lib/pinchflat/fast_indexing/youtube_behaviour.ex
+++ b/lib/pinchflat/fast_indexing/youtube_behaviour.ex
@@ -8,4 +8,5 @@ defmodule Pinchflat.FastIndexing.YoutubeBehaviour do
 
   @callback enabled?() :: boolean()
   @callback get_recent_media_ids(%Source{}) :: {:ok, [String.t()]} | {:error, String.t()}
+  @callback test_api_key(String.t()) :: :ok | {:error, String.t()}
 end

--- a/lib/pinchflat/fast_indexing/youtube_rss.ex
+++ b/lib/pinchflat/fast_indexing/youtube_rss.ex
@@ -20,6 +20,15 @@ defmodule Pinchflat.FastIndexing.YoutubeRss do
   def enabled?(), do: true
 
   @doc """
+  RSS feeds don't use API keys, so this always returns :ok.
+  Used to satisfy the `YoutubeBehaviour` behaviour.
+
+  Returns :ok
+  """
+  @impl YoutubeBehaviour
+  def test_api_key(_api_key), do: :ok
+
+  @doc """
   Fetches the recent media IDs from a YouTube RSS feed for a given source.
 
   Returns {:ok, [binary()]} | {:error, binary()}

--- a/lib/pinchflat/settings/cookie_file.ex
+++ b/lib/pinchflat/settings/cookie_file.ex
@@ -1,0 +1,123 @@
+defmodule Pinchflat.Settings.CookieFile do
+  @moduledoc """
+  Manages the user-provided `cookies.txt` file that yt-dlp uses to access
+  age-restricted, members-only, or otherwise gated content.
+
+  The file lives in the configured `:extras_directory` and is created (blank)
+  on boot by `Pinchflat.Boot.PreJobStartupTasks`. yt-dlp only attaches it when
+  it exists and is non-empty (see `Pinchflat.YtDlp.CommandRunner`).
+  """
+
+  alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
+
+  @filename "cookies.txt"
+
+  @doc """
+  Returns the absolute path to the cookies file.
+  """
+  def filepath do
+    base_dir = Application.get_env(:pinchflat, :extras_directory)
+    Path.join(base_dir, @filename)
+  end
+
+  @doc """
+  Returns true if a cookies file exists and has non-whitespace contents.
+  """
+  def present? do
+    FSUtils.exists_and_nonempty?(filepath())
+  end
+
+  @doc """
+  Reads the raw contents of the cookies file.
+
+  Returns {:ok, binary()} | {:error, File.posix()}
+  """
+  def read do
+    File.read(filepath())
+  end
+
+  @doc """
+  Replaces the cookies file with the contents at `source_path` (e.g. an uploaded
+  temp file). Ensures the destination directory exists.
+
+  Returns :ok | {:error, File.posix()}
+  """
+  def save_from_path(source_path) do
+    dest = filepath()
+    File.mkdir_p!(Path.dirname(dest))
+    File.cp(source_path, dest)
+  end
+
+  @doc """
+  Clears the cookies file by writing blank contents (rather than deleting it,
+  to keep the boot-time invariant that the file exists).
+
+  Returns :ok | {:error, File.posix()}
+  """
+  def clear do
+    File.write(filepath(), "")
+  end
+
+  @doc """
+  Validates the cookies file _offline_ by parsing it as a Netscape-format
+  cookie jar. This deliberately avoids a live network check (a public video
+  succeeds even with bad cookies, while an auth-gated check fails for cookies
+  only used to bypass bot-detection), so instead it surfaces the failures that
+  are actually common: empty, malformed, or fully-expired files.
+
+  Returns:
+    - {:ok, %{total: n, active: n, expired: n}}
+    - {:error, :empty}
+    - {:error, :invalid}
+  """
+  def validate(now \\ System.system_time(:second)) do
+    case read() do
+      {:ok, contents} -> validate_contents(contents, now)
+      {:error, _} -> {:error, :empty}
+    end
+  end
+
+  defp validate_contents(contents, now) do
+    if String.trim(contents) == "" do
+      {:error, :empty}
+    else
+      cookies =
+        contents
+        |> String.split(["\r\n", "\n"])
+        |> Enum.map(&parse_line/1)
+        |> Enum.reject(&is_nil/1)
+
+      case cookies do
+        [] ->
+          {:error, :invalid}
+
+        cookies ->
+          expired = Enum.count(cookies, fn expiry -> expiry != 0 and expiry < now end)
+
+          {:ok, %{total: length(cookies), active: length(cookies) - expired, expired: expired}}
+      end
+    end
+  end
+
+  # Netscape cookie format: domain \t flag \t path \t secure \t expiry \t name \t value
+  # Comment lines start with `#` (except the `#HttpOnly_` domain prefix). Returns the
+  # cookie's expiry (integer) for valid lines, otherwise nil.
+  defp parse_line(line) do
+    cond do
+      String.trim(line) == "" -> nil
+      String.starts_with?(line, "#") and not String.starts_with?(line, "#HttpOnly_") -> nil
+      true -> parse_fields(String.split(line, "\t"))
+    end
+  end
+
+  defp parse_fields(fields) when length(fields) >= 7 do
+    expiry = Enum.at(fields, 4)
+
+    case Integer.parse(String.trim(expiry)) do
+      {seconds, _} -> seconds
+      :error -> nil
+    end
+  end
+
+  defp parse_fields(_fields), do: nil
+end

--- a/lib/pinchflat/settings/setting.ex
+++ b/lib/pinchflat/settings/setting.ex
@@ -6,10 +6,15 @@ defmodule Pinchflat.Settings.Setting do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias Pinchflat.YtDlp.UpdateManager
+
   @allowed_fields [
     :onboarding,
     :pro_enabled,
     :yt_dlp_version,
+    :yt_dlp_update_policy,
+    :yt_dlp_pinned_version,
+    :yt_dlp_nightly_baseline,
     :apprise_version,
     :apprise_server,
     :external_base_url,
@@ -34,6 +39,9 @@ defmodule Pinchflat.Settings.Setting do
     field :onboarding, :boolean, default: true
     field :pro_enabled, :boolean, default: false
     field :yt_dlp_version, :string
+    field :yt_dlp_update_policy, :string, default: "stable"
+    field :yt_dlp_pinned_version, :string
+    field :yt_dlp_nightly_baseline, :string
     field :apprise_version, :string
     field :apprise_server, :string
     field :external_base_url, :string
@@ -55,5 +63,15 @@ defmodule Pinchflat.Settings.Setting do
     |> cast(attrs, @allowed_fields)
     |> validate_required(@required_fields)
     |> validate_number(:extractor_sleep_interval_seconds, greater_than_or_equal_to: 0)
+    |> validate_inclusion(:yt_dlp_update_policy, UpdateManager.policies())
+    |> validate_pinned_version()
+  end
+
+  defp validate_pinned_version(changeset) do
+    if get_field(changeset, :yt_dlp_update_policy) == "pinned" do
+      validate_required(changeset, [:yt_dlp_pinned_version])
+    else
+      changeset
+    end
   end
 end

--- a/lib/pinchflat/utils/version_utils.ex
+++ b/lib/pinchflat/utils/version_utils.ex
@@ -1,0 +1,43 @@
+defmodule Pinchflat.Utils.VersionUtils do
+  @moduledoc """
+  Utilities for comparing yt-dlp version strings.
+
+  yt-dlp uses date-based versions (`YYYY.MM.DD` for stable, `YYYY.MM.DD.NNNNNN`
+  for nightly builds) for both channels, so a component-wise numeric comparison
+  is reliable. A same-day nightly sorts _after_ that day's stable release because
+  it carries an extra trailing component.
+  """
+
+  @doc """
+  Compares two date-based yt-dlp versions.
+
+  Missing trailing components are treated as zero, so `"2025.07.01"` is considered
+  equal to `"2025.07.01.0"` and less than `"2025.07.01.123456"`.
+
+  Returns `:lt | :eq | :gt`
+  """
+  def compare(left, right) do
+    do_compare(parse(left), parse(right))
+  end
+
+  defp parse(version) do
+    version
+    |> to_string()
+    |> String.trim()
+    |> String.split(".")
+    |> Enum.map(fn part ->
+      case Integer.parse(part) do
+        {int, _} -> int
+        :error -> 0
+      end
+    end)
+  end
+
+  defp do_compare([], []), do: :eq
+  defp do_compare([head | left], []), do: if(head == 0, do: do_compare(left, []), else: :gt)
+  defp do_compare([], [head | right]), do: if(head == 0, do: do_compare([], right), else: :lt)
+
+  defp do_compare([head | left], [head | right]), do: do_compare(left, right)
+  defp do_compare([left | _], [right | _]) when left > right, do: :gt
+  defp do_compare(_, _), do: :lt
+end

--- a/lib/pinchflat/yt_dlp/command_runner.ex
+++ b/lib/pinchflat/yt_dlp/command_runner.ex
@@ -87,22 +87,36 @@ defmodule Pinchflat.YtDlp.CommandRunner do
   end
 
   @doc """
-  Updates yt-dlp to the latest version
+  Updates yt-dlp to the given target.
+
+  The target can be:
+    - "stable" - updates to the latest stable release
+    - "nightly" - updates to the latest nightly build
+    - "nightly@2025.12.08.123456" - pins to that exact nightly build
+    - a specific version like "2025.12.08" - pins to that exact stable release
 
   Returns {:ok, binary()} | {:error, binary()}
   """
   @impl YtDlpCommandRunner
-  def update do
+  def update(target) do
     command = backend_executable()
 
-    case retry_self_update(command) do
+    case retry_self_update(command, target) do
       {:ok, output} ->
         {:ok, output}
 
       {:error, output} ->
-        maybe_fallback_to_direct_download(command, output)
+        maybe_fallback_to_direct_download(command, output, target)
     end
   end
+
+  defp build_update_args("stable"), do: ["--update"]
+  defp build_update_args("nightly"), do: ["--update-to", "nightly"]
+  # `nightly` is yt-dlp's channel alias for the yt-dlp/yt-dlp-nightly-builds repo;
+  # `<channel>@<tag>` pins to an exact build. Naming the repo directly (e.g.
+  # `yt-dlp/yt-dlp_nightly@<tag>`) fails because that repo doesn't exist.
+  defp build_update_args("nightly@" <> version), do: ["--update-to", "nightly@#{version}"]
+  defp build_update_args(version), do: ["--update-to", "yt-dlp/yt-dlp@#{version}"]
 
   defp generate_output_filepath(addl_opts) do
     case Keyword.get(addl_opts, :output_filepath) do
@@ -342,10 +356,10 @@ defmodule Pinchflat.YtDlp.CommandRunner do
     Application.get_env(:pinchflat, :yt_dlp_executable)
   end
 
-  defp retry_self_update(command) do
+  defp retry_self_update(command, target) do
     1..3
     |> Enum.reduce_while({:error, ""}, fn attempt, _acc ->
-      case run_self_update(command) do
+      case run_self_update(command, target) do
         {:ok, output} ->
           {:halt, {:ok, output}}
 
@@ -360,15 +374,15 @@ defmodule Pinchflat.YtDlp.CommandRunner do
     end)
   end
 
-  defp run_self_update(command) do
-    case CliUtils.wrap_cmd(command, ["--update-to", "nightly"]) do
+  defp run_self_update(command, target) do
+    case CliUtils.wrap_cmd(command, build_update_args(target)) do
       {output, 0} -> {:ok, String.trim(output)}
       {output, _} -> {:error, String.trim(output)}
     end
   end
 
-  defp maybe_fallback_to_direct_download(command, output) do
-    if transient_update_error?(output) do
+  defp maybe_fallback_to_direct_download(command, output, target) do
+    if transient_update_error?(output) and target == "nightly" do
       Logger.warning("yt-dlp self-update failed with a transient network error, attempting direct nightly download")
 
       case direct_download_latest_nightly(command) do

--- a/lib/pinchflat/yt_dlp/release_lookup.ex
+++ b/lib/pinchflat/yt_dlp/release_lookup.ex
@@ -1,0 +1,51 @@
+defmodule Pinchflat.YtDlp.ReleaseLookup do
+  @moduledoc """
+  Looks up yt-dlp release information from the GitHub API.
+
+  Used to discover the latest stable release (so the `nightly_until_stable`
+  update policy knows when stable has caught up) and to validate that a
+  user-supplied pinned version actually exists before saving it.
+  """
+
+  @repo_api "https://api.github.com/repos/yt-dlp/yt-dlp"
+  @headers [{"User-Agent", "Pinchflat"}, {"Accept", "application/vnd.github+json"}]
+
+  @doc """
+  Returns the tag name of the latest stable yt-dlp release.
+
+  Returns `{:ok, binary()} | {:error, term()}`
+  """
+  def latest_stable_version do
+    case http_client().get("#{@repo_api}/releases/latest", @headers) do
+      {:ok, body} ->
+        case Jason.decode(body) do
+          {:ok, %{"tag_name" => tag}} -> {:ok, tag}
+          _ -> {:error, :unexpected_response}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Returns true if the given version exists as a release on the yt-dlp repo.
+
+  This is the same repo `--update-to yt-dlp/yt-dlp@<version>` installs from, so a
+  positive result means the pinned version is actually installable.
+
+  Returns boolean()
+  """
+  def version_available?(version) when is_binary(version) and version != "" do
+    case http_client().get("#{@repo_api}/releases/tags/#{version}", @headers) do
+      {:ok, _body} -> true
+      {:error, _reason} -> false
+    end
+  end
+
+  def version_available?(_version), do: false
+
+  defp http_client do
+    Application.get_env(:pinchflat, :http_client, Pinchflat.HTTP.HTTPClient)
+  end
+end

--- a/lib/pinchflat/yt_dlp/update_manager.ex
+++ b/lib/pinchflat/yt_dlp/update_manager.ex
@@ -1,0 +1,196 @@
+defmodule Pinchflat.YtDlp.UpdateManager do
+  @moduledoc """
+  Resolves the configured yt-dlp update policy into concrete yt-dlp update
+  actions. Centralizes the difference between a one-shot "jump" (performed once,
+  right after the user changes the setting) and the recurring behaviour run by
+  the cron/boot `UpdateWorker`.
+
+  Policies (stored in the `yt_dlp_update_policy` setting):
+
+    - `"stable"` - track the latest stable release, updating daily (default)
+    - `"nightly"` - track the latest nightly build, updating daily
+    - `"nightly_frozen"` - jump to the latest nightly once and hold there,
+      re-asserting that exact build on boot so an image swap can't drift it
+    - `"nightly_until_stable"` - jump to the latest nightly once, hold there, and
+      automatically revert to stable once a stable release catches up to (or
+      passes) the nightly we landed on
+    - `"pinned"` - install one exact version (`yt_dlp_pinned_version`) and hold
+      there, re-asserting it on boot so an image swap can't drift it
+  """
+
+  require Logger
+
+  alias Pinchflat.Settings
+  alias Pinchflat.Utils.VersionUtils
+  alias Pinchflat.YtDlp.ReleaseLookup
+
+  @policies ~w(stable nightly nightly_frozen nightly_until_stable pinned)
+
+  @doc "Returns the list of valid update policies"
+  def policies, do: @policies
+
+  @doc "Returns a human-friendly label for a policy, used in the UI"
+  def humanize_policy("stable"), do: "Stable"
+  def humanize_policy("nightly"), do: "Nightly"
+  def humanize_policy("nightly_frozen"), do: "Nightly, frozen"
+  def humanize_policy("nightly_until_stable"), do: "Nightly until stable"
+  def humanize_policy("pinned"), do: "Pinned"
+  def humanize_policy(_other), do: "Stable"
+
+  @doc """
+  Recurring update behaviour, run by the cron/boot worker. This is the
+  steady-state for a policy and never performs the initial one-shot jump.
+
+  The held policies (`pinned`, `nightly_frozen`, and `nightly_until_stable`
+  while it's still holding) re-assert their target here rather than doing
+  nothing. yt-dlp lives on the container's ephemeral filesystem, so
+  replacing/recreating the image reverts it to whatever version was baked in.
+  Re-asserting on every boot trues the binary back up to the version the
+  settings say we should be on (yt-dlp no-ops cheaply if it already matches).
+
+  Returns :ok
+  """
+  def run_scheduled_update do
+    case Settings.get!(:yt_dlp_update_policy) do
+      "stable" ->
+        update_to_stable()
+
+      "nightly" ->
+        update_to("nightly")
+
+      "nightly_until_stable" ->
+        maybe_revert_to_stable()
+
+      "nightly_frozen" ->
+        reassert_frozen_nightly()
+
+      "pinned" ->
+        reassert_pinned_version()
+
+      _unknown ->
+        :noop
+    end
+
+    refresh_installed_version()
+    :ok
+  end
+
+  @doc """
+  Applies the currently-saved policy immediately, performing the one-shot jump
+  to the target channel/version. Called right after the user saves the setting.
+
+  Returns :ok
+  """
+  def apply_policy do
+    case Settings.get!(:yt_dlp_update_policy) do
+      "stable" ->
+        update_to_stable()
+
+      "nightly" ->
+        update_to("nightly")
+
+      # Record which nightly we landed on so a later boot can true the binary
+      # back up to this exact build instead of drifting to the latest nightly.
+      channel when channel in ["nightly_frozen", "nightly_until_stable"] ->
+        update_to("nightly")
+        capture_nightly_baseline()
+
+      "pinned" ->
+        reassert_pinned_version()
+    end
+
+    refresh_installed_version()
+    :ok
+  end
+
+  defp reassert_pinned_version do
+    case Settings.get!(:yt_dlp_pinned_version) do
+      version when is_binary(version) and version != "" -> update_to(version)
+      _blank -> Logger.warning("yt-dlp policy is 'pinned' but no version is set; skipping update")
+    end
+  end
+
+  defp reassert_frozen_nightly do
+    case Settings.get!(:yt_dlp_nightly_baseline) do
+      version when is_binary(version) and version != "" ->
+        update_to("nightly@" <> version)
+
+      # We don't know which nightly was frozen (e.g. set before this was
+      # tracked), so there's nothing safe to re-assert. Leave the binary as-is.
+      _blank ->
+        :noop
+    end
+  end
+
+  defp maybe_revert_to_stable do
+    baseline = Settings.get!(:yt_dlp_nightly_baseline) || Settings.get!(:yt_dlp_version)
+
+    case ReleaseLookup.latest_stable_version() do
+      {:ok, stable_version} ->
+        if VersionUtils.compare(stable_version, baseline) in [:eq, :gt] do
+          Logger.info("Stable yt-dlp #{stable_version} caught up to nightly #{baseline}; reverting to stable")
+          update_to(stable_version)
+          Settings.set(yt_dlp_update_policy: "stable")
+          Settings.set(yt_dlp_nightly_baseline: nil)
+        else
+          Logger.info("Holding yt-dlp on nightly #{baseline}; latest stable #{stable_version} hasn't caught up")
+          reassert_frozen_nightly()
+        end
+
+      {:error, reason} ->
+        Logger.warning("Couldn't check latest stable yt-dlp version, staying on nightly: #{inspect(reason)}")
+        reassert_frozen_nightly()
+    end
+  end
+
+  defp capture_nightly_baseline do
+    case yt_dlp_runner().version() do
+      {:ok, version} -> Settings.set(yt_dlp_nightly_baseline: version)
+      _error -> :noop
+    end
+  end
+
+  # Targets the *exact* latest stable version rather than the `stable` channel.
+  # yt-dlp's plain channel update (`--update`) refuses to move backwards, so if
+  # the installed binary is a newer nightly (e.g. after switching off a frozen
+  # nightly), a channel update would no-op and strand us on that nightly.
+  # Pinning the resolved version forces yt-dlp to downgrade. Falls back to the
+  # channel update if the GitHub lookup is unavailable.
+  defp update_to_stable do
+    case ReleaseLookup.latest_stable_version() do
+      {:ok, stable_version} ->
+        update_to(stable_version)
+
+      {:error, reason} ->
+        Logger.warning(
+          "Couldn't resolve latest stable yt-dlp version, falling back to channel update: #{inspect(reason)}"
+        )
+
+        update_to("stable")
+    end
+  end
+
+  defp update_to(target) do
+    Logger.info("Updating yt-dlp (target: #{target})")
+
+    case yt_dlp_runner().update(target) do
+      {:ok, _output} = result ->
+        result
+
+      {:error, reason} = error ->
+        Logger.error("yt-dlp update to '#{target}' failed: #{inspect(reason)}")
+        error
+    end
+  end
+
+  defp refresh_installed_version do
+    case yt_dlp_runner().version() do
+      {:ok, version} -> Settings.set(yt_dlp_version: version)
+      _error -> :noop
+    end
+  end
+
+  defp yt_dlp_runner do
+    Application.get_env(:pinchflat, :yt_dlp_runner)
+  end
+end

--- a/lib/pinchflat/yt_dlp/update_worker.ex
+++ b/lib/pinchflat/yt_dlp/update_worker.ex
@@ -1,17 +1,22 @@
 defmodule Pinchflat.YtDlp.UpdateWorker do
-  @moduledoc false
+  @moduledoc """
+  Keeps the yt-dlp executable up to date according to the configured update
+  policy (see `Pinchflat.YtDlp.UpdateManager`).
+
+  Runs on a schedule (Oban Cron) and on app boot for the recurring policy
+  behaviour. Can also be enqueued with `%{"apply_policy" => true}` to perform the
+  one-shot jump immediately after the user changes the policy in settings.
+  """
 
   use Oban.Worker,
     queue: :local_data,
     tags: ["local_data"]
 
-  require Logger
-
   alias __MODULE__
-  alias Pinchflat.Settings
+  alias Pinchflat.YtDlp.UpdateManager
 
   @doc """
-  Starts the yt-dlp update worker. Does not attach it to a task like `kickoff_with_task/2`
+  Starts the yt-dlp update worker for a normal scheduled run.
 
   Returns {:ok, %Oban.Job{}} | {:error, %Ecto.Changeset{}}
   """
@@ -20,36 +25,31 @@ defmodule Pinchflat.YtDlp.UpdateWorker do
   end
 
   @doc """
-  Updates yt-dlp and saves the version to the settings.
+  Starts the yt-dlp update worker to immediately apply the current policy
+  (the one-shot jump performed after a settings change).
+
+  Returns {:ok, %Oban.Job{}} | {:error, %Ecto.Changeset{}}
+  """
+  def kickoff_apply do
+    Oban.insert(UpdateWorker.new(%{apply_policy: true}))
+  end
+
+  @doc """
+  Updates yt-dlp based on the configured policy and saves the resulting version
+  to settings.
 
   This worker is scheduled to run via the Oban Cron plugin as well as on app boot.
 
   Returns :ok
   """
   @impl Oban.Worker
-  def perform(%Oban.Job{}) do
-    Logger.info("Updating yt-dlp")
-
-    case yt_dlp_runner().update() do
-      {:ok, _output} ->
-        :ok
-
-      {:error, output} ->
-        Logger.warning("yt-dlp update failed: #{inspect(output)}")
-    end
-
-    case yt_dlp_runner().version() do
-      {:ok, yt_dlp_version} ->
-        Settings.set(yt_dlp_version: yt_dlp_version)
-
-      {:error, output} ->
-        Logger.warning("yt-dlp version check failed after update attempt: #{inspect(output)}")
+  def perform(%Oban.Job{args: args}) do
+    if Map.get(args, "apply_policy", false) do
+      UpdateManager.apply_policy()
+    else
+      UpdateManager.run_scheduled_update()
     end
 
     :ok
-  end
-
-  defp yt_dlp_runner do
-    Application.get_env(:pinchflat, :yt_dlp_runner)
   end
 end

--- a/lib/pinchflat/yt_dlp/yt_dlp_command_runner.ex
+++ b/lib/pinchflat/yt_dlp/yt_dlp_command_runner.ex
@@ -9,5 +9,5 @@ defmodule Pinchflat.YtDlp.YtDlpCommandRunner do
   @callback run(binary(), atom(), keyword(), binary()) :: {:ok, binary()} | {:error, binary(), integer()}
   @callback run(binary(), atom(), keyword(), binary(), keyword()) :: {:ok, binary()} | {:error, binary(), integer()}
   @callback version() :: {:ok, binary()} | {:error, binary()}
-  @callback update() :: {:ok, binary()} | {:error, binary()}
+  @callback update(binary()) :: {:ok, binary()} | {:error, binary()}
 end

--- a/lib/pinchflat_web/components/custom_components/button_components.ex
+++ b/lib/pinchflat_web/components/custom_components/button_components.ex
@@ -105,6 +105,7 @@ defmodule PinchflatWeb.CustomComponents.ButtonComponents do
   attr :icon_class, :string, default: nil
   attr :variant, :string, default: "outline", values: ["outline", "primary", "warning", "danger", "danger-solid"]
   attr :type, :string, default: "button"
+  attr :disabled, :boolean, default: false
   attr :rest, :global
 
   def icon_button(assigns) do
@@ -125,6 +126,7 @@ defmodule PinchflatWeb.CustomComponents.ButtonComponents do
           @class
         ]}
         type={@type}
+        disabled={@disabled}
         {@rest}
       >
         <CoreComponents.icon name={@icon_name} class={@resolved_icon_class} />

--- a/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
+++ b/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
@@ -127,16 +127,40 @@
             x-on:click={"markVersionAsSeen('#{Application.spec(:pinchflat)[:vsn]}')"}
             x-bind:class="sidebarCollapsed ? 'lg:hidden' : ''"
           >
-            <span x-bind:class="sidebarCollapsed ? 'lg:hidden' : ''">PinchYT {Application.spec(:pinchflat)[:vsn]}</span>
+            <span>PinchYT {Application.spec(:pinchflat)[:vsn]}</span>
+            <a
+              href="https://github.com/TheBadFella/PinchYT/releases"
+              target="_blank"
+              class="bg-meta-2 text-boxdark px-1.5 rounded-full text-xs"
+              x-cloak
+              x-show={"!isVersionSeen('#{Application.spec(:pinchflat)[:vsn]}')"}
+            >
+              NEW
+            </a>
           </span>
-          <.link
-            href="https://github.com/yt-dlp/yt-dlp-nightly-builds/releases"
-            target="_blank"
-            class="group relative flex items-center gap-2.5 px-4 pt-1 text-sm underline decoration-theme-on-surface-muted/60 decoration-1 transition hover:text-theme-on-surface hover:decoration-theme-on-surface lg:pt-2"
+          <div
+            class="group relative flex items-center gap-2.5 px-4 pt-1 text-sm"
             x-bind:class="sidebarCollapsed ? 'lg:hidden' : ''"
           >
-            <span x-bind:class="sidebarCollapsed ? 'lg:hidden' : ''">yt-dlp {Settings.get!(:yt_dlp_version)}</span>
-          </.link>
+            <.link
+              href="https://github.com/yt-dlp/yt-dlp-nightly-builds/releases"
+              target="_blank"
+              class="underline decoration-theme-on-surface-muted/60 decoration-1 transition hover:text-theme-on-surface hover:decoration-theme-on-surface"
+            >
+              yt-dlp {Settings.get!(:yt_dlp_version)}
+            </.link>
+            <span
+              :if={Settings.get!(:yt_dlp_update_policy) != "stable"}
+              class="bg-meta-2 text-boxdark px-1.5 rounded-full text-xs whitespace-nowrap text-center leading-tight"
+              title="yt-dlp update behavior"
+            >
+              {Phoenix.HTML.raw(
+                Pinchflat.YtDlp.UpdateManager.humanize_policy(Settings.get!(:yt_dlp_update_policy))
+                |> String.replace(" until ", " until<br />")
+                |> String.replace(", ", ",<br />")
+              )}
+            </span>
+          </div>
         </li>
       </ul>
     </nav>

--- a/lib/pinchflat_web/controllers/settings/diagnostics_html.ex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_html.ex
@@ -29,6 +29,7 @@ defmodule PinchflatWeb.Settings.DiagnosticsHTML do
     """
     - App Version: #{Application.spec(:pinchflat)[:vsn]}
     - yt-dlp Version: #{Settings.get!(:yt_dlp_version)}
+    - yt-dlp Update Behavior: #{Pinchflat.YtDlp.UpdateManager.humanize_policy(Settings.get!(:yt_dlp_update_policy))}
     - Apprise Version: #{Settings.get!(:apprise_version)}
     - System Architecture: #{to_string(:erlang.system_info(:system_architecture))}
     - Timezone: #{Application.get_env(:pinchflat, :timezone)}

--- a/lib/pinchflat_web/controllers/settings/setting_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_controller.ex
@@ -3,6 +3,9 @@ defmodule PinchflatWeb.Settings.SettingController do
 
   alias Pinchflat.Settings
   alias Pinchflat.Settings.CookieFile
+  alias Pinchflat.YtDlp.UpdateWorker
+
+  @yt_dlp_policy_fields [:yt_dlp_update_policy, :yt_dlp_pinned_version]
 
   def show(conn, _params) do
     setting = Settings.record()
@@ -15,7 +18,9 @@ defmodule PinchflatWeb.Settings.SettingController do
     setting = Settings.record()
 
     case Settings.update_setting(setting, setting_params) do
-      {:ok, _} ->
+      {:ok, updated_setting} ->
+        maybe_apply_yt_dlp_policy(setting, updated_setting)
+
         conn
         |> put_flash(:info, "Settings updated successfully.")
         |> redirect(to: ~p"/settings")
@@ -23,6 +28,15 @@ defmodule PinchflatWeb.Settings.SettingController do
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "show.html", changeset: changeset)
     end
+  end
+
+  # Performs the one-shot yt-dlp update (jump to the chosen channel/version) only
+  # when the policy or pinned version actually changed, so saving unrelated
+  # settings doesn't trigger an update.
+  defp maybe_apply_yt_dlp_policy(old_setting, new_setting) do
+    changed? = Enum.any?(@yt_dlp_policy_fields, &(Map.get(old_setting, &1) != Map.get(new_setting, &1)))
+
+    if changed?, do: UpdateWorker.kickoff_apply()
   end
 
   def download_cookies(conn, _params) do

--- a/lib/pinchflat_web/controllers/settings/setting_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_controller.ex
@@ -2,6 +2,7 @@ defmodule PinchflatWeb.Settings.SettingController do
   use PinchflatWeb, :controller
 
   alias Pinchflat.Settings
+  alias Pinchflat.Settings.CookieFile
 
   def show(conn, _params) do
     setting = Settings.record()
@@ -21,6 +22,16 @@ defmodule PinchflatWeb.Settings.SettingController do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "show.html", changeset: changeset)
+    end
+  end
+
+  def download_cookies(conn, _params) do
+    if CookieFile.present?() do
+      send_download(conn, {:file, CookieFile.filepath()}, filename: "cookies.txt")
+    else
+      conn
+      |> put_flash(:error, "No cookies file has been uploaded")
+      |> redirect(to: ~p"/settings")
     end
   end
 

--- a/lib/pinchflat_web/controllers/settings/setting_html.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_html.ex
@@ -28,6 +28,16 @@ defmodule PinchflatWeb.Settings.SettingHTML do
     ~s(API key for YouTube Data API v3. Greatly improves the accuracy of Fast Indexing. See <a href="#{url}" class="#{help_link_classes()}" target="_blank">here</a> for details on generating an API key)
   end
 
+  def yt_dlp_update_policy_help do
+    ~s(Controls how the bundled yt-dlp is kept up to date. Use "Nightly until stable" to temporarily ride nightly when YouTube breaks something, then auto-return to stable once the fix ships)
+  end
+
+  def yt_dlp_pinned_version_help do
+    url = "https://github.com/yt-dlp/yt-dlp/releases"
+
+    ~s(The exact yt-dlp version to install and hold, e.g. "2025.12.08". See the <a href="#{url}" class="#{help_link_classes()}" target="_blank">GH releases page</a> for valid versions, or use the check button to validate your entry)
+  end
+
   defp help_link_classes do
     "underline decoration-theme-on-surface-muted/70 decoration-1 hover:text-theme-on-surface hover:decoration-theme-on-surface"
   end

--- a/lib/pinchflat_web/controllers/settings/setting_html/apprise_server_live.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/apprise_server_live.ex
@@ -19,7 +19,13 @@ defmodule Pinchflat.Settings.AppriseServerLive do
     >
       <:input_append>
         <div class="ml-3 mt-2 shrink-0 sm:mt-0">
-          <.icon_button icon_name={@icon_name} class="h-12 w-12" phx-click="send_apprise_test" tooltip={@tooltip} />
+          <.icon_button
+            icon_name={@icon_name}
+            class="h-12 w-12"
+            phx-click="send_apprise_test"
+            tooltip={@tooltip}
+            disabled={blank?(@value)}
+          />
         </div>
       </:input_append>
     </.input>
@@ -37,10 +43,14 @@ defmodule Pinchflat.Settings.AppriseServerLive do
   end
 
   def handle_event("send_apprise_test", _params, %{assigns: assigns} = socket) do
-    backend_runner().run([assigns.value], title: "Pinchflat Test", body: "This is a test message from Pinchflat")
-    Process.send_after(self(), :reset_button_icon, 4_000)
+    if blank?(assigns.value) do
+      {:noreply, socket}
+    else
+      backend_runner().run([assigns.value], title: "Pinchflat Test", body: "This is a test message from Pinchflat")
+      Process.send_after(self(), :reset_button_icon, 4_000)
 
-    {:noreply, assign(socket, %{icon_name: "hero-check", tooltip: "Sent!"})}
+      {:noreply, assign(socket, %{icon_name: "hero-check", tooltip: "Sent!"})}
+    end
   end
 
   def handle_event("apprise_server_changed", %{"setting" => setting}, socket) do
@@ -50,6 +60,8 @@ defmodule Pinchflat.Settings.AppriseServerLive do
   def handle_info(:reset_button_icon, socket) do
     {:noreply, assign(socket, %{icon_name: "hero-paper-airplane", tooltip: "Send Test"})}
   end
+
+  defp blank?(value), do: value in [nil, ""] or String.trim(value) == ""
 
   defp backend_runner do
     Application.get_env(:pinchflat, :apprise_runner)

--- a/lib/pinchflat_web/controllers/settings/setting_html/cookie_file_live.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/cookie_file_live.ex
@@ -1,0 +1,156 @@
+defmodule Pinchflat.Settings.CookieFileLive do
+  use PinchflatWeb, :live_view
+
+  alias Pinchflat.Settings.CookieFile
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.label>
+        Cookies File
+        <span :if={@present} class="ml-2 rounded-full bg-meta-3 bg-opacity-20 px-3 py-1 text-xs font-medium text-meta-3">
+          Populated
+        </span>
+        <span :if={!@present} class="ml-2 rounded-full bg-meta-4 px-3 py-1 text-xs font-medium text-bodydark">
+          Empty
+        </span>
+      </.label>
+
+      <.help>{Phoenix.HTML.raw(cookie_help())}</.help>
+
+      <form
+        id="cookie-file-form"
+        phx-submit="upload_cookies"
+        phx-change="validate_upload"
+        class="mt-3 flex flex-wrap items-center gap-3"
+      >
+        <label
+          phx-drop-target={@uploads.cookies.ref}
+          class={[
+            "flex cursor-pointer items-center gap-2 rounded-lg border-[1.5px] border-form-strokedark",
+            "bg-form-input px-5 py-3 text-sm text-white hover:bg-meta-4"
+          ]}
+        >
+          <.icon name="hero-arrow-up-tray" class="h-5 w-5" />
+          <span>{upload_label(@uploads.cookies.entries)}</span>
+          <.live_file_input upload={@uploads.cookies} class="hidden" />
+        </label>
+
+        <.button :if={@uploads.cookies.entries != []} type="submit" rounding="rounded-lg" class="!px-5 !py-3">
+          Save File
+        </.button>
+
+        <.link
+          :if={@present}
+          href={~p"/settings/cookies"}
+          class={[
+            "flex items-center gap-2 rounded-lg border-2 border-strokedark bg-form-input",
+            "px-5 py-3 text-sm text-white hover:bg-meta-4"
+          ]}
+        >
+          <.icon name="hero-arrow-down-tray" class="h-5 w-5" /> Download
+        </.link>
+
+        <.icon_button
+          :if={@present}
+          icon_name={@validate_icon}
+          class="h-12 w-12"
+          phx-click="validate_cookies"
+          tooltip={@validate_tooltip}
+          type="button"
+        />
+
+        <button
+          :if={@present}
+          type="button"
+          phx-click="clear_cookies"
+          data-confirm="Clear the cookies file?"
+          class={[
+            "flex items-center gap-2 rounded-lg border-2 border-strokedark bg-form-input",
+            "px-5 py-3 text-sm text-meta-1 hover:bg-meta-4"
+          ]}
+        >
+          <.icon name="hero-trash" class="h-5 w-5" /> Clear
+        </button>
+      </form>
+
+      <.error :for={err <- upload_errors(@uploads.cookies)}>{error_to_string(err)}</.error>
+    </div>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(%{
+        present: CookieFile.present?(),
+        validate_icon: "hero-check-badge",
+        validate_tooltip: "Validate cookies file"
+      })
+      |> allow_upload(:cookies, accept: ~w(.txt), max_entries: 1, max_file_size: 5_000_000)
+
+    {:ok, socket}
+  end
+
+  def handle_event("validate_upload", _params, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("upload_cookies", _params, socket) do
+    consume_uploaded_entries(socket, :cookies, fn %{path: path}, _entry ->
+      {:ok, CookieFile.save_from_path(path)}
+    end)
+
+    {:noreply, assign(socket, present: CookieFile.present?())}
+  end
+
+  def handle_event("clear_cookies", _params, socket) do
+    CookieFile.clear()
+
+    {:noreply, assign(socket, present: false)}
+  end
+
+  def handle_event("validate_cookies", _params, socket) do
+    {icon, tooltip} =
+      case CookieFile.validate() do
+        {:ok, %{total: total, active: active, expired: 0}} ->
+          {"hero-check", "Valid: #{total} cookie(s), #{active} active"}
+
+        {:ok, %{total: total, expired: expired}} when expired == total ->
+          {"hero-x-mark", "All #{total} cookie(s) are expired"}
+
+        {:ok, %{total: total, active: active, expired: expired}} ->
+          {"hero-exclamation-triangle", "#{active} of #{total} active, #{expired} expired"}
+
+        {:error, :empty} ->
+          {"hero-x-mark", "File is empty"}
+
+        {:error, :invalid} ->
+          {"hero-x-mark", "Not a valid Netscape cookies file"}
+      end
+
+    Process.send_after(self(), :reset_validate_icon, 6_000)
+
+    {:noreply, assign(socket, validate_icon: icon, validate_tooltip: tooltip)}
+  end
+
+  def handle_info(:reset_validate_icon, socket) do
+    {:noreply, assign(socket, validate_icon: "hero-check-badge", validate_tooltip: "Validate cookies file")}
+  end
+
+  defp upload_label([]), do: "Choose cookies.txt"
+  defp upload_label([entry | _]), do: entry.client_name
+
+  defp error_to_string(:too_large), do: "File is too large (max 5MB)"
+  defp error_to_string(:not_accepted), do: "Only .txt files are accepted"
+  defp error_to_string(:too_many_files), do: "Only one file can be uploaded"
+  defp error_to_string(_), do: "Invalid file"
+
+  defp cookie_help do
+    url = "https://github.com/kieraneglin/pinchflat/wiki/Cookies"
+
+    ~s(Upload a Netscape-format <span class="font-mono">cookies.txt</span> to let yt-dlp access age-restricted, ) <>
+      ~s(members-only, or bot-gated content. See <a href="#{url}" class="underline decoration-bodydark ) <>
+      ~s(decoration-1 hover:decoration-white" target="_blank">the wiki</a> for how to export one)
+  end
+end

--- a/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
@@ -71,6 +71,23 @@
     </section>
   </section>
 
+  <section class="mt-8">
+    <section>
+      <h3 class="text-2xl text-black dark:text-white">
+        yt-dlp
+      </h3>
+
+      {live_render(
+        @conn,
+        Pinchflat.Settings.YtDlpVersionLive,
+        session: %{
+          "policy" => f[:yt_dlp_update_policy].value,
+          "pinned_version" => f[:yt_dlp_pinned_version].value
+        }
+      )}
+    </section>
+  </section>
+
   <section class="mt-8" x-show="advancedMode">
     <section>
       <h3 class="text-2xl text-theme-on-surface">Codec Options</h3>

--- a/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
@@ -37,15 +37,11 @@
     <section>
       <h3 class="text-2xl text-theme-on-surface">Extractor Settings</h3>
 
-      <.input
-        field={f[:youtube_api_key]}
-        placeholder="ABC123,DEF456"
-        type="text"
-        label="YouTube API Key(s)"
-        help={youtube_api_help()}
-        html_help={true}
-        inputclass="font-mono text-sm mr-4"
-      />
+      {live_render(
+        @conn,
+        Pinchflat.Settings.YoutubeApiKeyLive,
+        session: %{"value" => f[:youtube_api_key].value}
+      )}
       <.input
         field={f[:extractor_sleep_interval_seconds]}
         placeholder="0"

--- a/lib/pinchflat_web/controllers/settings/setting_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/show.html.heex
@@ -7,3 +7,11 @@
 <div class="theme-surface-raised px-5 py-5 sm:px-7.5">
   <div class="max-w-full"><.setting_form conn={@conn} changeset={@changeset} action={~p"/settings"} /></div>
 </div>
+<div class="mt-6 rounded-sm border border-stroke bg-white px-5 py-5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5">
+  <div class="max-w-full">
+    <h3 class="text-2xl text-black dark:text-white mb-2">
+      Cookies
+    </h3>
+    {live_render(@conn, Pinchflat.Settings.CookieFileLive, id: "cookie-file-live")}
+  </div>
+</div>

--- a/lib/pinchflat_web/controllers/settings/setting_html/youtube_api_key_live.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/youtube_api_key_live.ex
@@ -1,0 +1,81 @@
+defmodule Pinchflat.Settings.YoutubeApiKeyLive do
+  use PinchflatWeb, :live_view
+
+  alias PinchflatWeb.Settings.SettingHTML
+
+  def render(assigns) do
+    ~H"""
+    <.input
+      type="text"
+      id="setting_youtube_api_key"
+      name="setting[youtube_api_key]"
+      value={@value}
+      label="YouTube API Key(s)"
+      help={SettingHTML.youtube_api_help()}
+      html_help={true}
+      inputclass="font-mono text-sm mr-4"
+      placeholder="ABC123,DEF456"
+      phx-change="youtube_api_key_changed"
+    >
+      <:input_append>
+        <.icon_button icon_name={@icon_name} class="h-12 w-12" phx-click="test_youtube_api_key" tooltip={@tooltip} />
+      </:input_append>
+    </.input>
+    """
+  end
+
+  def mount(_params, session, socket) do
+    new_assigns = %{
+      value: session["value"],
+      icon_name: "hero-play",
+      tooltip: "Test API Key"
+    }
+
+    {:ok, assign(socket, new_assigns)}
+  end
+
+  def handle_event("test_youtube_api_key", _params, %{assigns: assigns} = socket) do
+    case test_api_key(assigns.value) do
+      :ok ->
+        Process.send_after(self(), :reset_button_icon, 4_000)
+        {:noreply, assign(socket, %{icon_name: "hero-check", tooltip: "Success!"})}
+
+      {:error, reason} ->
+        Process.send_after(self(), :reset_button_icon, 4_000)
+        {:noreply, assign(socket, %{icon_name: "hero-x-mark", tooltip: reason})}
+    end
+  end
+
+  def handle_event("youtube_api_key_changed", %{"setting" => setting}, socket) do
+    {:noreply, assign(socket, %{value: setting["youtube_api_key"]})}
+  end
+
+  def handle_info(:reset_button_icon, socket) do
+    {:noreply, assign(socket, %{icon_name: "hero-play", tooltip: "Test API Key"})}
+  end
+
+  defp test_api_key(nil), do: {:error, "No API key provided"}
+  defp test_api_key(""), do: {:error, "No API key provided"}
+
+  defp test_api_key(keys_string) do
+    # Test the first API key provided
+    first_key =
+      keys_string
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+      |> List.first()
+
+    case first_key do
+      nil ->
+        {:error, "No API key provided"}
+
+      key ->
+        youtube_api().test_api_key(key)
+    end
+  end
+
+  defp youtube_api do
+    Application.get_env(:pinchflat, :youtube_api, Pinchflat.FastIndexing.YoutubeApi)
+  end
+end

--- a/lib/pinchflat_web/controllers/settings/setting_html/youtube_api_key_live.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/youtube_api_key_live.ex
@@ -5,22 +5,44 @@ defmodule Pinchflat.Settings.YoutubeApiKeyLive do
 
   def render(assigns) do
     ~H"""
-    <.input
-      type="text"
-      id="setting_youtube_api_key"
-      name="setting[youtube_api_key]"
-      value={@value}
-      label="YouTube API Key(s)"
-      help={SettingHTML.youtube_api_help()}
-      html_help={true}
-      inputclass="font-mono text-sm mr-4"
-      placeholder="ABC123,DEF456"
-      phx-change="youtube_api_key_changed"
-    >
-      <:input_append>
-        <.icon_button icon_name={@icon_name} class="h-12 w-12" phx-click="test_youtube_api_key" tooltip={@tooltip} />
-      </:input_append>
-    </.input>
+    <div x-data="{ revealed: false }">
+      <.input
+        type="password"
+        x-bind:type="revealed ? 'text' : 'password'"
+        autocomplete="off"
+        id="setting_youtube_api_key"
+        name="setting[youtube_api_key]"
+        value={@value}
+        label="YouTube API Key(s)"
+        help={SettingHTML.youtube_api_help()}
+        html_help={true}
+        inputclass="font-mono text-sm mr-4"
+        placeholder="ABC123,DEF456"
+        phx-change="youtube_api_key_changed"
+      >
+        <:input_append>
+          <.icon_button
+            x-cloak
+            x-show="!revealed"
+            x-on:click="revealed = true"
+            icon_name="hero-eye"
+            class="h-12 w-12 mr-2"
+            tooltip="Reveal"
+            type="button"
+          />
+          <.icon_button
+            x-cloak
+            x-show="revealed"
+            x-on:click="revealed = false"
+            icon_name="hero-eye-slash"
+            class="h-12 w-12 mr-2"
+            tooltip="Hide"
+            type="button"
+          />
+          <.icon_button icon_name={@icon_name} class="h-12 w-12" phx-click="test_youtube_api_key" tooltip={@tooltip} />
+        </:input_append>
+      </.input>
+    </div>
     """
   end
 

--- a/lib/pinchflat_web/controllers/settings/setting_html/yt_dlp_version_live.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/yt_dlp_version_live.ex
@@ -1,0 +1,98 @@
+defmodule Pinchflat.Settings.YtDlpVersionLive do
+  use PinchflatWeb, :live_view
+
+  alias PinchflatWeb.Settings.SettingHTML
+  alias Pinchflat.YtDlp.ReleaseLookup
+
+  @policy_options [
+    {"Stable (recommended)", "stable"},
+    {"Nightly, auto-updated", "nightly"},
+    {"Nightly, frozen", "nightly_frozen"},
+    {"Nightly until stable catches up", "nightly_until_stable"},
+    {"Pin a specific version", "pinned"}
+  ]
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.input
+        type="select"
+        id="setting_yt_dlp_update_policy"
+        name="setting[yt_dlp_update_policy]"
+        value={@policy}
+        options={@policy_options}
+        label="Update Behavior"
+        help={SettingHTML.yt_dlp_update_policy_help()}
+        phx-change="policy_changed"
+      />
+
+      <.input
+        :if={@policy == "pinned"}
+        type="text"
+        id="setting_yt_dlp_pinned_version"
+        name="setting[yt_dlp_pinned_version]"
+        value={@pinned_version}
+        label="Pinned Version"
+        help={SettingHTML.yt_dlp_pinned_version_help()}
+        html_help={true}
+        inputclass="font-mono text-sm mr-4"
+        placeholder="2025.12.08"
+        phx-change="pinned_version_changed"
+      >
+        <:input_append>
+          <.icon_button
+            icon_name={@icon_name}
+            class="h-12 w-12 disabled:opacity-50 disabled:cursor-not-allowed"
+            phx-click="check_version"
+            tooltip={@tooltip}
+            disabled={blank?(@pinned_version)}
+          />
+        </:input_append>
+      </.input>
+    </div>
+    """
+  end
+
+  def mount(_params, session, socket) do
+    new_assigns = %{
+      policy: session["policy"] || "stable",
+      pinned_version: session["pinned_version"],
+      policy_options: @policy_options,
+      icon_name: "hero-beaker",
+      tooltip: "Check availability"
+    }
+
+    {:ok, assign(socket, new_assigns)}
+  end
+
+  def handle_event("policy_changed", %{"setting" => setting}, socket) do
+    {:noreply, assign(socket, %{policy: setting["yt_dlp_update_policy"]})}
+  end
+
+  def handle_event("pinned_version_changed", %{"setting" => setting}, socket) do
+    {:noreply, assign(socket, %{pinned_version: setting["yt_dlp_pinned_version"]})}
+  end
+
+  def handle_event("check_version", _params, %{assigns: assigns} = socket) do
+    if blank?(assigns.pinned_version) do
+      {:noreply, socket}
+    else
+      Process.send_after(self(), :reset_button_icon, 4_000)
+
+      assigns =
+        if ReleaseLookup.version_available?(String.trim(assigns.pinned_version)) do
+          %{icon_name: "hero-check", tooltip: "Version available"}
+        else
+          %{icon_name: "hero-x-mark", tooltip: "Version not found"}
+        end
+
+      {:noreply, assign(socket, assigns)}
+    end
+  end
+
+  def handle_info(:reset_button_icon, socket) do
+    {:noreply, assign(socket, %{icon_name: "hero-beaker", tooltip: "Check availability"})}
+  end
+
+  defp blank?(value), do: value in [nil, ""] or String.trim(value) == ""
+end

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -51,6 +51,7 @@ defmodule PinchflatWeb.Router do
     resources "/search", Searches.SearchController, only: [:show], singleton: true
 
     resources "/settings", Settings.SettingController, only: [:show, :update], singleton: true
+    get "/settings/cookies", Settings.SettingController, :download_cookies
     get "/download_logs", Settings.SettingController, :download_logs
 
     get "/diagnostics", Settings.DiagnosticsController, :show

--- a/priv/repo/migrations/20260629120000_add_yt_dlp_update_policy_to_settings.exs
+++ b/priv/repo/migrations/20260629120000_add_yt_dlp_update_policy_to_settings.exs
@@ -1,0 +1,16 @@
+defmodule Pinchflat.Repo.Migrations.AddYtDlpUpdatePolicyToSettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:settings) do
+      # How the yt-dlp executable should be kept up to date. One of:
+      # "stable", "nightly", "nightly_frozen", "nightly_until_stable", "pinned"
+      add :yt_dlp_update_policy, :string, default: "stable", null: false
+      # The exact version to install when the policy is "pinned"
+      add :yt_dlp_pinned_version, :string
+      # The nightly version we jumped to when the policy is "nightly_until_stable".
+      # Used to decide when stable has caught up so we can revert automatically.
+      add :yt_dlp_nightly_baseline, :string
+    end
+  end
+end

--- a/test/pinchflat/fast_indexing/youtube_api_test.exs
+++ b/test/pinchflat/fast_indexing/youtube_api_test.exs
@@ -118,4 +118,34 @@ defmodule Pinchflat.FastIndexing.YoutubeApiTest do
       assert {:error, "error"} = YoutubeApi.get_recent_media_ids(source)
     end
   end
+
+  describe "test_api_key/1" do
+    test "calls the test endpoint with the provided key" do
+      expect(HTTPClientMock, :get, fn url, _headers ->
+        assert url =~ "https://youtube.googleapis.com/youtube/v3/playlistItems"
+        assert url =~ "part=id"
+        assert url =~ "maxResults=1"
+        assert url =~ "key=test_key"
+
+        {:ok, "{}"}
+      end)
+
+      assert :ok = YoutubeApi.test_api_key("test_key")
+    end
+
+    test "returns :ok when the API accepts the key" do
+      expect(HTTPClientMock, :get, fn _url, _headers -> {:ok, ~s({"items": []})} end)
+
+      assert :ok = YoutubeApi.test_api_key("good_key")
+    end
+
+    test "returns an error when the request is rejected" do
+      expect(HTTPClientMock, :get, fn _url, _headers ->
+        {:error, "HTTP request failed with status code 400: Bad Request"}
+      end)
+
+      assert {:error, "HTTP request failed with status code 400: Bad Request"} =
+               YoutubeApi.test_api_key("bad_key")
+    end
+  end
 end

--- a/test/pinchflat/fast_indexing/youtube_rss_test.exs
+++ b/test/pinchflat/fast_indexing/youtube_rss_test.exs
@@ -80,4 +80,11 @@ defmodule Pinchflat.FastIndexing.YoutubeRssTest do
       assert {:ok, ["test_1"]} = YoutubeRss.get_recent_media_ids(source)
     end
   end
+
+  describe "test_api_key/1" do
+    test "always returns :ok since RSS feeds don't use API keys" do
+      assert :ok = YoutubeRss.test_api_key("anything")
+      assert :ok = YoutubeRss.test_api_key("")
+    end
+  end
 end

--- a/test/pinchflat/settings/cookie_file_test.exs
+++ b/test/pinchflat/settings/cookie_file_test.exs
@@ -1,0 +1,104 @@
+defmodule Pinchflat.Settings.CookieFileTest do
+  use ExUnit.Case, async: false
+
+  alias Pinchflat.Settings.CookieFile
+
+  setup do
+    base_dir =
+      Path.join([System.tmp_dir!(), "cookie_file_test", Integer.to_string(:erlang.unique_integer([:positive]))])
+
+    File.mkdir_p!(base_dir)
+    original = Application.get_env(:pinchflat, :extras_directory)
+    Application.put_env(:pinchflat, :extras_directory, base_dir)
+
+    on_exit(fn ->
+      Application.put_env(:pinchflat, :extras_directory, original)
+      File.rm_rf!(base_dir)
+    end)
+
+    {:ok, base_dir: base_dir}
+  end
+
+  defp write_cookies(contents), do: File.write!(CookieFile.filepath(), contents)
+
+  describe "filepath/0" do
+    test "points at cookies.txt in the extras directory", %{base_dir: base_dir} do
+      assert CookieFile.filepath() == Path.join(base_dir, "cookies.txt")
+    end
+  end
+
+  describe "present?/0" do
+    test "is false when the file is missing" do
+      refute CookieFile.present?()
+    end
+
+    test "is false when the file is blank" do
+      write_cookies("   \n  ")
+      refute CookieFile.present?()
+    end
+
+    test "is true when the file has contents" do
+      write_cookies(".youtube.com\tTRUE\t/\tTRUE\t9999999999\tNAME\tvalue")
+      assert CookieFile.present?()
+    end
+  end
+
+  describe "save_from_path/1 and clear/0" do
+    test "save_from_path copies the source file into place" do
+      source = Path.join(System.tmp_dir!(), "uploaded_cookies_#{:erlang.unique_integer([:positive])}.txt")
+      File.write!(source, "some-cookie-contents")
+
+      assert :ok = CookieFile.save_from_path(source)
+      assert {:ok, "some-cookie-contents"} = CookieFile.read()
+
+      File.rm!(source)
+    end
+
+    test "clear blanks the file but keeps it present on disk" do
+      write_cookies("stuff")
+      assert :ok = CookieFile.clear()
+      refute CookieFile.present?()
+      assert File.exists?(CookieFile.filepath())
+    end
+  end
+
+  describe "validate/0" do
+    test "returns :empty for a blank file" do
+      write_cookies("")
+      assert {:error, :empty} = CookieFile.validate()
+    end
+
+    test "returns :empty when the file does not exist" do
+      assert {:error, :empty} = CookieFile.validate()
+    end
+
+    test "returns :invalid when no cookie lines can be parsed" do
+      write_cookies("just some junk\nno tabs here either")
+      assert {:error, :invalid} = CookieFile.validate()
+    end
+
+    test "ignores comment lines but keeps #HttpOnly_ cookies" do
+      write_cookies("""
+      # Netscape HTTP Cookie File
+      #HttpOnly_.youtube.com\tTRUE\t/\tTRUE\t9999999999\tNAME\tvalue
+      """)
+
+      assert {:ok, %{total: 1, active: 1, expired: 0}} = CookieFile.validate(1_700_000_000)
+    end
+
+    test "counts active and expired cookies relative to now" do
+      write_cookies("""
+      .youtube.com\tTRUE\t/\tTRUE\t9999999999\tACTIVE\tvalue
+      .youtube.com\tTRUE\t/\tTRUE\t1000000000\tEXPIRED\tvalue
+      """)
+
+      assert {:ok, %{total: 2, active: 1, expired: 1}} = CookieFile.validate(1_700_000_000)
+    end
+
+    test "treats session cookies (expiry 0) as active" do
+      write_cookies(".youtube.com\tTRUE\t/\tTRUE\t0\tSESSION\tvalue")
+
+      assert {:ok, %{total: 1, active: 1, expired: 0}} = CookieFile.validate(1_700_000_000)
+    end
+  end
+end

--- a/test/pinchflat/settings_test.exs
+++ b/test/pinchflat/settings_test.exs
@@ -98,5 +98,21 @@ defmodule Pinchflat.SettingsTest do
 
       assert %Ecto.Changeset{valid?: true} = Settings.change_setting(setting, %{extractor_sleep_interval_seconds: 0})
     end
+
+    test "only allows known yt-dlp update policies" do
+      setting = Settings.record()
+
+      assert %Ecto.Changeset{valid?: true} = Settings.change_setting(setting, %{yt_dlp_update_policy: "nightly"})
+      assert %Ecto.Changeset{valid?: false} = Settings.change_setting(setting, %{yt_dlp_update_policy: "bogus"})
+    end
+
+    test "requires a pinned version when the policy is pinned" do
+      setting = Settings.record()
+
+      assert %Ecto.Changeset{valid?: false} = Settings.change_setting(setting, %{yt_dlp_update_policy: "pinned"})
+
+      assert %Ecto.Changeset{valid?: true} =
+               Settings.change_setting(setting, %{yt_dlp_update_policy: "pinned", yt_dlp_pinned_version: "2025.12.08"})
+    end
   end
 end

--- a/test/pinchflat/utils/version_utils_test.exs
+++ b/test/pinchflat/utils/version_utils_test.exs
@@ -1,0 +1,30 @@
+defmodule Pinchflat.Utils.VersionUtilsTest do
+  use ExUnit.Case, async: true
+
+  alias Pinchflat.Utils.VersionUtils
+
+  describe "compare/2" do
+    test "compares by date components" do
+      assert VersionUtils.compare("2025.07.01", "2025.06.28") == :gt
+      assert VersionUtils.compare("2025.06.28", "2025.07.01") == :lt
+      assert VersionUtils.compare("2025.07.01", "2025.07.01") == :eq
+    end
+
+    test "treats a same-day nightly as newer than that day's stable" do
+      assert VersionUtils.compare("2025.06.28.123456", "2025.06.28") == :gt
+      assert VersionUtils.compare("2025.06.28", "2025.06.28.123456") == :lt
+    end
+
+    test "treats missing trailing components as zero" do
+      assert VersionUtils.compare("2025.07.01", "2025.07.01.0") == :eq
+    end
+
+    test "a later stable date beats an earlier nightly even with a trailing component" do
+      assert VersionUtils.compare("2025.07.01", "2025.06.28.999999") == :gt
+    end
+
+    test "handles whitespace and non-numeric junk gracefully" do
+      assert VersionUtils.compare(" 2025.07.01 ", "2025.07.01") == :eq
+    end
+  end
+end

--- a/test/pinchflat/yt_dlp/command_runner_test.exs
+++ b/test/pinchflat/yt_dlp/command_runner_test.exs
@@ -188,11 +188,35 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
     end
   end
 
-  describe "update/0" do
-    test "adds the update arg" do
-      assert {:ok, output} = Runner.update()
+  describe "update/1" do
+    test "adds the update arg for the stable target" do
+      assert {:ok, output} = Runner.update("stable")
 
       assert String.contains?(output, "--update-to nightly")
+    end
+
+    test "targets the nightly channel" do
+      assert {:ok, output} = Runner.update("nightly")
+
+      assert String.contains?(output, "--update-to nightly")
+    end
+
+    test "pins to an exact version" do
+      assert {:ok, output} = Runner.update("2025.12.08")
+
+      assert String.contains?(output, "--update-to yt-dlp/yt-dlp@2025.12.08")
+    end
+
+    test "pins to an exact nightly build via the nightly channel alias" do
+      assert {:ok, output} = Runner.update("nightly@2025.12.08.123456")
+
+      assert String.contains?(output, "--update-to nightly@2025.12.08.123456")
+    end
+
+    test "treats a 100 exit code (yt-dlp's update error code) as a failure" do
+      wrap_executable("/app/test/support/scripts/yt-dlp-mocks/100_exit_code.sh", fn ->
+        assert {:error, _output} = Runner.update("nightly")
+      end)
     end
   end
 

--- a/test/pinchflat/yt_dlp/command_runner_test.exs
+++ b/test/pinchflat/yt_dlp/command_runner_test.exs
@@ -192,7 +192,7 @@ defmodule Pinchflat.YtDlp.CommandRunnerTest do
     test "adds the update arg for the stable target" do
       assert {:ok, output} = Runner.update("stable")
 
-      assert String.contains?(output, "--update-to nightly")
+      assert String.contains?(output, "--update")
     end
 
     test "targets the nightly channel" do

--- a/test/pinchflat/yt_dlp/release_lookup_test.exs
+++ b/test/pinchflat/yt_dlp/release_lookup_test.exs
@@ -1,0 +1,50 @@
+defmodule Pinchflat.YtDlp.ReleaseLookupTest do
+  use Pinchflat.DataCase
+
+  alias Pinchflat.YtDlp.ReleaseLookup
+
+  describe "latest_stable_version/1" do
+    test "returns the tag name from the GitHub response" do
+      expect(HTTPClientMock, :get, fn url, _headers ->
+        assert url =~ "releases/latest"
+        {:ok, Jason.encode!(%{"tag_name" => "2025.07.01"})}
+      end)
+
+      assert {:ok, "2025.07.01"} = ReleaseLookup.latest_stable_version()
+    end
+
+    test "returns an error when the response is missing the tag" do
+      expect(HTTPClientMock, :get, fn _url, _headers -> {:ok, Jason.encode!(%{})} end)
+
+      assert {:error, :unexpected_response} = ReleaseLookup.latest_stable_version()
+    end
+
+    test "passes through HTTP errors" do
+      expect(HTTPClientMock, :get, fn _url, _headers -> {:error, "boom"} end)
+
+      assert {:error, "boom"} = ReleaseLookup.latest_stable_version()
+    end
+  end
+
+  describe "version_available?/1" do
+    test "returns true when the release tag resolves" do
+      expect(HTTPClientMock, :get, fn url, _headers ->
+        assert url =~ "releases/tags/2025.07.01"
+        {:ok, "{}"}
+      end)
+
+      assert ReleaseLookup.version_available?("2025.07.01")
+    end
+
+    test "returns false when the release tag is missing" do
+      expect(HTTPClientMock, :get, fn _url, _headers -> {:error, "not found"} end)
+
+      refute ReleaseLookup.version_available?("9999.99.99")
+    end
+
+    test "returns false for blank input without making a request" do
+      refute ReleaseLookup.version_available?("")
+      refute ReleaseLookup.version_available?(nil)
+    end
+  end
+end

--- a/test/pinchflat/yt_dlp/update_worker_test.exs
+++ b/test/pinchflat/yt_dlp/update_worker_test.exs
@@ -32,7 +32,8 @@ defmodule Pinchflat.YtDlp.UpdateWorkerTest do
     end
 
     test "keeps going when the yt-dlp update fails but version lookup still works" do
-      expect(YtDlpRunnerMock, :update, fn -> {:error, "tls eof"} end)
+      stub_latest_stable("2025.07.01")
+      expect(YtDlpRunnerMock, :update, fn _target -> {:error, "tls eof"} end)
       expect(YtDlpRunnerMock, :version, fn -> {:ok, "1.2.3"} end)
 
       assert :ok = perform_job(UpdateWorker, %{})
@@ -40,7 +41,8 @@ defmodule Pinchflat.YtDlp.UpdateWorkerTest do
     end
 
     test "returns ok when both update and version lookup fail" do
-      expect(YtDlpRunnerMock, :update, fn -> {:error, "tls eof"} end)
+      stub_latest_stable("2025.07.01")
+      expect(YtDlpRunnerMock, :update, fn _target -> {:error, "tls eof"} end)
       expect(YtDlpRunnerMock, :version, fn -> {:error, "still broken"} end)
 
       assert :ok = perform_job(UpdateWorker, %{})

--- a/test/pinchflat/yt_dlp/update_worker_test.exs
+++ b/test/pinchflat/yt_dlp/update_worker_test.exs
@@ -4,16 +4,26 @@ defmodule Pinchflat.YtDlp.UpdateWorkerTest do
   alias Pinchflat.Settings
   alias Pinchflat.YtDlp.UpdateWorker
 
-  describe "perform/1" do
-    test "calls the yt-dlp runner to update yt-dlp" do
-      expect(YtDlpRunnerMock, :update, fn -> {:ok, ""} end)
+  describe "perform/1 with the default (stable) policy" do
+    test "updates to the exact latest stable version so yt-dlp will downgrade if needed" do
+      stub_latest_stable("2025.07.01")
+      expect(YtDlpRunnerMock, :update, fn "2025.07.01" -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, ""} end)
+
+      perform_job(UpdateWorker, %{})
+    end
+
+    test "falls back to a channel update when the stable lookup fails" do
+      expect(HTTPClientMock, :get, fn _url, _headers -> {:error, "boom"} end)
+      expect(YtDlpRunnerMock, :update, fn "stable" -> {:ok, ""} end)
       expect(YtDlpRunnerMock, :version, fn -> {:ok, ""} end)
 
       perform_job(UpdateWorker, %{})
     end
 
     test "saves the new version to the database" do
-      expect(YtDlpRunnerMock, :update, fn -> {:ok, ""} end)
+      stub_latest_stable("2025.07.01")
+      expect(YtDlpRunnerMock, :update, fn "2025.07.01" -> {:ok, ""} end)
       expect(YtDlpRunnerMock, :version, fn -> {:ok, "1.2.3"} end)
 
       perform_job(UpdateWorker, %{})
@@ -35,5 +45,124 @@ defmodule Pinchflat.YtDlp.UpdateWorkerTest do
 
       assert :ok = perform_job(UpdateWorker, %{})
     end
+  end
+
+  describe "perform/1 for scheduled runs" do
+    test "tracks nightly when the policy is nightly" do
+      Settings.set(yt_dlp_update_policy: "nightly")
+      expect(YtDlpRunnerMock, :update, fn "nightly" -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, ""} end)
+
+      perform_job(UpdateWorker, %{})
+    end
+
+    test "re-asserts the frozen nightly build when a baseline is recorded" do
+      Settings.set(yt_dlp_update_policy: "nightly_frozen")
+      Settings.set(yt_dlp_nightly_baseline: "2025.06.28.123456")
+      expect(YtDlpRunnerMock, :update, fn "nightly@2025.06.28.123456" -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, ""} end)
+
+      perform_job(UpdateWorker, %{})
+    end
+
+    test "does not update when the policy is nightly_frozen with no known baseline" do
+      Settings.set(yt_dlp_update_policy: "nightly_frozen")
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, ""} end)
+
+      perform_job(UpdateWorker, %{})
+    end
+
+    test "re-asserts the pinned version when the policy is pinned" do
+      pin_to_version("2025.01.01")
+      expect(YtDlpRunnerMock, :update, fn "2025.01.01" -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, ""} end)
+
+      perform_job(UpdateWorker, %{})
+    end
+  end
+
+  describe "perform/1 with the nightly_until_stable policy" do
+    setup do
+      Settings.set(yt_dlp_update_policy: "nightly_until_stable")
+      Settings.set(yt_dlp_nightly_baseline: "2025.06.28.123456")
+      :ok
+    end
+
+    test "reverts to stable and updates when stable has caught up" do
+      stub_latest_stable("2025.07.01")
+      expect(YtDlpRunnerMock, :update, fn "2025.07.01" -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, "2025.07.01"} end)
+
+      perform_job(UpdateWorker, %{})
+
+      assert {:ok, "stable"} = Settings.get(:yt_dlp_update_policy)
+      assert {:ok, nil} = Settings.get(:yt_dlp_nightly_baseline)
+    end
+
+    test "holds on nightly and re-asserts the baseline build when stable has not caught up" do
+      stub_latest_stable("2025.06.01")
+      # re-asserts the held nightly so an image swap can't strand us on the baked-in stable
+      expect(YtDlpRunnerMock, :update, fn "nightly@2025.06.28.123456" -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, "2025.06.28.123456"} end)
+
+      perform_job(UpdateWorker, %{})
+
+      assert {:ok, "nightly_until_stable"} = Settings.get(:yt_dlp_update_policy)
+    end
+
+    test "stays on nightly and re-asserts the baseline build when the stable lookup fails" do
+      expect(HTTPClientMock, :get, fn _url, _headers -> {:error, "boom"} end)
+      expect(YtDlpRunnerMock, :update, fn "nightly@2025.06.28.123456" -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, "2025.06.28.123456"} end)
+
+      perform_job(UpdateWorker, %{})
+
+      assert {:ok, "nightly_until_stable"} = Settings.get(:yt_dlp_update_policy)
+    end
+  end
+
+  describe "perform/1 when applying a policy (one-shot jump)" do
+    test "jumps to nightly for nightly_until_stable and records the baseline" do
+      Settings.set(yt_dlp_update_policy: "nightly_until_stable")
+      expect(YtDlpRunnerMock, :update, fn "nightly" -> {:ok, ""} end)
+      # once for the baseline capture, once for the version refresh
+      expect(YtDlpRunnerMock, :version, 2, fn -> {:ok, "2025.06.28.123456"} end)
+
+      perform_job(UpdateWorker, %{"apply_policy" => true})
+
+      assert {:ok, "2025.06.28.123456"} = Settings.get(:yt_dlp_nightly_baseline)
+    end
+
+    test "jumps to nightly for nightly_frozen and records the frozen baseline" do
+      Settings.set(yt_dlp_update_policy: "nightly_frozen")
+      expect(YtDlpRunnerMock, :update, fn "nightly" -> {:ok, ""} end)
+      # once for the baseline capture, once for the version refresh
+      expect(YtDlpRunnerMock, :version, 2, fn -> {:ok, "2025.06.28.123456"} end)
+
+      perform_job(UpdateWorker, %{"apply_policy" => true})
+
+      assert {:ok, "2025.06.28.123456"} = Settings.get(:yt_dlp_nightly_baseline)
+    end
+
+    test "installs the pinned version for the pinned policy" do
+      pin_to_version("2025.01.01")
+      expect(YtDlpRunnerMock, :update, fn "2025.01.01" -> {:ok, ""} end)
+      expect(YtDlpRunnerMock, :version, fn -> {:ok, "2025.01.01"} end)
+
+      perform_job(UpdateWorker, %{"apply_policy" => true})
+    end
+  end
+
+  defp stub_latest_stable(version) do
+    expect(HTTPClientMock, :get, fn _url, _headers -> {:ok, Jason.encode!(%{"tag_name" => version})} end)
+  end
+
+  # The policy and version are validated together, mirroring how the settings
+  # form submits both fields in a single changeset.
+  defp pin_to_version(version) do
+    Settings.update_setting(Settings.record(), %{
+      yt_dlp_update_policy: "pinned",
+      yt_dlp_pinned_version: version
+    })
   end
 end

--- a/test/pinchflat_web/controllers/settings/apprise_server_live_test.exs
+++ b/test/pinchflat_web/controllers/settings/apprise_server_live_test.exs
@@ -24,6 +24,28 @@ defmodule PinchflatWeb.Settings.AppriseServerLiveTest do
       assert html =~ "hero-paper-airplane"
       refute html =~ "hero-check"
     end
+
+    test "disables the test button when the input is blank", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, AppriseServerLive, session: create_session(""))
+
+      assert has_element?(view, "button[phx-click=send_apprise_test][disabled]")
+    end
+
+    test "enables the test button when the input has a value", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, AppriseServerLive, session: create_session("cool-value"))
+
+      refute has_element?(view, "button[phx-click=send_apprise_test][disabled]")
+    end
+  end
+
+  describe "when the input is blank" do
+    test "does not send a test message", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, AppriseServerLive, session: create_session(""))
+
+      # Push the event directly (bypassing the disabled button) to verify the
+      # server-side guard. Mox's verify_on_exit! fails if the runner is called.
+      assert render_click(view, "send_apprise_test")
+    end
   end
 
   describe "pressing the button" do

--- a/test/pinchflat_web/controllers/settings/cookie_file_live_test.exs
+++ b/test/pinchflat_web/controllers/settings/cookie_file_live_test.exs
@@ -1,0 +1,95 @@
+defmodule PinchflatWeb.Settings.CookieFileLiveTest do
+  use PinchflatWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Pinchflat.Settings.CookieFileLive
+  alias Pinchflat.Settings.CookieFile
+
+  setup do
+    base_dir =
+      Path.join([System.tmp_dir!(), "cookie_live_test", Integer.to_string(:erlang.unique_integer([:positive]))])
+
+    File.mkdir_p!(base_dir)
+    original = Application.get_env(:pinchflat, :extras_directory)
+    Application.put_env(:pinchflat, :extras_directory, base_dir)
+
+    on_exit(fn ->
+      Application.put_env(:pinchflat, :extras_directory, original)
+      File.rm_rf!(base_dir)
+    end)
+
+    :ok
+  end
+
+  describe "initial rendering" do
+    test "shows the Empty badge when no cookies are present", %{conn: conn} do
+      {:ok, _view, html} = live_isolated(conn, CookieFileLive)
+
+      assert html =~ "Empty"
+      refute html =~ "Populated"
+    end
+
+    test "shows the Populated badge, download and clear when cookies exist", %{conn: conn} do
+      File.write!(CookieFile.filepath(), "some-cookies")
+      {:ok, _view, html} = live_isolated(conn, CookieFileLive)
+
+      assert html =~ "Populated"
+      assert html =~ "Download"
+      assert html =~ "Clear"
+    end
+  end
+
+  describe "clearing cookies" do
+    test "blanks the file and updates the UI", %{conn: conn} do
+      File.write!(CookieFile.filepath(), "some-cookies")
+      {:ok, view, _html} = live_isolated(conn, CookieFileLive)
+
+      html = view |> element("button", "Clear") |> render_click()
+
+      assert html =~ "Empty"
+      refute CookieFile.present?()
+    end
+  end
+
+  describe "validating cookies" do
+    test "reports a valid file", %{conn: conn} do
+      File.write!(CookieFile.filepath(), ".youtube.com\tTRUE\t/\tTRUE\t9999999999\tNAME\tvalue")
+      {:ok, view, _html} = live_isolated(conn, CookieFileLive)
+
+      html = view |> element("[phx-click=validate_cookies]") |> render_click()
+
+      assert html =~ "hero-check"
+    end
+
+    test "reports an invalid file", %{conn: conn} do
+      File.write!(CookieFile.filepath(), "not a cookie file")
+      {:ok, view, _html} = live_isolated(conn, CookieFileLive)
+
+      html = view |> element("[phx-click=validate_cookies]") |> render_click()
+
+      assert html =~ "hero-x-mark"
+    end
+  end
+
+  describe "uploading cookies" do
+    test "saves the uploaded file and marks it populated", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, CookieFileLive)
+
+      cookies =
+        file_input(view, "#cookie-file-form", :cookies, [
+          %{
+            name: "cookies.txt",
+            content: ".youtube.com\tTRUE\t/\tTRUE\t9999999999\tNAME\tvalue",
+            type: "text/plain"
+          }
+        ])
+
+      render_upload(cookies, "cookies.txt")
+      html = view |> element("#cookie-file-form") |> render_submit()
+
+      assert html =~ "Populated"
+      assert CookieFile.present?()
+    end
+  end
+end

--- a/test/pinchflat_web/controllers/settings/yt_dlp_version_live_test.exs
+++ b/test/pinchflat_web/controllers/settings/yt_dlp_version_live_test.exs
@@ -1,0 +1,64 @@
+defmodule PinchflatWeb.Settings.YtDlpVersionLiveTest do
+  use PinchflatWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  alias Pinchflat.Settings.YtDlpVersionLive
+
+  describe "initial rendering" do
+    test "renders the policy select", %{conn: conn} do
+      {:ok, _view, html} = live_isolated(conn, YtDlpVersionLive, session: create_session("stable", nil))
+
+      assert html =~ ~s(name="setting[yt_dlp_update_policy]")
+    end
+
+    test "hides the pinned version field unless the policy is pinned", %{conn: conn} do
+      {:ok, _view, html} = live_isolated(conn, YtDlpVersionLive, session: create_session("stable", nil))
+
+      refute html =~ ~s(name="setting[yt_dlp_pinned_version]")
+    end
+
+    test "shows the pinned version field when the policy is pinned", %{conn: conn} do
+      {:ok, _view, html} = live_isolated(conn, YtDlpVersionLive, session: create_session("pinned", "2025.12.08"))
+
+      assert html =~ ~s(name="setting[yt_dlp_pinned_version]")
+      assert html =~ ~s(value="2025.12.08")
+    end
+  end
+
+  describe "changing the policy" do
+    test "reveals the pinned version field", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, YtDlpVersionLive, session: create_session("stable", nil))
+
+      html = render_change(view, "policy_changed", %{"setting" => %{"yt_dlp_update_policy" => "pinned"}})
+
+      assert html =~ ~s(name="setting[yt_dlp_pinned_version]")
+    end
+  end
+
+  describe "checking a pinned version" do
+    test "shows a checkmark when the version exists", %{conn: conn} do
+      expect(HTTPClientMock, :get, fn _url, _headers -> {:ok, "{}"} end)
+
+      {:ok, view, _html} = live_isolated(conn, YtDlpVersionLive, session: create_session("pinned", "2025.12.08"))
+
+      html = render_click(view, "check_version")
+
+      assert html =~ "hero-check"
+    end
+
+    test "shows an x-mark when the version does not exist", %{conn: conn} do
+      expect(HTTPClientMock, :get, fn _url, _headers -> {:error, "not found"} end)
+
+      {:ok, view, _html} = live_isolated(conn, YtDlpVersionLive, session: create_session("pinned", "9999.99.99"))
+
+      html = render_click(view, "check_version")
+
+      assert html =~ "hero-x-mark"
+    end
+  end
+
+  defp create_session(policy, pinned_version) do
+    %{"policy" => policy, "pinned_version" => pinned_version}
+  end
+end

--- a/test/support/scripts/yt-dlp-mocks/100_exit_code.sh
+++ b/test/support/scripts/yt-dlp-mocks/100_exit_code.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 100


### PR DESCRIPTION
## Summary

Ports the Settings Controls feature from CommunityMaintained/pinchflat.

### Changes
- **yt-dlp Update Manager**: New UpdateManager module that controls update behavior based on a configurable policy (stable, nightly, pinned version, or disabled)
- **Release Lookup**: New ReleaseLookup module that queries the GitHub API for the latest stable yt-dlp release to pin exact versions
- **Version Utils**: New VersionUtils helper for comparing version strings
- **Update Worker**: Refactored to delegate to UpdateManager and support both scheduled runs and policy application via job args
- **Settings Migration**: Adds yt_dlp_update_policy setting column to the database
- **yt-dlp Version LiveView**: New settings page showing current yt-dlp version and update policy selection
- **Sidebar**: Shows yt-dlp version as a link with update policy badge
- **icon_button component**: Added disabled attr to ButtonComponents.icon_button/1
- **Test fixes**: Updated mock arities and added required HTTP stubs

### Testing
- 1252 tests, 0 failures