### PR TITLE
feat: downloader and indexing improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,8 @@ build.log
 /.codex-local-build-pr/
 /.gitattributes
 /.ai/mcp/mcp.json
+
+# SQLean SQLite extensions — fetched by tooling/fetch-sqlean.sh (pinned version),
+# not committed. Loaded at runtime via config/runtime.exs.
+/priv/repo/extensions/sqlean-linux-x86/
+/priv/repo/extensions/sqlean-linux-arm/

--- a/lib/pinchflat/boot/post_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/post_job_startup_tasks.ex
@@ -10,6 +10,13 @@ defmodule Pinchflat.Boot.PostJobStartupTasks do
   # restart: :temporary means that this process will never be restarted (ie: will run once and then die)
   use GenServer, restart: :temporary
   import Ecto.Query, warn: false
+  require Logger
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Tasks
+  alias Pinchflat.Sources.Source
+  alias Pinchflat.FastIndexing.FastIndexingWorker
+  alias Pinchflat.SlowIndexing.SlowIndexingHelpers
 
   def start_link(opts \\ []) do
     GenServer.start_link(__MODULE__, %{env: Application.get_env(:pinchflat, :env)}, opts)
@@ -33,8 +40,49 @@ defmodule Pinchflat.Boot.PostJobStartupTasks do
   end
 
   def init(state) do
-    # Nothing at the moment!
+    reschedule_missing_indexing_tasks()
 
     {:ok, state}
+  end
+
+  # Indexing jobs are self-perpetuating: the next run is only enqueued from inside
+  # a completed run. If a job exhausts its retries and is discarded (eg: during an
+  # extended network or YouTube outage), the chain dies and the source would never
+  # be indexed again. Re-kick any missing chains on boot.
+  #
+  # This runs after PreJobStartupTasks has already reset stuck `executing` jobs to
+  # `retryable`, so a live chain always has a task in one of the pending states
+  # checked below and won't be double-scheduled.
+  defp reschedule_missing_indexing_tasks do
+    sources_query = from(s in Source, where: s.enabled == true and is_nil(s.marked_for_deletion_at))
+
+    sources_query
+    |> Repo.all()
+    |> Enum.each(fn source ->
+      maybe_reschedule_slow_indexing(source)
+      maybe_reschedule_fast_indexing(source)
+    end)
+  end
+
+  defp maybe_reschedule_slow_indexing(source) do
+    if source.index_frequency_minutes > 0 && !pending_task?(source, "MediaCollectionIndexingWorker") do
+      Logger.info("Rescheduling missing slow indexing job for source ##{source.id}")
+
+      SlowIndexingHelpers.kickoff_indexing_task(source)
+    end
+  end
+
+  # The reschedule is delayed by the fast indexing frequency (rather than running
+  # immediately) so that a boot with many sources doesn't burst RSS fetches.
+  defp maybe_reschedule_fast_indexing(source) do
+    if source.fast_index && !pending_task?(source, "FastIndexingWorker") do
+      Logger.info("Rescheduling missing fast indexing job for source ##{source.id}")
+
+      FastIndexingWorker.kickoff_with_task(source, schedule_in: Source.fast_index_frequency() * 60)
+    end
+  end
+
+  defp pending_task?(source, worker_name) do
+    Tasks.list_tasks_for(source, worker_name, [:available, :scheduled, :retryable, :executing]) != []
   end
 end

--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -148,16 +148,14 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
     QualityOptionBuilder.build(media_profile)
   end
 
+  # yt-dlp accepts both flags in one invocation, so each category can be
+  # removed or marked as a chapter independently
   defp sponsorblock_options(media_profile) do
-    categories = media_profile.sponsorblock_categories
-    behaviour = media_profile.sponsorblock_behaviour
-
-    case {behaviour, categories} do
-      {_, []} -> []
-      {:remove, _} -> [sponsorblock_remove: Enum.join(categories, ",")]
-      {:mark, _} -> [sponsorblock_mark: Enum.join(categories, ",")]
-      {:disabled, _} -> []
-    end
+    [
+      sponsorblock_remove: Enum.join(media_profile.sponsorblock_remove_categories, ","),
+      sponsorblock_mark: Enum.join(media_profile.sponsorblock_mark_categories, ",")
+    ]
+    |> Enum.reject(fn {_flag, categories} -> categories == "" end)
   end
 
   # This is put here instead of the CommandRunner module because it should only

--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -220,17 +220,11 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
     }
   end
 
-  # I don't love the string manipulation here, but what can ya' do.
-  # It's dependent on the output_path_template being a string ending `.{{ ext }}`
-  # (or equivalent), but that's validated by the MediaProfile schema.
+  # The thumbnail must share the media file's basename (differing only in
+  # extension) for media center apps to pick it up as the episode thumbnail -
+  # Plex in particular only matches an exactly-named sidecar image
   defp determine_thumbnail_location(media_item_with_preloads) do
-    output_path_template = Sources.output_path_template(media_item_with_preloads.source)
-
-    output_path_template
-    |> String.split(~r{\.}, include_captures: true)
-    |> List.insert_at(-3, "-thumb")
-    |> Enum.join()
-    |> build_output_path(media_item_with_preloads)
+    build_output_path_for(media_item_with_preloads)
   end
 
   defp pad_int(integer, count \\ 2, padding \\ "0") do

--- a/lib/pinchflat/downloading/quality_option_builder.ex
+++ b/lib/pinchflat/downloading/quality_option_builder.ex
@@ -38,21 +38,36 @@ defmodule Pinchflat.Downloading.QualityOptionBuilder do
     ]
   end
 
-  defp build_format_string(%MediaProfile{preferred_resolution: :audio, audio_track: audio_track}) do
+  defp build_format_string(%MediaProfile{preferred_resolution: :audio, audio_track: audio_track} = media_profile) do
+    super_resolution_filter = super_resolution_filter(media_profile)
+
     if audio_track do
-      "bestaudio[#{build_format_modifier(audio_track)}]/bestaudio/best"
+      "bestaudio[#{build_format_modifier(audio_track)}]#{super_resolution_filter}" <>
+        "/bestaudio#{super_resolution_filter}/best#{super_resolution_filter}"
     else
-      "bestaudio/best"
+      "bestaudio#{super_resolution_filter}/best#{super_resolution_filter}"
     end
   end
 
-  defp build_format_string(%MediaProfile{audio_track: audio_track}) do
+  defp build_format_string(%MediaProfile{audio_track: audio_track} = media_profile) do
+    super_resolution_filter = super_resolution_filter(media_profile)
+
     if audio_track do
-      "bestvideo+bestaudio[#{build_format_modifier(audio_track)}]/bestvideo*+bestaudio/best"
+      "bestvideo#{super_resolution_filter}+" <>
+        "bestaudio[#{build_format_modifier(audio_track)}]#{super_resolution_filter}/" <>
+        "bestvideo*#{super_resolution_filter}+bestaudio#{super_resolution_filter}/" <>
+        "best#{super_resolution_filter}"
     else
-      "bestvideo*+bestaudio/best"
+      "bestvideo*#{super_resolution_filter}+bestaudio#{super_resolution_filter}/" <>
+        "best#{super_resolution_filter}"
     end
   end
+
+  defp super_resolution_filter(%MediaProfile{ignore_youtube_super_resolution: true}) do
+    "[format_note!*=?AI-upscaled]"
+  end
+
+  defp super_resolution_filter(%MediaProfile{}), do: ""
 
   # Reminder to self: this conflicts with `--extractor-args "youtube:lang=<LANG>"`
   # since that will translate the format_notes as well, which means they may not match.

--- a/lib/pinchflat/metadata/metadata_parser.ex
+++ b/lib/pinchflat/metadata/metadata_parser.ex
@@ -54,24 +54,9 @@ defmodule Pinchflat.Metadata.MetadataParser do
       |> Enum.reverse()
       |> Enum.find_value(fn attrs -> attrs["filepath"] end)
 
-    if thumbnail_filepath do
-      # NOTE: whole ordeal needed due to a bug I found in yt-dlp
-      # https://github.com/yt-dlp/yt-dlp/issues/9445
-      # Can be reverted to remove this entire conditional once fixed
-      filepath =
-        thumbnail_filepath
-        |> String.split(~r{\.}, include_captures: true)
-        |> List.insert_at(-3, "-thumb")
-        |> Enum.join()
-
-      %{
-        thumbnail_filepath: filepath_if_exists(filepath)
-      }
-    else
-      %{
-        thumbnail_filepath: nil
-      }
-    end
+    %{
+      thumbnail_filepath: filepath_if_exists(thumbnail_filepath)
+    }
   end
 
   defp parse_infojson_metadata(metadata) do

--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -16,6 +16,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   alias Pinchflat.Utils.StringUtils
   alias Pinchflat.Metadata.NfoBuilder
   alias Pinchflat.YtDlp.MediaCollection
+  alias Pinchflat.YtDlp.ResponseDecoder
   alias Pinchflat.YtDlp.UnavailableMedia
   alias Pinchflat.Metadata.SourceImageParser
   alias Pinchflat.Metadata.MetadataFileHelpers
@@ -49,44 +50,47 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   @impl Oban.Worker
   def perform(%Oban.Job{args: %{"id" => source_id}}) do
     source = Repo.preload(Sources.get_source!(source_id), [:metadata, :media_profile])
-    series_directory = determine_series_directory(source)
 
-    case fetch_source_metadata_and_images(series_directory, source) do
-      {:ok, {source_metadata, source_image_attrs, metadata_image_attrs}} ->
-        source_metadata_filepath = MetadataFileHelpers.compress_and_store_metadata_for(source, source_metadata)
+    with {:ok, series_directory} <- determine_series_directory(source),
+         {:ok, source_metadata, source_image_attrs, metadata_image_attrs} <-
+           fetch_source_metadata_and_images(series_directory, source) do
+      source_metadata_filepath = MetadataFileHelpers.compress_and_store_metadata_for(source, source_metadata)
 
