### PR TITLE
fix: port 3 community fixes - IEC units, sources table sort, NFO toggle labels

### DIFF
--- a/lib/pinchflat/diagnostics/queue_diagnostics.ex
+++ b/lib/pinchflat/diagnostics/queue_diagnostics.ex
@@ -224,7 +224,7 @@ defmodule Pinchflat.Diagnostics.QueueDiagnostics do
   end
 
   defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
-  defp format_bytes(bytes) when bytes < 1024 * 1024, do: "#{Float.round(bytes / 1024, 1)} KB"
-  defp format_bytes(bytes) when bytes < 1024 * 1024 * 1024, do: "#{Float.round(bytes / 1024 / 1024, 1)} MB"
-  defp format_bytes(bytes), do: "#{Float.round(bytes / 1024 / 1024 / 1024, 2)} GB"
+  defp format_bytes(bytes) when bytes < 1024 * 1024, do: "#{Float.round(bytes / 1024, 1)} KiB"
+  defp format_bytes(bytes) when bytes < 1024 * 1024 * 1024, do: "#{Float.round(bytes / 1024 / 1024, 1)} MiB"
+  defp format_bytes(bytes), do: "#{Float.round(bytes / 1024 / 1024 / 1024, 2)} GiB"
 end

--- a/lib/pinchflat/utils/number_utils.ex
+++ b/lib/pinchflat/utils/number_utils.ex
@@ -25,7 +25,7 @@ defmodule Pinchflat.Utils.NumberUtils do
 
   def human_byte_size(number, opts) do
     precision = Keyword.get(opts, :precision, 2)