-        Sources.update_source(
-          source,
-          Map.merge(
-            %{
-              series_directory: series_directory,
-              nfo_filepath: store_source_nfo(source, series_directory, source_metadata),
-              description: source_metadata["description"],
-              metadata: Map.merge(%{metadata_filepath: source_metadata_filepath}, metadata_image_attrs)
-            },
-            source_image_attrs
-          ),
-          # `run_post_commit_tasks: false` prevents this from running in an infinite loop
-          run_post_commit_tasks: false
+      Sources.update_source(
+        source,
+        Map.merge(
+          %{
+            series_directory: series_directory,
+            nfo_filepath: store_source_nfo(source, series_directory, source_metadata),
+            description: source_metadata["description"],
+            metadata: Map.merge(%{metadata_filepath: source_metadata_filepath}, metadata_image_attrs)
+          },
+          source_image_attrs
+        ),
+        # `run_post_commit_tasks: false` prevents this from running in an infinite loop
+        run_post_commit_tasks: false
+      )
+
+      :ok
+    else
+      # A failed metadata/details fetch used to blow up here via a strict `{:ok, _} =` match,
+      # producing an opaque MatchError crash-loop. Instead, surface source context and let the
+      # job fail (and retry) cleanly. For decode errors, `ResponseDecoder` has already logged
+      # the raw yt-dlp response.
+      error ->
+        decode_hint =
+          if ResponseDecoder.decode_error?(error) do
+            " See the preceding yt-dlp log line for the raw response."
+          else
+            ""
+          end
+
+        Logger.error(
+          "#{__MODULE__} could not fetch metadata for source ##{source_id} (#{source.original_url}): " <>
+            "#{inspect(error)}." <> decode_hint
         )
 
-        :ok
-
-      {:error, message, exit_code} ->
-        Logger.warning(
-          "#{__MODULE__} failed to fetch metadata for source #{source.id} " <>
-            "(#{source.original_url}): #{message} (exit code #{exit_code})"
-        )
-
-        {:error, {message, exit_code}}
-
-      {:error, reason} ->
-        Logger.warning(
-          "#{__MODULE__} failed to fetch metadata for source #{source.id} " <>
-            "(#{source.original_url}): #{Exception.message(reason)}"
-        )
-
-        {:error, reason}
+        {:error, :source_metadata_fetch_failed}
     end
   rescue
     Ecto.NoResultsError -> Logger.info("#{__MODULE__} discarded: source #{source_id} not found")
@@ -102,21 +106,21 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
       if source.media_profile.download_source_images && series_directory do
         source_image_attrs = SourceImageParser.store_source_images(series_directory, metadata)
 
-        {:ok, {metadata, source_image_attrs, metadata_image_attrs}}
+        {:ok, metadata, source_image_attrs, metadata_image_attrs}
       else
-        {:ok, {metadata, %{}, metadata_image_attrs}}
+        {:ok, metadata, %{}, metadata_image_attrs}
       end
     end
   end
 
-  # The metadata/thumbnail fetch samples a single video (the first item for playlists)
-  # and, unlike indexing, doesn't pass `ignore_no_formats_error`. If that sampled video is
-  # members-only/private/removed, yt-dlp exits non-zero and the fetch returns an error.
+  # Both the details fetch and the metadata/thumbnail fetch sample a single video (the
+  # first item for playlists). If that sampled video is members-only/private/removed,
+  # yt-dlp exits non-zero and the fetch returns an error.
   #
   # When the "ignore unavailable media" setting is enabled we fall back to empty metadata
-  # (skipping source images) so the source can still be set up, rather than letting the
-  # `{:ok, metadata}` match crash and discard the job. Otherwise the original error is passed
-  # through unchanged, preserving the prior crash-and-retry behaviour.
+  # (skipping source images and the series directory) so the source can still be set up,
+  # rather than failing the job. Otherwise the original error is passed through unchanged,
+  # preserving the fail-and-retry behaviour.
   defp maybe_ignore_unavailable_source_metadata(source, {:error, message, _exit_code} = err) do
     if Settings.get!(:ignore_unavailable_media) && UnavailableMedia.error?(message) do
       Logger.info("Ignoring unavailable media while fetching metadata for source ##{source.id}: #{inspect(message)}")
@@ -133,11 +137,22 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
     output_path = DownloadOptionBuilder.build_output_path_for(source)
     runner_opts = [output: output_path]
     addl_opts = [use_cookies: Sources.use_cookies?(source, :metadata)]
-    {:ok, %{filepath: filepath}} = MediaCollection.get_source_details(source.original_url, runner_opts, addl_opts)
+    details_result = MediaCollection.get_source_details(source.original_url, runner_opts, addl_opts)
 
-    case MetadataFileHelpers.series_directory_from_media_filepath(filepath) do
-      {:ok, series_directory} -> series_directory
-      {:error, _} -> nil
+    case maybe_ignore_unavailable_source_metadata(source, details_result) do
+      {:ok, %{filepath: filepath}} when is_binary(filepath) ->
+        case MetadataFileHelpers.series_directory_from_media_filepath(filepath) do
+          {:ok, series_directory} -> {:ok, series_directory}
+          {:error, _} -> {:ok, nil}
+        end
+
+      # Either the ignored-unavailable fallback (`{:ok, %{}}`) or a parseable response
+      # that's missing `filename` - there's no filepath to derive a series directory from
+      {:ok, _} ->
+        {:ok, nil}
+
+      err ->
+        err
     end
   end
 

--- a/lib/pinchflat/profiles/media_profile.ex
+++ b/lib/pinchflat/profiles/media_profile.ex
@@ -28,6 +28,7 @@ defmodule Pinchflat.Profiles.MediaProfile do
     livestream_behaviour
     audio_track
     preferred_resolution
+    ignore_youtube_super_resolution
     media_container
     redownload_delay_days
     marked_for_deletion_at
@@ -68,6 +69,7 @@ defmodule Pinchflat.Profiles.MediaProfile do
     field :livestream_behaviour, Ecto.Enum, values: ~w(include exclude only)a, default: :include
     field :audio_track, :string
     field :preferred_resolution, Ecto.Enum, values: ~w(4320p 2160p 1440p 1080p 720p 480p 360p audio)a, default: :"1080p"
+    field :ignore_youtube_super_resolution, :boolean, default: false
     field :media_container, :string, default: nil
 
     field :marked_for_deletion_at, :utc_datetime

--- a/lib/pinchflat/profiles/media_profile.ex
+++ b/lib/pinchflat/profiles/media_profile.ex
@@ -22,8 +22,8 @@ defmodule Pinchflat.Profiles.MediaProfile do
     download_metadata
     embed_metadata
     download_nfo
-    sponsorblock_behaviour
-    sponsorblock_categories
+    sponsorblock_mark_categories
+    sponsorblock_remove_categories
     shorts_behaviour
     livestream_behaviour
     audio_track
@@ -35,6 +35,8 @@ defmodule Pinchflat.Profiles.MediaProfile do
   )a
 
   @required_fields ~w(name output_path_template)a
+
+  @sponsorblock_categories ~w(sponsor intro outro selfpromo preview filler interaction music_offtopic hook)
 
   schema "media_profiles" do
     field :name, :string
@@ -56,8 +58,8 @@ defmodule Pinchflat.Profiles.MediaProfile do
     field :embed_metadata, :boolean, default: false
 
     field :download_nfo, :boolean, default: false
-    field :sponsorblock_behaviour, Ecto.Enum, values: [:disabled, :mark, :remove], default: :disabled
-    field :sponsorblock_categories, {:array, :string}, default: []
+    field :sponsorblock_mark_categories, {:array, :string}, default: []
+    field :sponsorblock_remove_categories, {:array, :string}, default: []
     # NOTE: these do NOT speed up indexing - the indexer still has to go
     # through the entire collection to determine if a media is a short or
     # a livestream.
@@ -87,7 +89,34 @@ defmodule Pinchflat.Profiles.MediaProfile do
     # Ensures it ends with `.{{ ext }}` or `.%(ext)s` or similar (with a little wiggle room)
     |> validate_format(:output_path_template, ext_regex(), message: "must end with .{{ ext }}")
     |> validate_number(:redownload_delay_days, greater_than_or_equal_to: 0)
+    |> validate_subset(:sponsorblock_mark_categories, @sponsorblock_categories)
+    |> validate_subset(:sponsorblock_remove_categories, @sponsorblock_categories)
+    |> validate_sponsorblock_categories_do_not_overlap()
     |> unique_constraint(:name)
+  end
+
+  @doc """
+  Returns the list of SponsorBlock category identifiers a profile can act on.
+
+  Returns [binary()]
+  """
+  def sponsorblock_categories, do: @sponsorblock_categories
+
+  defp validate_sponsorblock_categories_do_not_overlap(changeset) do
+    mark = get_field(changeset, :sponsorblock_mark_categories) || []
+    remove = get_field(changeset, :sponsorblock_remove_categories) || []
+
+    case Enum.filter(mark, &(&1 in remove)) do
+      [] ->
+        changeset
+
+      overlap ->
+        add_error(
+          changeset,
+          :sponsorblock_mark_categories,
+          "can't mark and remove the same category: #{Enum.join(overlap, ", ")}"
+        )
+    end
   end
 
   @doc false

--- a/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
+++ b/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
@@ -213,7 +213,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
       |> Enum.map_join("\n", fn media_item -> "youtube #{media_item.media_id}" end)
 
     case File.write(tmpfile, archive_contents) do
-      :ok -> tmpfile
+      :ok -> {:ok, tmpfile}
       err -> err
     end
   end
@@ -246,10 +246,18 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
   defp build_download_archive_options(%Source{last_indexed_at: nil}, _was_forced), do: []
   defp build_download_archive_options(_source, true), do: []
 
+  # The archive is an optimization, so if the file can't be written we index
+  # without one rather than passing a bad option to yt-dlp or failing the run.
   defp build_download_archive_options(source, _was_forced) do
-    archive_file = create_download_archive_file(source)
+    case create_download_archive_file(source) do
+      {:ok, archive_file} ->
+        [:break_on_existing, download_archive: archive_file]
 
-    [:break_on_existing, download_archive: archive_file]
+      {:error, err} ->
+        Logger.warning("Unable to write download archive file for source ##{source.id}: #{inspect(err)}")
+
+        []
+    end
   end
 
   defp build_single_video_options(%Source{collection_type: :video}), do: [:no_playlist]

--- a/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
+++ b/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
@@ -153,7 +153,10 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
 
     results =
       Enum.map(indexing_urls_for(source), fn {url, content_type} ->
-        command_opts = base_command_opts ++ build_download_archive_options(source, was_forced, content_type)
+        command_opts =
+          base_command_opts ++
+            build_download_archive_options(source, was_forced, content_type) ++
+            build_index_cutoff_options(source, content_type)
 
         run_indexing_command(source, url, command_opts, should_use_cookies)
       end)
@@ -340,6 +343,32 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
   defp content_type_filter(:shorts), do: dynamic([mi], mi.short_form_content == true)
   defp content_type_filter(:streams), do: dynamic([mi], mi.livestream == true)
   defp content_type_filter(:all), do: dynamic(true)
+
+  # `--break-match-filters` aborts the crawl the moment it reaches a video older
+  # than the source's indexing cutoff date. Unlike the download archive (which is
+  # skipped on first/forced indexes), this applies to every index — the first crawl
+  # of a large channel is exactly where it saves the most time.
+  #
+  # Early abort is only safe when the listing is newest-first, which is only
+  # guaranteed for YouTube channel tabs — playlists are ordered arbitrarily and
+  # non-YouTube sources make no ordering promise. Both of those index with an
+  # `:all` content type, so matching on tab content types gates this to YouTube
+  # channels.
+  #
+  # yt-dlp ORs repeated match filters, so this breaks only when a video HAS an
+  # upload date and it's older than the cutoff. The `!upload_date` clause keeps
+  # entries without one (eg: upcoming premieres) from tripping the break.
+  defp build_index_cutoff_options(%Source{index_cutoff_date: %Date{} = cutoff_date}, content_type)
+       when content_type in [:videos, :shorts, :streams] do
+    formatted_date = Calendar.strftime(cutoff_date, "%Y%m%d")
+
+    [
+      break_match_filters: "upload_date >= #{formatted_date}",
+      break_match_filters: "!upload_date"
+    ]
+  end
+
+  defp build_index_cutoff_options(_source, _content_type), do: []
 
   # The download archive isn't useful for playlists (since those are ordered arbitrarily)
   # and we don't want to use it if the indexing was forced by the user. In other words,

--- a/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
+++ b/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
@@ -70,6 +70,13 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
   clarity to the user experience. This has a few things to be aware of which are documented
   below in the file watcher setup method.
 