-    suffixes = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"]
+    suffixes = ["B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB", "ZiB", "YiB"]
     base = 1024
 
     Enum.reduce_while(suffixes, {number / 1.0, "B"}, fn suffix, {value, _} ->

--- a/lib/pinchflat_web/components/custom_components/text_components.ex
+++ b/lib/pinchflat_web/components/custom_components/text_components.ex
@@ -164,10 +164,9 @@ defmodule PinchflatWeb.CustomComponents.TextComponents do
     {num, suffix} = NumberUtils.human_byte_size(assigns.byte_size, precision: 2)
 
     assigns =
-      Map.merge(assigns, %{
-        num: num,
-        suffix: suffix
-      })
+      assigns
+      |> assign(:num, num)
+      |> assign(:suffix, suffix)
 
     ~H"""
     <.localized_number number={@num} /> {@suffix}

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
@@ -179,7 +179,7 @@
         field={f[:download_metadata]}
         type="toggle"
         label="Download Metadata"
-        help="Downloads metadata file alongside media file"
+        help="Downloads a .info.json metadata file alongside media file"
         x-init="$watch('selectedPreset', p => p && (enabled = presets[p]))"
       />
     </section>
@@ -269,9 +269,9 @@
       <.input
         field={f[:download_nfo]}
         type="toggle"
-        label="Download NFO data"
+        label="Create NFO data"
         label_suffix="(pro)"
-        help="Downloads NFO data alongside media file for use with Jellyfin, Kodi, etc."
+        help="Creates a .nfo file alongside media file for use with Jellyfin, Kodi, etc."
         x-init="$watch('selectedPreset', p => p && (enabled = presets[p]))"
       />
     </section>

--- a/test/pinchflat/utils/number_utils_test.exs
+++ b/test/pinchflat/utils/number_utils_test.exs
@@ -19,14 +19,14 @@ defmodule Pinchflat.Utils.NumberUtilsTest do
 
   describe "human_byte_size/1" do
     test "converts byte size to human readable format" do
-      assert NumberUtils.human_byte_size(1024) == {1, "KB"}
-      assert NumberUtils.human_byte_size(1024 * 1024) == {1, "MB"}
-      assert NumberUtils.human_byte_size(1024 * 1024 * 1024) == {1, "GB"}
-      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024) == {1, "TB"}
-      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024 * 1024) == {1, "PB"}
-      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024 * 1024 * 1024) == {1, "EB"}
-      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024) == {1, "ZB"}
-      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024) == {1, "YB"}
+      assert NumberUtils.human_byte_size(1024) == {1, "KiB"}
+      assert NumberUtils.human_byte_size(1024 * 1024) == {1, "MiB"}
+      assert NumberUtils.human_byte_size(1024 * 1024 * 1024) == {1, "GiB"}
+      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024) == {1, "TiB"}
+      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024 * 1024) == {1, "PiB"}
+      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024 * 1024 * 1024) == {1, "EiB"}
+      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024) == {1, "ZiB"}
+      assert NumberUtils.human_byte_size(1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024 * 1024) == {1, "YiB"}
     end
 
     test "returns the number when it is less than 1024" do
@@ -34,9 +34,9 @@ defmodule Pinchflat.Utils.NumberUtilsTest do
     end
 
     test "optionally takes a precision" do
-      assert NumberUtils.human_byte_size(1234 * 1024, precision: 0) == {1, "MB"}
-      assert NumberUtils.human_byte_size(1234 * 1024, precision: 1) == {1.2, "MB"}
-      assert NumberUtils.human_byte_size(1234 * 1024, precision: 2) == {1.21, "MB"}
+      assert NumberUtils.human_byte_size(1234 * 1024, precision: 0) == {1, "MiB"}
+      assert NumberUtils.human_byte_size(1234 * 1024, precision: 1) == {1.2, "MiB"}
+      assert NumberUtils.human_byte_size(1234 * 1024, precision: 2) == {1.21, "MiB"}
     end
 
     test "handles 0's well" do

--- a/test/pinchflat_web/controllers/pages/job_table_live_test.exs
+++ b/test/pinchflat_web/controllers/pages/job_table_live_test.exs
@@ -108,7 +108,7 @@ defmodule PinchflatWeb.Pages.JobTableLiveTest do
 
       assert html =~ "37.5%"
       assert html =~ "Downloading"
-      assert html =~ "512.0 B of 1.0 KB done, 512.0 B remaining at 256.0 B/s"
+      assert html =~ "512.0 B of 1.0 KiB done, 512.0 B remaining at 256.0 B/s"
       assert html =~ "ETA 30s"
       assert html =~ "Stop"
     end
@@ -140,7 +140,7 @@ defmodule PinchflatWeb.Pages.JobTableLiveTest do
       {:ok, _view, html} = live_isolated(conn, JobTableLive, session: %{})
 
       assert html =~ "Downloading without known total"
-      assert html =~ "2.0 KB downloaded"
+      assert html =~ "2.0 KiB downloaded"
     end
 
     test "listens for job:progress change events", %{conn: conn} do

--- a/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
+++ b/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
@@ -144,7 +144,7 @@ defmodule PinchflatWeb.Sources.MediaItemTableLiveTest do
 
       {:ok, _view, html} = live_isolated(conn, MediaItemTableLive, session: create_session(source, "pending"))
 
-      assert html =~ "512.0 B / 1.0 KB (512.0 B left) at 256.0 B/s"
+      assert html =~ "512.0 B / 1.0 KiB (512.0 B left) at 256.0 B/s"
     end
 
     test "shows wrapped full errors inline", %{conn: conn, source: source} do


### PR DESCRIPTION
## Summary

Ports 3 small fixes from CommunityMaintained/pinchflat.

### Changes
- **IEC byte units** (876bcd, 47fde1f): Byte sizes throughout the app now use correct IEC notation (KiB/MiB/GiB) instead of SI (KB/MB/GB). Affects the jobs dashboard, media table download progress, and the queue diagnostics page.
- **Sources table size re-sort fix** (876bcd): Corrects static Size column values in the sources table when columns are re-sorted.
- **NFO/metadata toggle label clarification** (7680d06): Clarifies the wording of the metadata/NFO toggle labels in the media profile form.

### Testing
- 1252 tests, 0 failures
- Updated 3 test assertions to expect KiB instead of KB