+  YouTube channels are indexed one tab at a time (videos, shorts, streams) as separate
+  yt-dlp invocations. This matters because `--break-on-existing` aborts the whole yt-dlp
+  process — not just the current tab — so indexing a bare channel URL with a download
+  archive would stop at the first known video and never reach the shorts or streams tabs.
+  Indexing each tab separately (with an archive filtered to that tab's content type) lets
+  the early-abort optimization work per-tab without starving the others.
+
   Additionally, in the case of a repeat index we create a download archive file that
   contains some media IDs that we've indexed in the past. Note that this archive doesn't
   contain the most recent IDs but rather a subset of IDs that are offset by some amount.
@@ -136,24 +143,112 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
   # for a sufficiently long time.
   defp setup_file_watcher_and_kickoff_indexing(source, opts) do
     was_forced = Keyword.get(opts, :was_forced, false)
-    {:ok, pid} = FileFollowerServer.start_link()
-
-    handler = fn filepath -> setup_file_follower_watcher(pid, filepath, source) end
     should_use_cookies = Sources.use_cookies?(source, :indexing)
 
-    command_opts =
+    base_command_opts =
       [output: DownloadOptionBuilder.build_output_path_for(source)] ++
         build_single_video_options(source) ++
         DownloadOptionBuilder.build_quality_options_for(source) ++
-        build_download_archive_options(source, was_forced) ++
         build_dateafter_options(source)
 
-    runner_opts = [file_listener_handler: handler, use_cookies: should_use_cookies]
-    result = MediaCollection.get_media_attributes_for_collection(source.original_url, command_opts, runner_opts)
+    results =
+      Enum.map(indexing_urls_for(source), fn {url, content_type} ->
+        command_opts = base_command_opts ++ build_download_archive_options(source, was_forced, content_type)
+
+        run_indexing_command(source, url, command_opts, should_use_cookies)
+      end)
+
+    # A channel can legitimately lack a shorts or streams tab (yt-dlp errors out
+    # on those), so a failed URL only fails the index if no URL succeeded at all.
+    # Tabs shouldn't overlap in content, but dedupe across them just in case.
+    case Enum.split_with(results, &match?({:ok, _}, &1)) do
+      {[], [first_error | _]} ->
+        first_error
+
+      {successes, _} ->
+        media_attributes =
+          successes
+          |> Enum.flat_map(fn {:ok, media_attributes} -> media_attributes end)
+          |> Enum.uniq_by(& &1.media_id)
+
+        {:ok, media_attributes}
+    end
+  end
+
+  defp run_indexing_command(source, url, command_opts, should_use_cookies) do
+    {:ok, pid} = FileFollowerServer.start_link()
+
+    handler = fn filepath -> setup_file_follower_watcher(pid, filepath, source) end
+
+    # Exit code 1 is declared as expected so the runner logs it at debug instead
+    # of error — failures are logged here instead, where we can tell a channel
+    # legitimately missing a shorts/streams tab apart from a real error.
+    runner_opts = [
+      file_listener_handler: handler,
+      use_cookies: should_use_cookies,
+      expected_exit_codes: [1]
+    ]
+
+    result = MediaCollection.get_media_attributes_for_collection(url, command_opts, runner_opts)
 
     FileFollowerServer.stop(pid)
 
-    result
+    case result do
+      {:ok, media_attributes} ->
+        {:ok, media_attributes}
+
+      err ->
+        log_indexing_failure(url, err)
+        err
+    end
+  end
+
+  # A channel not having a shorts/streams/live tab is a normal state of affairs,
+  # not something to warn about on every scheduled index.
+  defp log_indexing_failure(url, {:error, message, _status} = err) when is_binary(message) do
+    if message =~ ~r/does not have a \S+ tab/ do
+      Logger.debug("Indexing skipped for #{url}: #{String.trim(message)}")
+    else
+      Logger.warning("Indexing failed for #{url}: #{inspect(err)}")
+    end
+  end
+
+  defp log_indexing_failure(url, err) do
+    Logger.warning("Indexing failed for #{url}: #{inspect(err)}")
+  end
+
+  # YouTube channels are indexed one content tab at a time because `--break-on-existing`
+  # aborts the entire yt-dlp process, not just the current tab — indexing a bare channel
+  # URL with a download archive stops at the first known video and never reaches the
+  # shorts or streams tabs (see moduledoc). Channels whose URL already names a tab are
+  # respected as-is, and playlists/non-YouTube sources are passed through untouched.
+  defp indexing_urls_for(%Source{collection_type: :channel} = source) do
+    explicit_tab = explicit_channel_tab(source.original_url)
+
+    cond do
+      not String.contains?(source.original_url, "youtube.com") ->
+        [{source.original_url, :all}]
+
+      explicit_tab ->
+        [{source.original_url, explicit_tab}]
+
+      true ->
+        Enum.map([:videos, :shorts, :streams], fn tab ->
+          {"https://www.youtube.com/channel/#{source.collection_id}/#{tab}", tab}
+        end)
+    end
+  end
+
+  defp indexing_urls_for(source), do: [{source.original_url, :all}]
+
+  defp explicit_channel_tab(url) do
+    case Regex.run(~r{youtube\.com/.+/(videos|shorts|streams|live)/?(?:\?.*)?$}, url) do
+      [_, "videos"] -> :videos
+      [_, "shorts"] -> :shorts
+      [_, "streams"] -> :streams
+      [_, "live"] -> :streams
+      _ -> nil
+    end
   end
 
   defp setup_file_follower_watcher(pid, filepath, source) do
@@ -201,15 +296,18 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
   # yt-dlp once we've hit media items we've already indexed. But we generate
   # this list with a bit of an offset so we do intentionally re-scan some media
   # items to pick up any recent changes (see `get_media_items_for_download_archive`).
+  # The archive only contains media matching the content tab being indexed —
+  # a short in the videos tab's archive would never match anything and would
+  # eat into the re-scan buffer.
   #
   # From there, we format the media IDs in the way that yt-dlp expects (ie: "<extractor> <media_id>")
   # and return the filepath to the caller.
-  defp create_download_archive_file(source) do
+  defp create_download_archive_file(source, content_type) do
     tmpfile = FilesystemUtils.generate_metadata_tmpfile(:txt)
 
     archive_contents =
       source
-      |> get_media_items_for_download_archive()
+      |> get_media_items_for_download_archive(content_type)
       |> Enum.map_join("\n", fn media_item -> "youtube #{media_item.media_id}" end)
 
     case File.write(tmpfile, archive_contents) do
@@ -228,28 +326,34 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
   #
   # The chosen limit and offset are arbitary, independent, and vibes-based. Feel free to
   # tweak as-needed
-  defp get_media_items_for_download_archive(source) do
+  defp get_media_items_for_download_archive(source, content_type) do
     MediaQuery.new()
     |> where(^MediaQuery.for_source(source))
+    |> where(^content_type_filter(content_type))
     |> order_by(desc: :uploaded_at)
     |> limit(50)
     |> offset(20)
     |> Repo.all()
   end
 
+  defp content_type_filter(:videos), do: dynamic([mi], mi.short_form_content == false and mi.livestream == false)
+  defp content_type_filter(:shorts), do: dynamic([mi], mi.short_form_content == true)
+  defp content_type_filter(:streams), do: dynamic([mi], mi.livestream == true)
+  defp content_type_filter(:all), do: dynamic(true)
+
   # The download archive isn't useful for playlists (since those are ordered arbitrarily)
   # and we don't want to use it if the indexing was forced by the user. In other words,
   # only create an archive for channels that are being indexed as part of their regular
   # indexing schedule. The first indexing pass should also not create an archive.
-  defp build_download_archive_options(%Source{collection_type: :playlist}, _was_forced), do: []
-  defp build_download_archive_options(%Source{collection_type: :video}, _was_forced), do: []
-  defp build_download_archive_options(%Source{last_indexed_at: nil}, _was_forced), do: []
-  defp build_download_archive_options(_source, true), do: []
+  defp build_download_archive_options(%Source{collection_type: :playlist}, _was_forced, _content_type), do: []
+  defp build_download_archive_options(%Source{collection_type: :video}, _was_forced, _content_type), do: []
+  defp build_download_archive_options(%Source{last_indexed_at: nil}, _was_forced, _content_type), do: []
+  defp build_download_archive_options(_source, true, _content_type), do: []
 
   # The archive is an optimization, so if the file can't be written we index
   # without one rather than passing a bad option to yt-dlp or failing the run.
-  defp build_download_archive_options(source, _was_forced) do
-    case create_download_archive_file(source) do
+  defp build_download_archive_options(source, _was_forced, content_type) do
+    case create_download_archive_file(source, content_type) do
       {:ok, archive_file} ->
         [:break_on_existing, download_archive: archive_file]
 

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -34,6 +34,7 @@ defmodule Pinchflat.Sources.Source do
     last_indexed_at
     original_url
     download_cutoff_date
+    index_cutoff_date
     retention_period_days
     title_filter_regex
     download_subdirectory
@@ -86,6 +87,11 @@ defmodule Pinchflat.Sources.Source do
     field :last_indexed_at, :utc_datetime
     # Only download media items that were published after this date
     field :download_cutoff_date, :date
+    # Stop indexing a channel once it reaches media published before this date.
+    # Only applied to YouTube channels — their tab listings are newest-first,
+    # which is what makes an early abort on an old video safe. Playlists are
+    # ordered arbitrarily so this is ignored for them (see SlowIndexingHelpers)
+    field :index_cutoff_date, :date
     field :retention_period_days, :integer
     field :original_url, :string
     field :title_filter_regex, :string
@@ -133,6 +139,7 @@ defmodule Pinchflat.Sources.Source do
     |> normalize_download_subdirectory()
     |> validate_download_subdirectory()
     |> validate_min_and_max_durations()
+    |> validate_index_cutoff_date()
     |> validate_number(:retention_period_days, greater_than_or_equal_to: 0)
     # Ensures it ends with `.{{ ext }}` or `.%(ext)s` or similar (with a little wiggle room)
     |> validate_format(:output_path_template_override, MediaProfile.ext_regex(), message: "must end with .{{ ext }}")
@@ -285,6 +292,20 @@ defmodule Pinchflat.Sources.Source do
   end
 
   defp validate_title_regex(changeset), do: changeset
+
+  # An indexing cutoff after the download cutoff would stop indexing before
+  # reaching media the download cutoff still allows — that media would never be
+  # indexed, so it could never be downloaded
+  defp validate_index_cutoff_date(changeset) do
+    index_cutoff = get_field(changeset, :index_cutoff_date)
+    download_cutoff = get_field(changeset, :download_cutoff_date)
+
+    if index_cutoff && download_cutoff && Date.compare(index_cutoff, download_cutoff) == :gt do
+      add_error(changeset, :index_cutoff_date, "must be on or before the download cutoff date")
+    else
+      changeset
+    end
+  end
 
   defp validate_min_and_max_durations(changeset) do
     min_duration = get_change(changeset, :min_duration_seconds)

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -196,10 +196,10 @@ defmodule Pinchflat.Sources.Source do
 
   def supported_youtube_url?(url) when is_binary(url) do
     supported_patterns = [
-      ~r<^https?://(?:www\.)?youtube\.com/channel/[^/?#]+(?:/(?:featured|videos))?$>,
-      ~r<^https?://(?:www\.)?youtube\.com/@[^/?#]+(?:/(?:featured|videos))?$>,
-      ~r<^https?://(?:www\.)?youtube\.com/c/[^/?#]+(?:/(?:featured|videos))?$>,
-      ~r<^https?://(?:www\.)?youtube\.com/user/[^/?#]+(?:/(?:featured|videos))?$>,
+      ~r<^https?://(?:www\.)?youtube\.com/channel/[^/?#]+(?:/(?:featured|videos|shorts|streams|live))?$>,
+      ~r<^https?://(?:www\.)?youtube\.com/@[^/?#]+(?:/(?:featured|videos|shorts|streams|live))?$>,
+      ~r<^https?://(?:www\.)?youtube\.com/c/[^/?#]+(?:/(?:featured|videos|shorts|streams|live))?$>,
+      ~r<^https?://(?:www\.)?youtube\.com/user/[^/?#]+(?:/(?:featured|videos|shorts|streams|live))?$>,
       ~r<^https?://(?:www\.)?youtube\.com/playlist\?list=[^&]+>
     ]
 

--- a/lib/pinchflat/sources/sources.ex
+++ b/lib/pinchflat/sources/sources.ex
@@ -794,6 +794,21 @@ defmodule Pinchflat.Sources do
     applied_changes = Ecto.Changeset.apply_changes(changeset)
 
     case {current_changes, applied_changes} do
+      # Widening the index cutoff further into the past means videos that were
+      # previously out of range are now in range, so we need to re-crawl. This
+      # must be a *forced* index: a normal scheduled index builds a
+      # `--break-on-existing` download archive that would halt at the first known
+      # video and never reach the newly-in-range older ones (see
+      # `SlowIndexingHelpers.build_download_archive_options/3`). Narrowing the
+      # cutoff needs no action since those items are already indexed.
+      {%{index_cutoff_date: _}, %{enabled: true, index_frequency_minutes: mins}}
+      when mins > 0 ->
+        if index_cutoff_widened?(changeset) do
+          SlowIndexingHelpers.kickoff_indexing_task(source, %{force: true})
+        else
+          :ok
+        end
+
       {%{index_frequency_minutes: mins}, %{enabled: true}} when mins > 0 ->
         SlowIndexingHelpers.kickoff_indexing_task(source)
 
@@ -808,6 +823,21 @@ defmodule Pinchflat.Sources do
 
       _ ->
         :ok
+    end
+  end
+
+  # A cutoff is "widened" when the new date reaches further into the past than
+  # the old one (or is removed entirely, making indexing unbounded). Removing a
+  # cutoff (-> nil) always widens; adding one to a previously unbounded source
+  # (nil -> date) only narrows and needs no re-index.
+  defp index_cutoff_widened?(changeset) do
+    old_cutoff = changeset.data.index_cutoff_date
+    new_cutoff = Ecto.Changeset.get_field(changeset, :index_cutoff_date)
+
+    case {old_cutoff, new_cutoff} do
+      {_, nil} -> not is_nil(old_cutoff)
+      {nil, _} -> false
+      {old, new} -> Date.compare(new, old) == :lt
     end
   end
 

--- a/lib/pinchflat/utils/cli_utils.ex
+++ b/lib/pinchflat/utils/cli_utils.ex
@@ -18,6 +18,10 @@ defmodule Pinchflat.Utils.CliUtils do
   Custom options:
     - logging_arg_override: if set, the passed value will be logged in place of
       the actual arguments passed to the command
+    - expected_exit_codes: exit codes (besides 0) that the caller treats as a
+      normal outcome and handles itself — these are logged at debug instead of
+      error so routine exits (eg: yt-dlp's 101 on --break-on-existing) don't
+      show up as noise
 
   Returns {binary(), integer()}
   """
@@ -26,11 +30,12 @@ defmodule Pinchflat.Utils.CliUtils do
     actual_command = [command] ++ args
     command_opts = set_command_opts() ++ passthrough_opts
     logging_arg_override = Keyword.get(opts, :logging_arg_override, Enum.join(args, " "))
+    expected_exit_codes = Keyword.get(opts, :expected_exit_codes, [])
 
     Logger.info("[command_wrapper]: #{command} called with: #{logging_arg_override}")
 
     {output, status} = System.cmd(wrapper_command, actual_command, command_opts)
-    log_cmd_result(command, logging_arg_override, status, output)
+    log_cmd_result(command, logging_arg_override, status, output, expected_exit_codes)
 
     {output, status}
   end
@@ -76,9 +81,9 @@ defmodule Pinchflat.Utils.CliUtils do
     acc ++ [arg]
   end
 
-  defp log_cmd_result(command, logging_arg_override, status, output) do
+  defp log_cmd_result(command, logging_arg_override, status, output, expected_exit_codes) do
     log_message = "[command_wrapper]: #{command} called with: #{logging_arg_override} exited: #{status} with: #{output}"
-    log_level = if status == 0, do: :debug, else: :error
+    log_level = if status == 0 || status in expected_exit_codes, do: :debug, else: :error
 
     Logger.log(log_level, log_message)
   end

--- a/lib/pinchflat/yt_dlp/command_runner.ex
+++ b/lib/pinchflat/yt_dlp/command_runner.ex
@@ -26,6 +26,9 @@ defmodule Pinchflat.YtDlp.CommandRunner do
       attach a cookie file if the user hasn't set one up.
     - :skip_sleep_interval - if true, will not add the sleep interval options to the command.
       Usually only used for commands that would be UI-blocking
+    - :expected_exit_codes - additional non-zero exit codes the caller treats as a
+      normal outcome and handles itself. These (plus 101, which this runner already
+      treats as success) get logged at debug instead of error.
 
   Returns {:ok, binary()} | {:error, output, status}.
   """
@@ -45,12 +48,15 @@ defmodule Pinchflat.YtDlp.CommandRunner do
     # These must stay in exactly this order, hence why I'm giving it its own variable.
     all_opts = command_opts ++ print_to_file_opts ++ user_configured_opts ++ global_options(addl_opts)
     formatted_command_opts = [url] ++ CliUtils.parse_options(all_opts)
+    expected_exit_codes = [101] ++ Keyword.get(addl_opts, :expected_exit_codes, [])
+
+    wrap_cmd_opts = [expected_exit_codes: expected_exit_codes]
 
     command_result =
       if action_name == :download && Keyword.has_key?(addl_opts, :progress_handler) do
         wrap_streaming_cmd(backend_executable(), formatted_command_opts, addl_opts)
       else
-        CliUtils.wrap_cmd(backend_executable(), formatted_command_opts, stderr_to_stdout: true)
+        CliUtils.wrap_cmd(backend_executable(), formatted_command_opts, [stderr_to_stdout: true], wrap_cmd_opts)
       end
 
     case command_result do

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -29,7 +29,7 @@ defmodule Pinchflat.YtDlp.Media do
   ]
 
   alias __MODULE__
-  alias Pinchflat.Utils.FunctionUtils
+  alias Pinchflat.YtDlp.ResponseDecoder
   alias Pinchflat.Metadata.MetadataFileHelpers
 
   @doc """
@@ -41,11 +41,8 @@ defmodule Pinchflat.YtDlp.Media do
   def download(url, command_opts \\ [], addl_opts \\ []) do
     all_command_opts = [:no_simulate] ++ command_opts
 
-    with {:ok, output} <- backend_runner().run(url, :download, all_command_opts, "after_move:%()j", addl_opts),
-         {:ok, parsed_json} <- Phoenix.json_library().decode(output) do
-      {:ok, parsed_json}
-    else
-      err -> err
+    with {:ok, output} <- backend_runner().run(url, :download, all_command_opts, "after_move:%()j", addl_opts) do
+      ResponseDecoder.decode(output, :download)
     end
   end
 
@@ -59,14 +56,9 @@ defmodule Pinchflat.YtDlp.Media do
     action = :get_downloadable_status
     command_opts = [:simulate, :skip_download]
 
-    case backend_runner().run(url, action, command_opts, "%(.{live_status})j", addl_opts) do
-      {:ok, output} ->
-        output
-        |> Phoenix.json_library().decode!()
-        |> parse_downloadable_status()
-
-      err ->
-        err
+    with {:ok, output} <- backend_runner().run(url, action, command_opts, "%(.{live_status})j", addl_opts),
+         {:ok, parsed_json} <- ResponseDecoder.decode(output, action) do
+      parse_downloadable_status(parsed_json)
     end
   end
 
@@ -95,15 +87,9 @@ defmodule Pinchflat.YtDlp.Media do
     all_command_opts = [:simulate, :skip_download] ++ command_opts
     output_template = indexing_output_template()
 
-    case backend_runner().run(url, :get_media_attributes, all_command_opts, output_template, addl_opts) do
-      {:ok, output} ->
-        output
-        |> Phoenix.json_library().decode!()
-        |> response_to_struct()
-        |> FunctionUtils.wrap_ok()
-
-      err ->
-        err
+    with {:ok, output} <- backend_runner().run(url, :get_media_attributes, all_command_opts, output_template, addl_opts),
+         {:ok, parsed_json} <- ResponseDecoder.decode(output, :get_media_attributes) do
+      {:ok, response_to_struct(parsed_json)}
     end
   end
 

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -87,7 +87,8 @@ defmodule Pinchflat.YtDlp.Media do
     all_command_opts = [:simulate, :skip_download] ++ command_opts
     output_template = indexing_output_template()
 
-    with {:ok, output} <- backend_runner().run(url, :get_media_attributes, all_command_opts, output_template, addl_opts),
+    with {:ok, output} <-
+           backend_runner().run(url, :get_media_attributes, all_command_opts, output_template, addl_opts),
          {:ok, parsed_json} <- ResponseDecoder.decode(output, :get_media_attributes) do
       {:ok, response_to_struct(parsed_json)}
     end

--- a/lib/pinchflat/yt_dlp/media_collection.ex
+++ b/lib/pinchflat/yt_dlp/media_collection.ex
@@ -8,6 +8,7 @@ defmodule Pinchflat.YtDlp.MediaCollection do
 
   alias Pinchflat.Sources.Source
   alias Pinchflat.Utils.FilesystemUtils
+  alias Pinchflat.YtDlp.ResponseDecoder
   alias Pinchflat.YtDlp.Media, as: YtDlpMedia
 
   @doc """
@@ -94,11 +95,8 @@ defmodule Pinchflat.YtDlp.MediaCollection do
     action = :get_source_details
 
     with {:ok, output} <- backend_runner().run(source_url, action, all_command_opts, output_template, addl_opts),
-         {:ok, parsed_json} <- Phoenix.json_library().decode(output) do
+         {:ok, parsed_json} <- ResponseDecoder.decode(output, action) do
       {:ok, format_source_details(parsed_json)}
-    else
-      {:error, %Jason.DecodeError{}} -> {:error, "Error decoding JSON response"}
-      err -> err
     end
   end
 
@@ -154,11 +152,8 @@ defmodule Pinchflat.YtDlp.MediaCollection do
     output_template = "playlist:%()j"
     action = :get_source_metadata
 
-    with {:ok, output} <- backend_runner().run(source_url, action, all_command_opts, output_template, addl_opts),
-         {:ok, parsed_json} <- Phoenix.json_library().decode(output) do
-      {:ok, parsed_json}
-    else
-      err -> err
+    with {:ok, output} <- backend_runner().run(source_url, action, all_command_opts, output_template, addl_opts) do
+      ResponseDecoder.decode(output, action)
     end
   end
 

--- a/lib/pinchflat/yt_dlp/media_collection.ex
+++ b/lib/pinchflat/yt_dlp/media_collection.ex
@@ -21,6 +21,8 @@ defmodule Pinchflat.YtDlp.MediaCollection do
       file that will be written to when yt-dlp is done. This is useful for
       setting up a file watcher to know when the file is ready to be read.
     - :use_cookies - whether or not to use user-provided cookies when fetching the media details
+    - :expected_exit_codes - passed through to the runner; non-zero exit codes the
+      caller treats as a normal outcome (logged at debug instead of error)
 
   Returns {:ok, [map()]} | {:error, any, ...}.
   """
@@ -33,7 +35,11 @@ defmodule Pinchflat.YtDlp.MediaCollection do
     output_template = YtDlpMedia.indexing_output_template()
     output_filepath = FilesystemUtils.generate_metadata_tmpfile(:json)
     file_listener_handler = Keyword.get(addl_opts, :file_listener_handler, false)
-    runner_opts = [output_filepath: output_filepath, use_cookies: use_cookies]
+
+    runner_opts =
+      [output_filepath: output_filepath, use_cookies: use_cookies] ++
+        Keyword.take(addl_opts, [:expected_exit_codes])
+
     action = :get_media_attributes_for_collection
 
     if file_listener_handler do

--- a/lib/pinchflat/yt_dlp/response_decoder.ex
+++ b/lib/pinchflat/yt_dlp/response_decoder.ex
@@ -1,0 +1,46 @@
+defmodule Pinchflat.YtDlp.ResponseDecoder do
+  @moduledoc """
+  Decodes JSON output from yt-dlp commands.
+
+  yt-dlp writes its `--print`/`--print-to-file` template to a file that we read back and
+  expect to be a single JSON document. An empty or truncated response - an extractor change,
+  a geo-block, an empty/unavailable collection, or a yt-dlp behaviour change - fails to
+  decode. Log the raw yt-dlp response so the underlying cause is diagnosable, then return a
+  clean error tuple instead of a bare Jason.DecodeError (which callers would otherwise
+  crash on via a strict `{:ok, _} =` match or a `decode!`).
+  """
+
+  require Logger
+
+  @decode_error_message "Error decoding JSON response"
+
+  @doc """
+  Decodes a JSON response from the given yt-dlp action, logging the raw
+  response (truncated) when it can't be parsed.
+
+  Returns {:ok, map()} | {:error, binary()}
+  """
+  def decode(output, action) do
+    case Phoenix.json_library().decode(output) do
+      {:ok, parsed_json} ->
+        {:ok, parsed_json}
+
+      {:error, decode_error} ->
+        Logger.error(
+          "yt-dlp #{action} returned an unparseable response (#{byte_size(output)} bytes): " <>
+            "#{inspect(Exception.message(decode_error))}. Raw response: #{inspect(String.slice(output, 0, 500))}"
+        )
+
+        {:error, @decode_error_message}
+    end
+  end
+
+  @doc """
+  Determines if the given term is a decode error produced by `decode/2`, letting
+  callers reference the raw-response log line only when one was actually emitted.
+
+  Returns boolean()
+  """
+  def decode_error?({:error, @decode_error_message}), do: true
+  def decode_error?(_), do: false
+end

--- a/lib/pinchflat_web/components/core_components.ex
+++ b/lib/pinchflat_web/components/core_components.ex
@@ -353,7 +353,8 @@ defmodule PinchflatWeb.CoreComponents do
       <.label for={@id}>
         {@label}<span :if={@label_suffix} class="text-xs text-theme-on-surface-muted">{@label_suffix}</span>
       </.label>
-
+      <%!-- Ensures the field is submitted (as an empty list) even when no boxes are checked --%>
+      <input type="hidden" name={"#{@name}[]"} value="" />
       <section class="grid grid-cols-1 gap-2 md:grid-cols-2 max-w-prose mb-4 ml-1">
         <div :for={{option_name, option_value} <- @options} class="flex items-center">
           <input

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html.ex
@@ -35,15 +35,7 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
     ]
   end
 
-  def friendly_sponsorblock_options do
-    [
-      {"Disabled (default)", "disabled"},
-      {"Mark Segments as Chapters", "mark"},
-      {"Remove Segments", "remove"}
-    ]
-  end
-
-  def frieldly_sponsorblock_categories do
+  def friendly_sponsorblock_categories do
     [
       {"Sponsor", "sponsor"},
       {"Intro/Intermission", "intro"},
@@ -52,7 +44,8 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileHTML do
       {"Preview/Recap", "preview"},
       {"Filler Tangent", "filler"},
       {"Interaction Reminder", "interaction"},
-      {"Non-music Section", "music_offtopic"}
+      {"Non-music Section", "music_offtopic"},
+      {"Hook/Greetings", "hook"}
     ]
   end
 

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
@@ -20,7 +20,7 @@
         type="select"
         x-model="selection"
         inputclass="w-full"
-        help="You can further customize the settings after selecting a preset. This is just a starting point"
+        help="You can further customize the settings after selecting a preset. This is just a starting point."
       >
         <.button
           class="h-13 w-2/5 lg:w-1/5 ml-2 md:ml-4"

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
@@ -298,31 +298,30 @@
 
     <h3 class="mt-10 text-2xl text-theme-on-surface">SponsorBlock Options</h3>
 
-    <section x-data="{ sponsorblockBehaviour: null }">
-      <section x-data="{ presets: { default: 'disabled', media_center: 'disabled', audio: 'disabled', archiving: 'disabled' } }">
-        <.input
-          field={f[:sponsorblock_behaviour]}
-          options={friendly_sponsorblock_options()}
-          type="select"
-          label="SponsorBlock Behaviour"
-          help="Action to take when SponsorBlock segments are found. 'Disabled' won't take any action"
-          x-model="sponsorblockBehaviour"
-          x-init="
-            sponsorblockBehaviour = $el.value
-          $watch('selectedPreset', p => p && ($el.value = presets[p], $el.dispatchEvent(new Event('change', { bubbles: true }))))
-          "
-        />
-      </section>
+    <p class="mb-4 text-sm text-theme-on-surface-muted">
+      Not sure what a category covers? See the
+      <.subtle_link href="https://wiki.sponsor.ajay.app/w/Guidelines#Category_breakdown" target="_blank">
+        SponsorBlock category breakdown
+      </.subtle_link>
+      for a description of each one.
+    </p>
 
-      <section x-show="sponsorblockBehaviour !== 'disabled'" x-transition>
-        <.input
-          field={f[:sponsorblock_categories]}
-          options={frieldly_sponsorblock_categories()}
-          type="checkbox_group"
-          label="SponsorBlock Categories"
-        />
-      </section>
-    </section>
+    <.input
+      field={f[:sponsorblock_remove_categories]}
+      options={friendly_sponsorblock_categories()}
+      type="checkbox_group"
+      label="Remove These Segments"
+      help="Segments in these categories are cut out of the downloaded file entirely"
+    />
+
+    <.input
+      field={f[:sponsorblock_mark_categories]}
+      options={friendly_sponsorblock_categories()}
+      type="checkbox_group"
+      label="Mark These Segments as Chapters"
+      help="Segments in these categories are kept but marked as chapters so your player can skip them. A category can't also be selected for removal above. Leave everything unchecked to disable SponsorBlock"
+    />
+
     <.button class="my-10 w-full sm:mb-7.5 sm:w-auto" rounding="rounded-m3-sm">Save Media profile</.button>
   </section>
 

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_html/media_profile_form.html.heex
@@ -231,6 +231,16 @@
       />
     </section>
 
+    <section x-data="{ presets: { default: false, media_center: false, audio: false, archiving: false } }">
+      <.input
+        field={f[:ignore_youtube_super_resolution]}
+        type="toggle"
+        label="Ignore YouTube Super Resolution"
+        help="Excludes YouTube's AI-upscaled video formats and downloads the best available non-AI-upscaled format instead"
+        x-init="$watch('selectedPreset', p => p && (enabled = presets[p]))"
+      />
+    </section>
+
     <section x-show="advancedMode">
       <.input
         field={f[:media_container]}

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -8,7 +8,21 @@
 >
   <.error :if={@changeset.action}>Oops, something went wrong! Please check the errors below.</.error>
 
-  <section x-data="{ mediaProfileId: null }">
+  <section x-data={
+    """
+    {
+      mediaProfileId: null,
+      sourceUrl: '',
+      cutoffDate: '#{f[:download_cutoff_date].value}',
+      indexCutoffDate: '#{f[:index_cutoff_date].value}',
+      isPlaylist: #{Ecto.Changeset.get_field(@changeset, :collection_type) == :playlist},
+      get looksLikePlaylist() { return this.isPlaylist || /[?&]list=|\\/playlist/.test(this.sourceUrl) },
+      get indexCutoffAfterDownloadCutoff() {
+        return !!(this.indexCutoffDate && this.cutoffDate && this.indexCutoffDate > this.cutoffDate)
+      }
+    }
+    """
+  }>
     <section class="flex justify-between items-center mt-4">
       <h3 class="text-2xl text-theme-on-surface">General Options</h3>
 
@@ -43,6 +57,7 @@
       label="Source URL"
       help="URL of a channel, playlist, or single video (required). Single video sources are indexed once and fast indexing is disabled automatically"
       x-init="$el.focus()"
+      x-model.fill="sourceUrl"
     />
     <.input
       field={f[:custom_name]}
@@ -86,7 +101,32 @@
       </div>
     </section>
 
-    <h3 class="mt-8 text-2xl text-theme-on-surface">Downloading Options</h3>
+    <.input
+      field={f[:index_cutoff_date]}
+      type="text"
+      label="Indexing Cutoff Date"
+      placeholder="YYYY-MM-DD"
+      maxlength="10"
+      pattern="((?:19|20)[0-9][0-9])-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])"
+      title="YYYY-MM-DD"
+      help="Stop indexing a channel once it reaches videos uploaded before this date — big time-saver for channels with a large back catalog. Set it a few days <em>before</em> the Download Cutoff Date for safety. Only applies to YouTube channels; ignored for playlists. A few videos from before this date may still be indexed (but not downloaded) — especially on channels with few videos or when Fast Indexing is enabled, since those checks look at the most recent videos regardless of date. Leave blank to index everything"
+      html_help={true}
+      x-model="indexCutoffDate"
+      x-bind:disabled="looksLikePlaylist"
+    />
+    <p x-cloak x-show="looksLikePlaylist" class="mt-1 text-sm text-theme-warning">
+      The Indexing Cutoff Date doesn't apply to playlists — they aren't ordered by upload date, so
+      indexing can't safely stop early.
+    </p>
+    <p x-cloak x-show="indexCutoffAfterDownloadCutoff" class="mt-1 text-sm text-theme-warning">
+      The Indexing Cutoff Date is after the Download Cutoff Date — media between the two dates would
+      never be indexed, so it could never be downloaded. Set it on or before the Download Cutoff
+      Date.
+    </p>
+
+    <h3 class="mt-8 text-2xl text-theme-on-surface">
+      Downloading Options
+    </h3>
 
     <.input
       field={f[:download_media]}
@@ -193,7 +233,7 @@
       />
     </section>
 
-    <section x-data={"{ cutoffDate: '#{f[:download_cutoff_date].value}' }"}>
+    <section>
       <.input
         field={f[:download_cutoff_date]}
         type="text"

--- a/priv/repo/migrations/20260717140000_add_ignore_youtube_super_resolution_to_media_profiles.exs
+++ b/priv/repo/migrations/20260717140000_add_ignore_youtube_super_resolution_to_media_profiles.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddIgnoreYoutubeSuperResolutionToMediaProfiles do
+  use Ecto.Migration
+
+  def change do
+    alter table(:media_profiles) do
+      add :ignore_youtube_super_resolution, :boolean, default: false, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260717150000_add_index_cutoff_date_to_sources.exs
+++ b/priv/repo/migrations/20260717150000_add_index_cutoff_date_to_sources.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddIndexCutoffDateToSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add :index_cutoff_date, :date
+    end
+  end
+end

--- a/priv/repo/migrations/20260718120000_split_sponsorblock_categories_by_action.exs
+++ b/priv/repo/migrations/20260718120000_split_sponsorblock_categories_by_action.exs
@@ -1,0 +1,52 @@
+defmodule Pinchflat.Repo.Migrations.SplitSponsorblockCategoriesByAction do
+  use Ecto.Migration
+
+  def up do
+    alter table(:media_profiles) do
+      add :sponsorblock_mark_categories, {:array, :string}, default: []
+      add :sponsorblock_remove_categories, {:array, :string}, default: []
+    end
+
+    execute """
+    UPDATE media_profiles
+    SET sponsorblock_mark_categories = sponsorblock_categories
+    WHERE sponsorblock_behaviour = 'mark' AND sponsorblock_categories IS NOT NULL
+    """
+
+    execute """
+    UPDATE media_profiles
+    SET sponsorblock_remove_categories = sponsorblock_categories
+    WHERE sponsorblock_behaviour = 'remove' AND sponsorblock_categories IS NOT NULL
+    """
+
+    alter table(:media_profiles) do
+      remove :sponsorblock_behaviour
+      remove :sponsorblock_categories
+    end
+  end
+
+  def down do
+    alter table(:media_profiles) do
+      add :sponsorblock_behaviour, :string, default: "disabled"
+      add :sponsorblock_categories, {:array, :string}, default: []
+    end
+
+    # Remove takes precedence over mark when collapsing back to a single behaviour
+    execute """
+    UPDATE media_profiles
+    SET sponsorblock_behaviour = 'mark', sponsorblock_categories = sponsorblock_mark_categories
+    WHERE json_array_length(sponsorblock_mark_categories) > 0
+    """
+
+    execute """
+    UPDATE media_profiles
+    SET sponsorblock_behaviour = 'remove', sponsorblock_categories = sponsorblock_remove_categories
+    WHERE json_array_length(sponsorblock_remove_categories) > 0
+    """
+
+    alter table(:media_profiles) do
+      remove :sponsorblock_mark_categories
+      remove :sponsorblock_remove_categories
+    end
+  end
+end

--- a/test/pinchflat/boot/post_job_startup_tasks_test.exs
+++ b/test/pinchflat/boot/post_job_startup_tasks_test.exs
@@ -1,0 +1,97 @@
+defmodule Pinchflat.Boot.PostJobStartupTasksTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.SourcesFixtures
+
+  alias Pinchflat.Boot.PostJobStartupTasks
+  alias Pinchflat.FastIndexing.FastIndexingWorker
+  alias Pinchflat.SlowIndexing.MediaCollectionIndexingWorker
+
+  describe "reschedule_missing_indexing_tasks (slow indexing)" do
+    test "schedules an indexing job for a source that has none" do
+      source = source_fixture()
+
+      assert [] = all_enqueued(worker: MediaCollectionIndexingWorker)
+
+      PostJobStartupTasks.init(%{})
+
+      assert [job] = all_enqueued(worker: MediaCollectionIndexingWorker)
+      assert job.args["id"] == source.id
+    end
+
+    test "does not schedule a duplicate job if one already exists" do
+      source = source_fixture()
+      MediaCollectionIndexingWorker.kickoff_with_task(source)
+
+      assert [_] = all_enqueued(worker: MediaCollectionIndexingWorker)
+
+      PostJobStartupTasks.init(%{})
+
+      assert [_] = all_enqueued(worker: MediaCollectionIndexingWorker)
+    end
+
+    test "does not schedule a job for disabled sources" do
+      source_fixture(enabled: false)
+
+      PostJobStartupTasks.init(%{})
+
+      assert [] = all_enqueued(worker: MediaCollectionIndexingWorker)
+    end
+
+    test "does not schedule a job for sources marked for deletion" do
+      source_fixture(marked_for_deletion_at: DateTime.utc_now())
+
+      PostJobStartupTasks.init(%{})
+
+      assert [] = all_enqueued(worker: MediaCollectionIndexingWorker)
+    end
+
+    test "does not schedule a job for sources that don't index" do
+      source_fixture(index_frequency_minutes: 0)
+
+      PostJobStartupTasks.init(%{})
+
+      assert [] = all_enqueued(worker: MediaCollectionIndexingWorker)
+    end
+  end
+
+  describe "reschedule_missing_indexing_tasks (fast indexing)" do
+    test "schedules a fast indexing job for a fast-index source that has none" do
+      source = source_fixture(fast_index: true)
+
+      assert [] = all_enqueued(worker: FastIndexingWorker)
+
+      PostJobStartupTasks.init(%{})
+
+      assert [job] = all_enqueued(worker: FastIndexingWorker)
+      assert job.args["id"] == source.id
+    end
+
+    test "does not schedule a duplicate job if one already exists" do
+      source = source_fixture(fast_index: true)
+      FastIndexingWorker.kickoff_with_task(source)
+
+      assert [_] = all_enqueued(worker: FastIndexingWorker)
+
+      PostJobStartupTasks.init(%{})
+
+      assert [_] = all_enqueued(worker: FastIndexingWorker)
+    end
+
+    test "does not schedule a job for sources without fast indexing" do
+      source_fixture(fast_index: false)
+
+      PostJobStartupTasks.init(%{})
+
+      assert [] = all_enqueued(worker: FastIndexingWorker)
+    end
+
+    test "does not schedule a job for disabled sources" do
+      source_fixture(fast_index: true, enabled: false)
+
+      PostJobStartupTasks.init(%{})
+
+      assert [] = all_enqueued(worker: FastIndexingWorker)
+    end
+  end
+end

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -278,45 +278,46 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
     test "includes :sponsorblock_remove option when specified", %{media_item: media_item} do
       media_item =
         update_media_profile_attribute(media_item, %{
-          sponsorblock_behaviour: :remove,
-          sponsorblock_categories: ["sponsor", "intro"]
+          sponsorblock_remove_categories: ["sponsor", "intro"]
         })
 
       assert {:ok, res} = DownloadOptionBuilder.build(media_item)
 
       assert {:sponsorblock_remove, "sponsor,intro"} in res
+      refute Keyword.has_key?(res, :sponsorblock_mark)
     end
 
     test "includes :sponsorblock_mark option when specified", %{media_item: media_item} do
       media_item =
         update_media_profile_attribute(media_item, %{
-          sponsorblock_behaviour: :mark,
-          sponsorblock_categories: ["sponsor", "intro"]
+          sponsorblock_mark_categories: ["sponsor", "intro"]
         })
 
       assert {:ok, res} = DownloadOptionBuilder.build(media_item)
 
       assert {:sponsorblock_mark, "sponsor,intro"} in res
+      refute Keyword.has_key?(res, :sponsorblock_remove)
     end
 
-    test "does not include any sponsorblock option without categories", %{media_item: media_item} do
+    test "includes both options when different categories use different actions", %{media_item: media_item} do
       media_item =
         update_media_profile_attribute(media_item, %{
-          sponsorblock_behaviour: :remove,
-          sponsorblock_categories: []
+          sponsorblock_remove_categories: ["sponsor", "selfpromo"],
+          sponsorblock_mark_categories: ["intro", "outro"]
         })
 
       assert {:ok, res} = DownloadOptionBuilder.build(media_item)
 
-      refute Keyword.has_key?(res, :sponsorblock_remove)
-      refute Keyword.has_key?(res, :sponsorblock_mark)
-      refute :sponsorblock_remove in res
-      refute :sponsorblock_mark in res
+      assert {:sponsorblock_remove, "sponsor,selfpromo"} in res
+      assert {:sponsorblock_mark, "intro,outro"} in res
     end
 
-    test "does not include any sponsorblock options when disabled", %{media_item: media_item} do
+    test "does not include any sponsorblock options without categories", %{media_item: media_item} do
       media_item =
-        update_media_profile_attribute(media_item, %{sponsorblock_behaviour: :disabled})
+        update_media_profile_attribute(media_item, %{
+          sponsorblock_remove_categories: [],
+          sponsorblock_mark_categories: []
+        })
 
       assert {:ok, res} = DownloadOptionBuilder.build(media_item)
 

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -166,15 +166,15 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
       assert :write_thumbnail in res
     end
 
-    test "appends -thumb to the thumbnail name when download_thumbnail is true", %{media_item: media_item} do
+    test "matches the thumbnail name to the media name when download_thumbnail is true", %{media_item: media_item} do
       media_item = update_media_profile_attribute(media_item, %{download_thumbnail: true})
 
       assert {:ok, res} = DownloadOptionBuilder.build(media_item)
 
-      assert {:output, "thumbnail:/tmp/test/media/%(title)S-thumb.%(ext)s"} in res
+      assert {:output, "thumbnail:/tmp/test/media/%(title)S.%(ext)s"} in res
     end
 
-    test "appends -thumb to source's output path override, if present", %{media_item: media_item} do
+    test "matches the thumbnail name to the source's output path override, if present", %{media_item: media_item} do
       media_item = update_media_profile_attribute(media_item, %{download_thumbnail: true})
       {:ok, _} = Sources.update_source(media_item.source, %{output_path_template_override: "override.%(ext)s"})
 
@@ -185,7 +185,7 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
 
       assert {:ok, res} = DownloadOptionBuilder.build(media_item)
 
-      assert {:output, "thumbnail:/tmp/test/media/override-thumb.%(ext)s"} in res
+      assert {:output, "thumbnail:/tmp/test/media/override.%(ext)s"} in res
     end
 
     test "converts thumbnail to jpg when download_thumbnail is true", %{media_item: media_item} do

--- a/test/pinchflat/downloading/media_downloader_test.exs
+++ b/test/pinchflat/downloading/media_downloader_test.exs
@@ -450,9 +450,6 @@ defmodule Pinchflat.Downloading.MediaDownloaderTest do
             metadata["thumbnails"]
             |> Enum.reverse()
             |> Enum.find_value(fn attrs -> attrs["filepath"] end)
-            |> String.split(~r{\.}, include_captures: true)
-            |> List.insert_at(-3, "-thumb")
-            |> Enum.join()
 
           :ok = File.cp(thumbnail_filepath_fixture(), thumbnail_filepath)
 

--- a/test/pinchflat/downloading/quality_option_builder_test.exs
+++ b/test/pinchflat/downloading/quality_option_builder_test.exs
@@ -30,6 +30,22 @@ defmodule Pinchflat.Downloading.QualityOptionBuilderTest do
 
       assert {:format, "bestvideo+bestaudio[language^=en]/bestvideo*+bestaudio/best"} in res
     end
+
+    test "excludes AI-upscaled formats from video and fallback selectors" do
+      media_profile =
+        media_profile_fixture(%{
+          audio_track: "original",
+          ignore_youtube_super_resolution: true
+        })
+
+      assert res = QualityOptionBuilder.build(media_profile)
+
+      filter = "[format_note!*=?AI-upscaled]"
+
+      assert {:format,
+              "bestvideo#{filter}+bestaudio[format_note*=original]#{filter}/" <>
+                "bestvideo*#{filter}+bestaudio#{filter}/best#{filter}"} in res
+    end
   end
 
   describe "build/1 when testing audio profiles" do
@@ -59,6 +75,30 @@ defmodule Pinchflat.Downloading.QualityOptionBuilderTest do
       assert res = QualityOptionBuilder.build(media_profile)
 
       assert {:format, "bestaudio/best"} in res
+    end
+
+    test "excludes AI-upscaled formats from audio selectors", %{media_profile: media_profile} do
+      {:ok, media_profile} =
+        Profiles.update_media_profile(media_profile, %{ignore_youtube_super_resolution: true})
+
+      assert res = QualityOptionBuilder.build(media_profile)
+
+      filter = "[format_note!*=?AI-upscaled]"
+      assert {:format, "bestaudio#{filter}/best#{filter}"} in res
+    end
+
+    test "combines the AI-upscaled filter with an audio track preference", %{media_profile: media_profile} do
+      {:ok, media_profile} =
+        Profiles.update_media_profile(media_profile, %{
+          audio_track: "original",
+          ignore_youtube_super_resolution: true
+        })
+
+      assert res = QualityOptionBuilder.build(media_profile)
+
+      filter = "[format_note!*=?AI-upscaled]"
+
+      assert {:format, "bestaudio[format_note*=original]#{filter}/bestaudio#{filter}/best#{filter}"} in res
     end
   end
 
@@ -104,6 +144,16 @@ defmodule Pinchflat.Downloading.QualityOptionBuilderTest do
       assert res = QualityOptionBuilder.build(media_profile)
 
       assert {:format, "bestvideo*+bestaudio/best"} in res
+    end
+
+    test "excludes AI-upscaled formats from video selectors", %{media_profile: media_profile} do
+      {:ok, media_profile} =
+        Profiles.update_media_profile(media_profile, %{ignore_youtube_super_resolution: true})
+
+      assert res = QualityOptionBuilder.build(media_profile)
+
+      filter = "[format_note!*=?AI-upscaled]"
+      assert {:format, "bestvideo*#{filter}+bestaudio#{filter}/best#{filter}"} in res
     end
   end
 end

--- a/test/pinchflat/metadata/metadata_parser_test.exs
+++ b/test/pinchflat/metadata/metadata_parser_test.exs
@@ -109,9 +109,6 @@ defmodule Pinchflat.Metadata.MetadataParserTest do
         metadata["thumbnails"]
         |> Enum.reverse()
         |> Enum.find_value(fn attrs -> attrs["filepath"] end)
-        |> String.split(~r{\.}, include_captures: true)
-        |> List.insert_at(-3, "-thumb")
-        |> Enum.join()
 
       :ok = File.cp(thumbnail_filepath_fixture(), thumbnail_filepath)
 
@@ -124,15 +121,6 @@ defmodule Pinchflat.Metadata.MetadataParserTest do
       result = Parser.parse_for_media_item(metadata)
 
       assert String.ends_with?(result.thumbnail_filepath, ".webp")
-    end
-
-    # NOTE: this can be removed once this bug is fixed
-    # https://github.com/yt-dlp/yt-dlp/issues/9445
-    # and the associated conditional in the parser is removed
-    test "automatically appends `-thumb` to the thumbnail filename", %{metadata: metadata} do
-      result = Parser.parse_for_media_item(metadata)
-
-      assert String.contains?(result.thumbnail_filepath, "-thumb.webp")
     end
 
     test "doesn't include thumbnail if the file doesn't exist on-disk", %{metadata: metadata, filepath: filepath} do

--- a/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
+++ b/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
@@ -55,7 +55,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
 
       source = source_fixture()
 
-      assert {:error, %Jason.DecodeError{data: ""}} =
+      assert {:error, :source_metadata_fetch_failed} =
                perform_job(SourceMetadataStorageWorker, %{id: source.id})
     end
   end

--- a/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
+++ b/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
@@ -74,7 +74,21 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
       assert :ok = perform_job(SourceMetadataStorageWorker, %{id: source.id})
     end
 
-    test "still fails for unavailable media when the setting is disabled" do
+    test "completes without crashing when the details fetch also hits unavailable media" do
+      Settings.set(ignore_unavailable_media: true)
+
+      stub(YtDlpRunnerMock, :run, fn
+        _url, :get_source_details, _opts, _ot, _addl -> {:error, @members_only_error, 1}
+        _url, :get_source_metadata, _opts, _ot, _addl -> {:error, @members_only_error, 1}
+      end)
+
+      source = source_fixture(%{series_directory: nil})
+
+      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+      refute Repo.reload(source).series_directory
+    end
+
+    test "fails cleanly (no crash) for unavailable media when the setting is disabled" do
       Settings.set(ignore_unavailable_media: false)
 
       stub(YtDlpRunnerMock, :run, fn
@@ -84,10 +98,10 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
 
       source = source_fixture()
 
-      assert {:error, _} = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+      assert {:error, :source_metadata_fetch_failed} = perform_job(SourceMetadataStorageWorker, %{id: source.id})
     end
 
-    test "still fails for unrelated errors even when the setting is enabled" do
+    test "fails cleanly (no crash) for unrelated errors even when the setting is enabled" do
       Settings.set(ignore_unavailable_media: true)
 
       stub(YtDlpRunnerMock, :run, fn
@@ -97,7 +111,44 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
 
       source = source_fixture()
 
-      assert {:error, _} = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+      assert {:error, :source_metadata_fetch_failed} = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+    end
+  end
+
+  describe "perform/1 when yt-dlp returns an unparseable response" do
+    test "fails cleanly (no crash) when the source metadata response can't be decoded" do
+      stub(YtDlpRunnerMock, :run, fn
+        _url, :get_source_details, _opts, _ot, _addl -> {:ok, source_details_return_fixture()}
+        # An empty/truncated response - eg. after a yt-dlp behaviour change - fails to decode
+        _url, :get_source_metadata, _opts, _ot, _addl -> {:ok, ""}
+      end)
+
+      source = source_fixture()
+
+      assert {:error, :source_metadata_fetch_failed} = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+    end
+
+    test "fails cleanly (no crash) when the source details response can't be decoded" do
+      stub(YtDlpRunnerMock, :run, fn
+        _url, :get_source_details, _opts, _ot, _addl -> {:ok, ""}
+        _url, :get_source_metadata, _opts, _ot, _addl -> {:ok, "{}"}
+      end)
+
+      source = source_fixture()
+
+      assert {:error, :source_metadata_fetch_failed} = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+    end
+
+    test "completes (with no series directory) when the details response is valid JSON missing the filename" do
+      stub(YtDlpRunnerMock, :run, fn
+        _url, :get_source_details, _opts, _ot, _addl -> {:ok, "{}"}
+        _url, :get_source_metadata, _opts, _ot, _addl -> {:ok, "{}"}
+      end)
+
+      source = source_fixture(%{series_directory: nil})
+
+      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+      refute Repo.reload(source).series_directory
     end
   end
 

--- a/test/pinchflat/profiles_test.exs
+++ b/test/pinchflat/profiles_test.exs
@@ -52,6 +52,68 @@ defmodule Pinchflat.ProfilesTest do
     end
   end
 
+  describe "create_media_profile/1 when testing sponsorblock categories" do
+    test "different categories can be marked and removed at the same time" do
+      attrs = %{
+        name: "sponsorblock test",
+        output_path_template: "output.{{ ext }}",
+        sponsorblock_remove_categories: ["sponsor", "selfpromo", "hook"],
+        sponsorblock_mark_categories: ["intro", "outro"]
+      }
+
+      assert {:ok, %MediaProfile{} = media_profile} = Profiles.create_media_profile(attrs)
+      assert media_profile.sponsorblock_remove_categories == ["sponsor", "selfpromo", "hook"]
+      assert media_profile.sponsorblock_mark_categories == ["intro", "outro"]
+    end
+
+    test "a category can't be both marked and removed" do
+      attrs = %{
+        name: "sponsorblock test",
+        output_path_template: "output.{{ ext }}",
+        sponsorblock_remove_categories: ["sponsor", "intro"],
+        sponsorblock_mark_categories: ["intro"]
+      }
+
+      assert {:error, %Ecto.Changeset{} = changeset} = Profiles.create_media_profile(attrs)
+      assert "can't mark and remove the same category: intro" in errors_on(changeset).sponsorblock_mark_categories
+    end
+
+    test "unknown categories are rejected" do
+      attrs = %{
+        name: "sponsorblock test",
+        output_path_template: "output.{{ ext }}",
+        sponsorblock_remove_categories: ["sponsor", "not_a_category"]
+      }
+
+      assert {:error, %Ecto.Changeset{} = changeset} = Profiles.create_media_profile(attrs)
+      assert errors_on(changeset).sponsorblock_remove_categories != []
+    end
+
+    test "empty-string entries from the form's hidden input are discarded" do
+      attrs = %{
+        name: "sponsorblock test",
+        output_path_template: "output.{{ ext }}",
+        sponsorblock_remove_categories: [""],
+        sponsorblock_mark_categories: ["", "intro"]
+      }
+
+      assert {:ok, %MediaProfile{} = media_profile} = Profiles.create_media_profile(attrs)
+      assert media_profile.sponsorblock_remove_categories == []
+      assert media_profile.sponsorblock_mark_categories == ["intro"]
+    end
+
+    test "unchecking every category clears a previously-set list" do
+      media_profile = media_profile_fixture(%{sponsorblock_remove_categories: ["sponsor", "intro"]})
+
+      # A fully-unchecked checkbox group submits only the hidden input's empty string
+      assert {:ok, %MediaProfile{} = media_profile} =
+               Profiles.update_media_profile(media_profile, %{"sponsorblock_remove_categories" => [""]})
+
+      assert media_profile.sponsorblock_remove_categories == []
+      assert Profiles.get_media_profile!(media_profile.id).sponsorblock_remove_categories == []
+    end
+  end
+
   describe "update_media_profile/2" do
     test "updating with valid data updates the media_profile" do
       media_profile = media_profile_fixture()

--- a/test/pinchflat/profiles_test.exs
+++ b/test/pinchflat/profiles_test.exs
@@ -16,6 +16,12 @@ defmodule Pinchflat.ProfilesTest do
 
       assert {:ok, _} = Phoenix.json_library().encode(profile)
     end
+
+    test "does not ignore YouTube Super Resolution by default" do
+      profile = media_profile_fixture()
+
+      refute profile.ignore_youtube_super_resolution
+    end
   end
 
   describe "list_media_profiles/0" do
@@ -60,6 +66,16 @@ defmodule Pinchflat.ProfilesTest do
 
       assert media_profile.name == "some updated name"
       assert media_profile.output_path_template == "new_output_template.{{ ext }}"
+    end
+
+    test "updates the YouTube Super Resolution preference" do
+      media_profile = media_profile_fixture()
+
+      assert {:ok, %MediaProfile{} = media_profile} =
+               Profiles.update_media_profile(media_profile, %{ignore_youtube_super_resolution: true})
+
+      assert media_profile.ignore_youtube_super_resolution
+      assert Profiles.get_media_profile!(media_profile.id).ignore_youtube_super_resolution
     end
 
     test "updating with invalid data returns error changeset" do

--- a/test/pinchflat/slow_indexing/media_collection_indexing_worker_test.exs
+++ b/test/pinchflat/slow_indexing/media_collection_indexing_worker_test.exs
@@ -58,7 +58,7 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
     end
 
     test "indexes the source if it should be indexed" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, ""}
       end)
 
@@ -68,7 +68,7 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
     end
 
     test "indexes the source no matter what if the source has never been indexed before" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, ""}
       end)
 
@@ -78,7 +78,7 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
     end
 
     test "indexes the source no matter what if the 'force' arg is passed" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, ""}
       end)
 
@@ -88,7 +88,7 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
     end
 
     test "doesn't use a download archive if the index has been forced" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         refute :break_on_existing in opts
         refute Keyword.has_key?(opts, :download_archive)
 
@@ -121,7 +121,7 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
     end
 
     test "kicks off a download job for each pending media item" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, source_attributes_return_fixture()}
       end)
 
@@ -168,7 +168,7 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
     end
 
     test "starts a job for any pending media item even if it's from another run" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, source_attributes_return_fixture()}
       end)
 
@@ -180,7 +180,7 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
     end
 
     test "does not kick off a job for media items that could not be saved" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, source_attributes_return_fixture()}
       end)
 
@@ -263,7 +263,7 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
     end
 
     test "creates the basic media_item records" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, source_attributes_return_fixture()}
       end)
 
@@ -296,7 +296,7 @@ defmodule Pinchflat.SlowIndexing.MediaCollectionIndexingWorkerTest do
     test "sends a notification if new media was found" do
       source = source_fixture()
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
         {:ok, source_attributes_return_fixture()}
       end)
 

--- a/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
+++ b/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
@@ -373,7 +373,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     end
 
     test "passes the source's download options to the yt-dlp runner", %{source: source} do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         assert {:output, "/tmp/test/media/%(title)S.%(ext)S"} in opts
         assert {:remux_video, "mp4"} in opts
         {:ok, source_attributes_return_fixture()}
@@ -385,7 +385,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
 
   describe "index_and_enqueue_download_for_media_items/2 when testing cookies" do
     test "sets use_cookies if the source uses cookies" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         assert {:use_cookies, true} in addl_opts
         {:ok, source_attributes_return_fixture()}
       end)
@@ -396,7 +396,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     end
 
     test "sets use_cookies if the source uses cookies when needed" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         assert {:use_cookies, true} in addl_opts
         {:ok, source_attributes_return_fixture()}
       end)
@@ -407,7 +407,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     end
 
     test "doesn't set use_cookies if the source doesn't use cookies" do
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
         assert {:use_cookies, false} in addl_opts
         {:ok, source_attributes_return_fixture()}
       end)
@@ -584,7 +584,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "a download archive is used if the source is a channel that has been indexed before" do
       source = source_fixture(%{collection_type: :channel, last_indexed_at: now()})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         assert :break_on_existing in opts
         assert Keyword.has_key?(opts, :download_archive)
 
@@ -610,7 +610,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "a download archive is not used if the source has never been indexed before" do
       source = source_fixture(%{collection_type: :channel, last_indexed_at: nil})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         refute :break_on_existing in opts
         refute Keyword.has_key?(opts, :download_archive)
 
@@ -623,7 +623,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "a download archive is not used if the index has been forced to run" do
       source = source_fixture(%{collection_type: :channel})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         refute :break_on_existing in opts
         refute Keyword.has_key?(opts, :download_archive)
 
@@ -642,11 +642,54 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
           media_item_fixture(%{source_id: source.id, uploaded_at: now_minus(n, :days)})
         end)
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         archive_file = Keyword.get(opts, :download_archive)
         last_media_item = List.last(media_items)
 
-        assert File.read!(archive_file) == "youtube #{last_media_item.media_id}"
+        if String.ends_with?(url, "/videos") do
+          assert File.read!(archive_file) == "youtube #{last_media_item.media_id}"
+        else
+          # The seeded media items are all regular videos, so the shorts and
+          # streams archives have nothing to hold
+          assert File.read!(archive_file) == ""
+        end
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
+
+    test "each tab's download archive only contains media of that tab's content type" do
+      source = source_fixture(%{collection_type: :channel, last_indexed_at: now()})
+
+      [oldest_video, oldest_short, oldest_stream] =
+        Enum.map(
+          [
+            %{short_form_content: false, livestream: false},
+            %{short_form_content: true, livestream: false},
+            %{short_form_content: false, livestream: true}
+          ],
+          fn content_attrs ->
+            1..21
+            |> Enum.map(fn n ->
+              media_item_fixture(Map.merge(content_attrs, %{source_id: source.id, uploaded_at: now_minus(n, :days)}))
+            end)
+            |> List.last()
+          end
+        )
+
+      expect(YtDlpRunnerMock, :run, 3, fn url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+        archive_contents = opts |> Keyword.get(:download_archive) |> File.read!()
+
+        expected_media_item =
+          case Regex.run(~r{/(videos|shorts|streams)$}, url) do
+            [_, "videos"] -> oldest_video
+            [_, "shorts"] -> oldest_short
+            [_, "streams"] -> oldest_stream
+          end
+
+        assert archive_contents == "youtube #{expected_media_item.media_id}"
 
         {:ok, source_attributes_return_fixture()}
       end)
@@ -655,12 +698,183 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     end
   end
 
+  describe "index_and_enqueue_download_for_media_items/2 when splitting channels into tabs" do
+    test "indexes a channel's videos, shorts, and streams tabs separately" do
+      source = source_fixture(%{collection_type: :channel})
+      base_url = "https://www.youtube.com/channel/#{source.collection_id}"
+
+      expect(YtDlpRunnerMock, :run, 3, fn url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        send(self(), {:indexed_url, url})
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+
+      assert_received {:indexed_url, url_1}
+      assert_received {:indexed_url, url_2}
+      assert_received {:indexed_url, url_3}
+
+      assert [url_1, url_2, url_3] == Enum.map(~w(videos shorts streams), fn tab -> "#{base_url}/#{tab}" end)
+    end
+
+    test "doesn't return duplicate media items if multiple tabs return the same media" do
+      source = source_fixture(%{collection_type: :channel})
+
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      assert media_items = SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+      assert Enum.count(media_items) == 3
+    end
+
+    test "uses the source's URL as-is if it already points at a specific tab" do
+      source = source_fixture(%{collection_type: :channel, original_url: "https://www.youtube.com/@foo/videos"})
+
+      expect(YtDlpRunnerMock, :run, fn url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        assert url == "https://www.youtube.com/@foo/videos"
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
+
+    test "the archive for an explicit tab URL is filtered to that tab's content type" do
+      source =
+        source_fixture(%{
+          collection_type: :channel,
+          last_indexed_at: now(),
+          original_url: "https://www.youtube.com/@foo/shorts"
+        })
+
+      oldest_short =
+        1..21
+        |> Enum.map(fn n ->
+          media_item_fixture(%{source_id: source.id, short_form_content: true, uploaded_at: now_minus(n, :days)})
+        end)
+        |> List.last()
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+        archive_contents = opts |> Keyword.get(:download_archive) |> File.read!()
+
+        assert archive_contents == "youtube #{oldest_short.media_id}"
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
+
+    test "doesn't split non-YouTube channels into tabs" do
+      source = source_fixture(%{collection_type: :channel, original_url: "https://example.com/some-channel"})
+
+      expect(YtDlpRunnerMock, :run, fn url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        assert url == "https://example.com/some-channel"
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
+
+    test "doesn't split playlists into tabs" do
+      source = source_fixture(%{collection_type: :playlist})
+
+      expect(YtDlpRunnerMock, :run, fn url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        assert url == source.original_url
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
+
+    test "still indexes the other tabs if one tab fails" do
+      source = source_fixture(%{collection_type: :channel})
+
+      expect(YtDlpRunnerMock, :run, 3, fn url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        if String.ends_with?(url, "/shorts") do
+          {:error, "This channel does not have a shorts tab", 1}
+        else
+          {:ok, source_attributes_return_fixture()}
+        end
+      end)
+
+      assert media_items = SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+      assert Enum.count(media_items) == 3
+    end
+
+    test "fails the indexing run if every tab fails" do
+      source = source_fixture(%{collection_type: :channel})
+
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        {:error, "Something went wrong", 1}
+      end)
+
+      assert_raise MatchError, fn ->
+        SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+      end
+    end
+  end
+
+  describe "index_and_enqueue_download_for_media_items/2 when logging tab failures" do
+    setup do
+      # The test env logger level suppresses everything below :critical,
+      # so it needs to be loosened for log output to be capturable
+      original_level = Logger.level()
+      Logger.configure(level: :debug)
+      on_exit(fn -> Logger.configure(level: original_level) end)
+    end
+
+    test "a channel missing a tab is not logged as a failure" do
+      source = source_fixture(%{collection_type: :channel})
+
+      expect(YtDlpRunnerMock, :run, 3, fn url, :get_media_attributes_for_collection, _opts, _ot, addl_opts ->
+        assert {:expected_exit_codes, [1]} in addl_opts
+
+        if String.ends_with?(url, "/streams") do
+          {:error, "ERROR: [youtube:tab] UC123: This channel does not have a streams tab", 1}
+        else
+          {:ok, source_attributes_return_fixture()}
+        end
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log([level: :warning], fn ->
+          SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+        end)
+
+      refute log =~ "Indexing failed"
+    end
+
+    test "other tab failures are logged as warnings" do
+      source = source_fixture(%{collection_type: :channel})
+
+      expect(YtDlpRunnerMock, :run, 3, fn url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        if String.ends_with?(url, "/streams") do
+          {:error, "Something went wrong", 1}
+        else
+          {:ok, source_attributes_return_fixture()}
+        end
+      end)
+
+      log =
+        ExUnit.CaptureLog.capture_log([level: :warning], fn ->
+          SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+        end)
+
+      assert log =~ "Indexing failed"
+    end
+  end
+
   describe "index_and_enqueue_download_for_media_items when testing dateafter options" do
     test "uses dateafter when download_cutoff_date is set" do
       cutoff_date = Date.utc_today() |> Date.add(-10)
       source = source_fixture(%{download_cutoff_date: cutoff_date})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         expected_dateafter = Date.to_iso8601(cutoff_date, :basic)
         assert {:dateafter, ^expected_dateafter} = Enum.find(opts, fn opt -> match?({:dateafter, _}, opt) end)
 
@@ -676,7 +890,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
       # Retention of 5 days means we only need to scan ~8 days (5 + 3 buffer)
       source = source_fixture(%{download_cutoff_date: old_cutoff, retention_period_days: 5})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         {:dateafter, dateafter_value} = Enum.find(opts, fn opt -> match?({:dateafter, _}, opt) end)
 
         # Should be retention + buffer days ago (5 + 3 = 8 days ago)
@@ -696,7 +910,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
       # Retention of 30 days would mean scanning 33 days (30 + 3 buffer)
       source = source_fixture(%{download_cutoff_date: recent_cutoff, retention_period_days: 30})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         expected_dateafter = Date.to_iso8601(recent_cutoff, :basic)
         assert {:dateafter, ^expected_dateafter} = Enum.find(opts, fn opt -> match?({:dateafter, _}, opt) end)
 
@@ -709,7 +923,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "does not use dateafter when neither cutoff nor retention is set" do
       source = source_fixture(%{download_cutoff_date: nil, retention_period_days: nil})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         refute Keyword.has_key?(opts, :dateafter)
 
         {:ok, source_attributes_return_fixture()}
@@ -721,7 +935,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "does not use dateafter when retention is 0 (keep forever) and no cutoff" do
       source = source_fixture(%{download_cutoff_date: nil, retention_period_days: 0})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         refute Keyword.has_key?(opts, :dateafter)
 
         {:ok, source_attributes_return_fixture()}
@@ -734,7 +948,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
       cutoff_date = Date.utc_today() |> Date.add(-10)
       source = source_fixture(%{download_cutoff_date: cutoff_date, retention_period_days: 0})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         expected_dateafter = Date.to_iso8601(cutoff_date, :basic)
         assert {:dateafter, ^expected_dateafter} = Enum.find(opts, fn opt -> match?({:dateafter, _}, opt) end)
 
@@ -747,7 +961,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     test "uses retention-based date when cutoff is nil but retention is set" do
       source = source_fixture(%{download_cutoff_date: nil, retention_period_days: 7})
 
-      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
         {:dateafter, dateafter_value} = Enum.find(opts, fn opt -> match?({:dateafter, _}, opt) end)
 
         # Should be retention + buffer days ago (7 + 3 = 10 days ago)

--- a/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
+++ b/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
@@ -698,6 +698,84 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
     end
   end
 
+  describe "index_and_enqueue_download_for_media_items when testing the indexing cutoff date" do
+    test "a channel with an indexing cutoff date passes break filters to every tab" do
+      source =
+        source_fixture(%{
+          collection_type: :channel,
+          index_cutoff_date: ~D[2026-07-01]
+        })
+
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+        break_filters = for {:break_match_filters, filter} <- opts, do: filter
+
+        assert break_filters == ["upload_date >= 20260701", "!upload_date"]
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
+
+    test "the cutoff applies even when the index is forced" do
+      source =
+        source_fixture(%{
+          collection_type: :channel,
+          last_indexed_at: now(),
+          index_cutoff_date: ~D[2026-07-01]
+        })
+
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+        assert Keyword.has_key?(opts, :break_match_filters)
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source, was_forced: true)
+    end
+
+    test "the cutoff is not applied when the source has no indexing cutoff date" do
+      source = source_fixture(%{collection_type: :channel, index_cutoff_date: nil})
+
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+        refute Keyword.has_key?(opts, :break_match_filters)
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
+
+    test "the cutoff is not applied to playlists" do
+      source = source_fixture(%{collection_type: :playlist, index_cutoff_date: ~D[2026-07-01]})
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+        refute Keyword.has_key?(opts, :break_match_filters)
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
+
+    test "the cutoff is not applied to non-YouTube channels" do
+      source =
+        source_fixture(%{
+          collection_type: :channel,
+          original_url: "https://example.com/some-channel",
+          index_cutoff_date: ~D[2026-07-01]
+        })
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+        refute Keyword.has_key?(opts, :break_match_filters)
+
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
+  end
+
   describe "index_and_enqueue_download_for_media_items/2 when splitting channels into tabs" do
     test "indexes a channel's videos, shorts, and streams tabs separately" do
       source = source_fixture(%{collection_type: :channel})

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -945,6 +945,46 @@ defmodule Pinchflat.SourcesTest do
       assert {:ok, %Source{}} = Sources.update_source(source, update_attrs)
       refute_enqueued(worker: MediaCollectionIndexingWorker)
     end
+
+    test "widening the index cutoff further into the past forces a re-index" do
+      source = source_fixture(index_cutoff_date: ~D[2026-06-01])
+      update_attrs = %{index_cutoff_date: ~D[2026-01-01]}
+
+      assert {:ok, %Source{}} = Sources.update_source(source, update_attrs)
+      assert_enqueued(worker: MediaCollectionIndexingWorker, args: %{"id" => source.id, "force" => true})
+    end
+
+    test "removing the index cutoff entirely forces a re-index" do
+      source = source_fixture(index_cutoff_date: ~D[2026-06-01])
+      update_attrs = %{index_cutoff_date: nil}
+
+      assert {:ok, %Source{}} = Sources.update_source(source, update_attrs)
+      assert_enqueued(worker: MediaCollectionIndexingWorker, args: %{"id" => source.id, "force" => true})
+    end
+
+    test "narrowing the index cutoff closer to the present will not re-index" do
+      source = source_fixture(index_cutoff_date: ~D[2026-01-01])
+      update_attrs = %{index_cutoff_date: ~D[2026-06-01]}
+
+      assert {:ok, %Source{}} = Sources.update_source(source, update_attrs)
+      refute_enqueued(worker: MediaCollectionIndexingWorker)
+    end
+
+    test "adding a cutoff to a previously unbounded source will not re-index" do
+      source = source_fixture(index_cutoff_date: nil)
+      update_attrs = %{index_cutoff_date: ~D[2026-06-01]}
+
+      assert {:ok, %Source{}} = Sources.update_source(source, update_attrs)
+      refute_enqueued(worker: MediaCollectionIndexingWorker)
+    end
+
+    test "widening the index cutoff will not re-index a disabled source" do
+      source = source_fixture(enabled: false, index_cutoff_date: ~D[2026-06-01])
+      update_attrs = %{index_cutoff_date: ~D[2026-01-01]}
+
+      assert {:ok, %Source{}} = Sources.update_source(source, update_attrs)
+      refute_enqueued(worker: MediaCollectionIndexingWorker)
+    end
   end
 
   describe "update_source/3 when testing fast indexing" do

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -1249,6 +1249,44 @@ defmodule Pinchflat.SourcesTest do
     end
   end
 
+  describe "change_source/3 when testing index cutoff date validation" do
+    test "succeeds if either cutoff date is nil" do
+      source = source_fixture()
+
+      assert %{errors: []} = Sources.change_source(source, %{index_cutoff_date: nil, download_cutoff_date: nil})
+      assert %{errors: []} = Sources.change_source(source, %{index_cutoff_date: ~D[2026-07-01]})
+      assert %{errors: []} = Sources.change_source(source, %{download_cutoff_date: ~D[2026-07-01]})
+    end
+
+    test "succeeds if the index cutoff is on or before the download cutoff" do
+      source = source_fixture()
+
+      assert %{errors: []} =
+               Sources.change_source(source, %{
+                 index_cutoff_date: ~D[2026-06-24],
+                 download_cutoff_date: ~D[2026-07-01]
+               })
+
+      assert %{errors: []} =
+               Sources.change_source(source, %{
+                 index_cutoff_date: ~D[2026-07-01],
+                 download_cutoff_date: ~D[2026-07-01]
+               })
+    end
+
+    test "fails if the index cutoff is after the download cutoff" do
+      source = source_fixture()
+
+      changeset =
+        Sources.change_source(source, %{
+          index_cutoff_date: ~D[2026-07-15],
+          download_cutoff_date: ~D[2026-07-01]
+        })
+
+      assert "must be on or before the download cutoff date" in errors_on(changeset).index_cutoff_date
+    end
+  end
+
   describe "change_source/3 when testing original_url validation" do
     test "succeeds when an original URL is valid" do
       source = source_fixture()

--- a/test/pinchflat/utils/cli_utils_test.exs
+++ b/test/pinchflat/utils/cli_utils_test.exs
@@ -1,6 +1,8 @@
 defmodule Pinchflat.Utils.CliUtilsTest do
   use Pinchflat.DataCase
 
+  import ExUnit.CaptureLog
+
   alias Pinchflat.Utils.CliUtils
 
   describe "wrap_cmd/3" do
@@ -10,6 +12,31 @@ defmodule Pinchflat.Utils.CliUtilsTest do
 
     test "sets the current directory to the tmp dir" do
       assert {"/tmp/test/tmpfiles\n", 0} = CliUtils.wrap_cmd("pwd", [])
+    end
+  end
+
+  describe "wrap_cmd/3 when logging results" do
+    setup do
+      # The test env logger level suppresses everything below :critical,
+      # so it needs to be loosened for log output to be capturable
+      original_level = Logger.level()
+      Logger.configure(level: :debug)
+      on_exit(fn -> Logger.configure(level: original_level) end)
+    end
+
+    test "logs non-zero exits at the error level by default" do
+      log = capture_log([level: :error], fn -> CliUtils.wrap_cmd("false", []) end)
+
+      assert log =~ "exited: 1"
+    end
+
+    test "logs expected exit codes at the debug level instead" do
+      log =
+        capture_log([level: :error], fn ->
+          CliUtils.wrap_cmd("false", [], [], expected_exit_codes: [1])
+        end)
+
+      refute log =~ "exited: 1"
     end
   end
 

--- a/test/pinchflat/yt_dlp/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/media_collection_test.exs
@@ -240,7 +240,8 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
     test "returns an error if the output is not JSON" do
       expect(YtDlpRunnerMock, :run, fn _url, :get_source_metadata, _opts, _ot, _addl_opts -> {:ok, "Not JSON"} end)
 
-      assert {:error, %Jason.DecodeError{}} = MediaCollection.get_source_metadata(@channel_url, playlist_items: 0)
+      assert {:error, "Error decoding JSON response"} =
+               MediaCollection.get_source_metadata(@channel_url, playlist_items: 0)
     end
   end
 end

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -56,6 +56,14 @@ defmodule Pinchflat.YtDlp.MediaTest do
 
       assert {:error, "something"} = Media.download(@media_url)
     end
+
+    test "returns an error if the output is not JSON" do
+      expect(YtDlpRunnerMock, :run, fn _url, :download, _opt, _ot, _addl ->
+        {:ok, "Not JSON"}
+      end)
+
+      assert {:error, "Error decoding JSON response"} = Media.download(@media_url)
+    end
   end
 
   describe "get_downloadable_status/1" do
@@ -123,6 +131,14 @@ defmodule Pinchflat.YtDlp.MediaTest do
       end)
 
       assert {:ok, :downloadable} = Media.get_downloadable_status(@media_url, addl_arg: true)
+    end
+
+    test "returns an error (instead of raising) if the output is not JSON" do
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, _addl ->
+        {:ok, ""}
+      end)
+
+      assert {:error, "Error decoding JSON response"} = Media.get_downloadable_status(@media_url)
     end
   end
 
@@ -210,6 +226,12 @@ defmodule Pinchflat.YtDlp.MediaTest do
       expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl -> {:error, "Big issue", 1} end)
 
       assert {:error, "Big issue", 1} = Media.get_media_attributes(@media_url)
+    end
+
+    test "returns an error (instead of raising) if the output is not JSON" do
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl -> {:ok, ""} end)
+
+      assert {:error, "Error decoding JSON response"} = Media.get_media_attributes(@media_url)
     end
   end
 

--- a/test/pinchflat/yt_dlp/response_decoder_test.exs
+++ b/test/pinchflat/yt_dlp/response_decoder_test.exs
@@ -1,0 +1,28 @@
+defmodule Pinchflat.YtDlp.ResponseDecoderTest do
+  use Pinchflat.DataCase
+
+  alias Pinchflat.YtDlp.ResponseDecoder
+
+  describe "decode/2" do
+    test "returns the parsed JSON for a valid response" do
+      assert {:ok, %{"title" => "test"}} = ResponseDecoder.decode(~s({"title": "test"}), :get_source_metadata)
+    end
+
+    test "returns a clean error tuple for an unparseable response" do
+      assert {:error, "Error decoding JSON response"} = ResponseDecoder.decode("Not JSON", :get_source_metadata)
+      assert {:error, "Error decoding JSON response"} = ResponseDecoder.decode("", :get_source_details)
+    end
+  end
+
+  describe "decode_error?/1" do
+    test "returns true for errors produced by decode/2" do
+      assert ResponseDecoder.decode_error?(ResponseDecoder.decode("", :get_source_details))
+    end
+
+    test "returns false for other errors" do
+      refute ResponseDecoder.decode_error?({:error, "Some other error"})
+      refute ResponseDecoder.decode_error?({:error, "Some runner error", 1})
+      refute ResponseDecoder.decode_error?(:ok)
+    end
+  end
+end

--- a/test/pinchflat_web/controllers/media_profile_controller_test.exs
+++ b/test/pinchflat_web/controllers/media_profile_controller_test.exs
@@ -39,7 +39,11 @@ defmodule PinchflatWeb.MediaProfileControllerTest do
   describe "new media_profile" do
     test "renders form", %{conn: conn} do
       conn = get(conn, ~p"/media_profiles/new")
-      assert html_response(conn, 200) =~ "New Media Profile"
+      html = html_response(conn, 200)
+
+      assert html =~ "New Media Profile"
+      assert html =~ "Ignore YouTube Super Resolution"
+      assert html =~ ~s(name="media_profile[ignore_youtube_super_resolution]")
     end
 
     test "renders correct layout when onboarding", %{conn: conn} do
@@ -111,6 +115,16 @@ defmodule PinchflatWeb.MediaProfileControllerTest do
 
       conn = get(conn, ~p"/media_profiles/#{media_profile}")
       assert html_response(conn, 200) =~ "some updated name"
+    end
+
+    test "persists the YouTube Super Resolution preference", %{conn: conn, media_profile: media_profile} do
+      conn =
+        put(conn, ~p"/media_profiles/#{media_profile}",
+          media_profile: Map.put(@update_attrs, :ignore_youtube_super_resolution, true)
+        )
+
+      assert redirected_to(conn) == ~p"/media_profiles/#{media_profile}"
+      assert Repo.reload!(media_profile).ignore_youtube_super_resolution
     end
 
     test "renders errors when data is invalid", %{conn: conn, media_profile: media_profile} do


### PR DESCRIPTION
### Summary of Changes

- **SponsorBlock Independent Categories**: Replaced single behaviour toggle with independent mark and remove category lists.
- **YouTube AI-Upscaled Format Filter**: Added Media Profile toggle to exclude AI-upscaled formats.
- **Plex-Compatible Episode Thumbnails**: Updated episode thumbnail naming to direct-match video filenames (<basename>.jpg).
- **Per-Tab Channel Indexing**: Channels now index /videos, /shorts, and /streams tabs separately to ensure newly uploaded Shorts are discovered on repeat scans.
- **Source Indexing Cutoff Date**: Added indexing cutoff date setting to sources with automatic forced re-indexing on widened cutoff.
- **Resilient Decoding & Boot Recovery**: Added ResponseDecoder to safely handle invalid yt-dlp outputs and post-boot indexing chain recovery.

### Verification
- Full test suite passed (1309 tests, 0 failures).
- mix check passed (credo, sobelow, format, prettier, compiler).
- UI theme check passed.