### PR TITLE
Batch 3: Database Compaction and File Reconciliation

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,6 +29,11 @@ config :pinchflat,
   expose_feed_endpoints: false,
   file_watcher_poll_interval: 1000,
   db_maintenance_poll_interval: 15_000,
+  # How many media items reconcile applies in parallel. Only matters for the
+  # network-bound online/full backfills (thumbnails/subtitles) — local moves are
+  # instant. Kept low by default (and tied to YT_DLP_WORKER_CONCURRENCY at runtime)
+  # so we don't hammer YouTube and earn a rate-limit/IP ban. Overridden in runtime.exs.
+  reconcile_backfill_concurrency: 2,
   timezone: "UTC",
   base_route_path: "/"
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -16,6 +16,7 @@ config :pinchflat,
   apprise_executable: System.find_executable("apprise"),
   yt_dlp_runner: Pinchflat.YtDlp.CommandRunner,
   apprise_runner: Pinchflat.Lifecycle.Notifications.CommandRunner,
+  disk_space_checker: Pinchflat.Diagnostics.DiskSpaceChecker,
   media_directory: "/downloads",
   # The user may or may not store metadata for their needs, but the app will always store its copy
   metadata_directory: "/config/metadata",
@@ -27,37 +28,18 @@ config :pinchflat,
   basic_auth_password: "",
   expose_feed_endpoints: false,
   file_watcher_poll_interval: 1000,
+  db_maintenance_poll_interval: 15_000,
   timezone: "UTC",
   base_route_path: "/"
 
 config :pinchflat, Pinchflat.Repo,
   journal_mode: :wal,
-  # Explicit (matches exqlite's default): NORMAL is safe under WAL — only a
-  # transaction can be lost on OS/power loss, never corruption — and avoids a
-  # per-write fsync. Pinned here so a future driver-default change can't regress it.
   synchronous: :normal,
-  # BEGIN IMMEDIATE for every transaction. The default DEFERRED mode starts as a
-  # read transaction and upgrades to a write on the first write statement — under
-  # WAL that upgrade fails instantly with SQLITE_BUSY (busy_timeout never runs)
-  # whenever another connection committed since the read snapshot was taken, which
-  # is constant under an active queue (Oban's stager does exactly this
-  # select-then-update shape every second). IMMEDIATE takes the write lock at
-  # BEGIN, so contending writers queue on busy_timeout instead of erroring.
   default_transaction_mode: :immediate,
-  # Explicit (matches ecto_sqlite3's defaults — negative = KiB, so ~64 MB page
-  # cache per connection): keeps the reconcile working set off the disk
-  # and pins us against a future driver-default change.
   cache_size: -64_000,
   temp_store: :memory,
-  # Generous so slow writes on weak hardware (or a database VACUUM) surface as
-  # brief waits instead of "database is locked" errors
   busy_timeout: 30_000,
-  # Must exceed busy_timeout: Ecto's default per-query timeout is 15s, which
-  # would kill a write while it's still legitimately queued on the busy handler
   timeout: 45_000,
-  # Small pools starved the LiveView/other jobs while a reconcile held connections.
-  # WAL lets extra readers run without blocking, so a larger pool is cheap.
-  # Overridable at runtime via DATABASE_POOL_SIZE.
   pool_size: 10
 
 # Configures the endpoint

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -78,7 +78,10 @@ config :pinchflat, Oban,
      crontab: [
        {"#{current_minute} #{current_hour} * * *", Pinchflat.YtDlp.UpdateWorker},
        {"0 1 * * *", Pinchflat.Downloading.MediaRetentionWorker},
-       {"0 2 * * *", Pinchflat.Downloading.MediaQualityUpgradeWorker}
+       {"0 2 * * *", Pinchflat.Downloading.MediaQualityUpgradeWorker},
+       # Monthly, after retention (1AM) and quality upgrades (2AM) have had a
+       # chance to delete records whose space the VACUUM can then reclaim
+       {"0 3 1 * *", Pinchflat.Diagnostics.DatabaseMaintenanceWorker}
      ]}
   ]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -71,7 +71,10 @@ config :pinchflat, Oban,
     media_collection_indexing: yt_dlp_index_worker_count,
     media_fetching: yt_dlp_download_worker_count,
     remote_metadata: yt_dlp_remote_metadata_worker_count,
-    local_data: 8
+    local_data: 8,
+    # Reconciliation and database compaction both reserve a full quiet window.
+    # Serializing them here prevents each from waiting for the other to finish.
+    maintenance: 1
   ],
   plugins: [
     # Keep old jobs for 30 days for display in the UI

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -54,6 +54,10 @@ config :pinchflat, Pinchflat.Repo,
 {yt_dlp_remote_metadata_worker_count, _} =
   Integer.parse(System.get_env("YT_DLP_REMOTE_METADATA_WORKER_CONCURRENCY", Integer.to_string(yt_dlp_worker_count)))
 
+# Reconcile applies network-bound backfills (thumbnails/subtitles) in parallel;
+# tie its ceiling to the same politeness knob as the yt-dlp queues so a big
+# online/full reconcile doesn't hammer YouTube any harder than normal downloads
+config :pinchflat, reconcile_backfill_concurrency: max(yt_dlp_worker_count, 1)
 # Used to set the cron for the yt-dlp update worker. The reason for this is
 # to avoid all instances of PF updating yt-dlp at the same time, which 1)
 # could result in rate limiting and 2) gives me time to react if an update

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,7 +8,8 @@ config :pinchflat,
   metadata_directory: Path.join([System.tmp_dir!(), "test", "metadata"]),
   tmpfile_directory: Path.join([System.tmp_dir!(), "test", "tmpfiles"]),
   extras_directory: Path.join([System.tmp_dir!(), "test", "extras"]),
-  file_watcher_poll_interval: 50
+  file_watcher_poll_interval: 50,
+  db_maintenance_poll_interval: 5
 
 config :pinchflat, Oban, testing: :manual
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,7 +9,10 @@ config :pinchflat,
   tmpfile_directory: Path.join([System.tmp_dir!(), "test", "tmpfiles"]),
   extras_directory: Path.join([System.tmp_dir!(), "test", "extras"]),
   file_watcher_poll_interval: 50,
-  db_maintenance_poll_interval: 5
+  db_maintenance_poll_interval: 5,
+  # Run reconcile apply serially in tests so it stays within the Ecto SQL sandbox
+  # connection (parallel groups run in spawned processes without the sandbox)
+  reconcile_backfill_concurrency: 1
 
 config :pinchflat, Oban, testing: :manual
 

--- a/lib/pinchflat/boot/pre_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/pre_job_startup_tasks.ex
@@ -42,6 +42,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
   def init(state) do
     ensure_tmpfile_directory()
     reset_executing_jobs()
+    revive_stalled_reconcile_jobs()
     create_blank_yt_dlp_files()
     create_blank_user_script_file()
     apply_default_settings()
@@ -68,6 +69,26 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
       |> Repo.update_all(set: [state: "retryable"])
 
     Logger.info("Reset #{count} executing jobs")
+  end
+
+  # ReconcileWorker is `max_attempts: 1`, so an apply/build job that was `executing`
+  # at an ungraceful shutdown gets flipped to `retryable` by reset_executing_jobs/0
+  # above already at its attempt ceiling (`attempt >= max_attempts`). Oban's SQLite
+  # engine only ever fetches `available` jobs with `attempt < max_attempts`, so such
+  # a job is never picked up again — an apply is stranded with its plan stuck
+  # `:applying` forever (which also blocks new plans, since the worker's uniqueness
+  # dedupes against the incomplete job). Hand these a fresh attempt so Oban re-runs
+  # them; both ops are idempotent (a build re-scans read-only, an apply resumes only
+  # the rows the interrupted run didn't reach).
+  defp revive_stalled_reconcile_jobs do
+    {count, _} =
+      Oban.Job
+      |> where(worker: "Pinchflat.Reconciliation.ReconcileWorker")
+      |> where([j], j.state in ["available", "scheduled", "retryable"])
+      |> where([j], j.attempt >= j.max_attempts)
+      |> Repo.update_all(set: [state: "available", attempt: 0, errors: [], scheduled_at: DateTime.utc_now()])
+
+    if count > 0, do: Logger.info("Revived #{count} stalled reconcile job(s)")
   end
 
   defp create_blank_yt_dlp_files do

--- a/lib/pinchflat/diagnostics/database_diagnostics.ex
+++ b/lib/pinchflat/diagnostics/database_diagnostics.ex
@@ -1,0 +1,136 @@
+defmodule Pinchflat.Diagnostics.DatabaseDiagnostics do
+  @moduledoc """
+  Insight into the SQLite database itself: on-disk size (including the WAL/SHM
+  sidecar files), space reclaimable by VACUUM, row counts for key tables, and
+  the status of the most recent database maintenance run.
+
+  Powers the "Database" section of the diagnostics page.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Tasks.Task
+
+  # Sorted roughly by how interesting they are on a diagnostics page
+  @tracked_tables ~w(media_items sources media_profiles tasks oban_jobs)
+
+  @doc """
+  Returns size and page statistics for the database.
+
+  The UI-facing "database size" is the sum of the main file plus the `-wal`
+  and `-shm` sidecars, which is why it reads larger than an `ls` of the main
+  file alone. `reclaimable_bytes` is the freelist (pages left behind by
+  deleted rows) — the space a VACUUM would return to the filesystem.
+
+  Returns map()
+  """
+  def get_database_stats do
+    main_file_bytes = file_size(database_filepath())
+    wal_file_bytes = file_size(database_filepath() <> "-wal")
+    shm_file_bytes = file_size(database_filepath() <> "-shm")
+
+    %{
+      main_file_bytes: main_file_bytes,
+      wal_file_bytes: wal_file_bytes,
+      shm_file_bytes: shm_file_bytes,
+      total_bytes: main_file_bytes + wal_file_bytes + shm_file_bytes,
+      page_size: pragma_number("page_size"),
+      page_count: pragma_number("page_count"),
+      freelist_count: pragma_number("freelist_count"),
+      reclaimable_bytes: pragma_number("freelist_count") * pragma_number("page_size"),
+      journal_mode: to_string(pragma_value("journal_mode"))
+    }
+  end
+
+  @doc """
+  Returns row counts for the tables that dominate database growth.
+
+  Returns [{table_name :: binary(), count :: non_neg_integer()}]
+  """
+  def table_row_counts do
+    Enum.map(@tracked_tables, fn table ->
+      {table, Repo.aggregate(from(t in table), :count)}
+    end)
+  end
+
+  @doc """
+  Counts tasks whose Oban job no longer exists. Should always be zero (the
+  foreign key cascades task deletion when jobs are pruned) — a non-zero value
+  is a canary for records being left behind.
+
+  Returns non_neg_integer()
+  """
+  def orphaned_task_count do
+    from(t in Task,
+      left_join: j in Oban.Job,
+      on: t.job_id == j.id,
+      where: is_nil(j.id)
+    )
+    |> Repo.aggregate(:count)
+  end
+
+  @doc """
+  Returns the most recent `DatabaseMaintenanceWorker` job record (in any
+  state), or nil if none exists. Used to surface the outcome of both manual
+  and scheduled maintenance runs in the UI.
+
+  Returns %Oban.Job{} | nil
+  """
+  def latest_maintenance_job do
+    worker_name = Oban.Worker.to_string(Pinchflat.Diagnostics.DatabaseMaintenanceWorker)
+
+    from(j in Oban.Job,
+      where: j.worker == ^worker_name,
+      order_by: [desc: j.id],
+      limit: 1
+    )
+    |> Repo.one()
+  end
+
+  @doc """
+  Returns the full path to the main database file.
+
+  Returns binary()
+  """
+  def database_filepath do
+    Application.get_env(:pinchflat, Pinchflat.Repo)[:database]
+  end
+
+  @doc """
+  Returns the size of the file at the given path in bytes, or 0 if it
+  doesn't exist.
+
+  Returns non_neg_integer()
+  """
+  def file_size(filepath) do
+    case File.stat(filepath) do
+      {:ok, %{size: size}} -> size
+      _ -> 0
+    end
+  end
+
+  @doc """
+  Formats a byte count as a human-readable binary-unit string.
+
+  Returns binary()
+  """
+  def format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
+  def format_bytes(bytes) when bytes < 1024 * 1024, do: "#{Float.round(bytes / 1024, 1)} KiB"
+  def format_bytes(bytes) when bytes < 1024 * 1024 * 1024, do: "#{Float.round(bytes / 1024 / 1024, 1)} MiB"
+  def format_bytes(bytes), do: "#{Float.round(bytes / 1024 / 1024 / 1024, 2)} GiB"
+
+  defp pragma_number(pragma) do
+    case pragma_value(pragma) do
+      value when is_integer(value) -> value
+      _ -> 0
+    end
+  end
+
+  # Restricted to a known allowlist since PRAGMA names can't be parameterized
+  defp pragma_value(pragma) when pragma in ~w(page_size page_count freelist_count journal_mode) do
+    %{rows: [[value]]} = Repo.query!("PRAGMA #{pragma}")
+
+    value
+  end
+end

--- a/lib/pinchflat/diagnostics/database_diagnostics.ex
+++ b/lib/pinchflat/diagnostics/database_diagnostics.ex
@@ -1,8 +1,9 @@
 defmodule Pinchflat.Diagnostics.DatabaseDiagnostics do
   @moduledoc """
   Insight into the SQLite database itself: on-disk size (including the WAL/SHM
-  sidecar files), space reclaimable by VACUUM, row counts for key tables, and
-  the status of the most recent database maintenance run.
+  sidecar files), space reclaimable by VACUUM, row counts for key tables, the
+  results of integrity checks, and the status of the most recent database
+  maintenance run.
 
   Powers the "Database" section of the diagnostics page.
   """
@@ -14,6 +15,10 @@ defmodule Pinchflat.Diagnostics.DatabaseDiagnostics do
 
   # Sorted roughly by how interesting they are on a diagnostics page
   @tracked_tables ~w(media_items sources media_profiles tasks oban_jobs)
+
+  # An integrity check reads every page of the database, which on weak hardware
+  # with a large database is minutes rather than seconds
+  @integrity_check_timeout :timer.minutes(30)
 
   @doc """
   Returns size and page statistics for the database.
@@ -71,6 +76,38 @@ defmodule Pinchflat.Diagnostics.DatabaseDiagnostics do
   end
 
   @doc """
+  Runs a SQLite integrity check and returns whatever problems it reports.
+
+  `:quick` runs `PRAGMA quick_check`, which verifies page structure but skips
+  the expensive cross-check of every index entry against its table. `:full`
+  runs `PRAGMA integrity_check`, which does that cross-check too and is
+  correspondingly slower.
+
+  Both are read-only and take only a read transaction, so in WAL mode they
+  never block writers — the cost is disk I/O, not contention. Both also call
+  each virtual table's `xIntegrity` method, so they report FTS5 corruption
+  (eg: "malformed inverted index for FTS5 table main.media_items_search_index")
+  alongside ordinary b-tree damage.
+
+  Findings are returned verbatim: SQLite's wording is what a user needs in
+  order to work out which table is damaged and how to repair it. An empty list
+  means the database is healthy — SQLite reports a single "ok" row in that
+  case, which is filtered out. Nothing here repairs anything.
+
+  Returns {:ok, [binary()]} | {:error, binary()}
+  """
+  def run_integrity_check(mode) when mode in [:quick, :full] do
+    pragma = if mode == :quick, do: "quick_check", else: "integrity_check"
+
+    case Repo.query("PRAGMA #{pragma}", [], timeout: @integrity_check_timeout) do
+      {:ok, %{rows: rows}} -> {:ok, extract_findings(rows)}
+      {:error, error} -> {:error, Exception.message(error)}
+    end
+  rescue
+    error -> {:error, Exception.message(error)}
+  end
+
+  @doc """
   Returns the most recent `DatabaseMaintenanceWorker` job record (in any
   state), or nil if none exists. Used to surface the outcome of both manual
   and scheduled maintenance runs in the UI.
@@ -119,6 +156,15 @@ defmodule Pinchflat.Diagnostics.DatabaseDiagnostics do
   def format_bytes(bytes) when bytes < 1024 * 1024, do: "#{Float.round(bytes / 1024, 1)} KiB"
   def format_bytes(bytes) when bytes < 1024 * 1024 * 1024, do: "#{Float.round(bytes / 1024 / 1024, 1)} MiB"
   def format_bytes(bytes), do: "#{Float.round(bytes / 1024 / 1024 / 1024, 2)} GiB"
+
+  # SQLite reports a healthy database as a single "ok" row; everything else is
+  # a problem description meant to be read as-is.
+  defp extract_findings(rows) do
+    rows
+    |> List.flatten()
+    |> Enum.map(&to_string/1)
+    |> Enum.reject(&(&1 == "ok"))
+  end
 
   defp pragma_number(pragma) do
     case pragma_value(pragma) do

--- a/lib/pinchflat/diagnostics/database_maintenance_worker.ex
+++ b/lib/pinchflat/diagnostics/database_maintenance_worker.ex
@@ -1,0 +1,203 @@
+defmodule Pinchflat.Diagnostics.DatabaseMaintenanceWorker do
+  @moduledoc false
+
+  use Oban.Worker,
+    queue: :local_data,
+    # Dedupe on worker alone (not args) so a manual run and a scheduled run
+    # can't be queued alongside each other
+    unique: [period: :infinity, states: :incomplete, fields: [:worker, :queue]],
+    max_attempts: 3,
+    tags: ["local_data", "maintenance"]
+
+  import Ecto.Query, warn: false
+
+  require Logger
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Settings
+  alias Pinchflat.Diagnostics.DatabaseDiagnostics
+  alias Pinchflat.Diagnostics.QueueDiagnostics
+
+  # VACUUM rebuilds the database into a temporary copy before swapping it in,
+  # so it can briefly need as much free space as the database itself. The
+  # margin keeps the disk from being filled to the brim even if the estimate
+  # is exact.
+  @disk_space_margin_bytes 64 * 1024 * 1024
+  @vacuum_timeout :timer.minutes(30)
+
+  @doc """
+  Enqueues a manual database maintenance job (the Compact Now button).
+  Manual runs execute regardless of the `database_maintenance_enabled`
+  setting — pressing the button is its own consent. Uniqueness ensures a
+  manual kickoff and the scheduled run can't stack up or run concurrently.
+
+  Returns {:ok, %Oban.Job{}} | {:error, %Ecto.Changeset{}}
+  """
+  def kickoff do
+    Oban.insert(new(%{"manual" => true}))
+  end
+
+  @doc """
+  Compacts the database: truncates the WAL sidecar, then VACUUMs to return
+  freelist pages to the filesystem and refreshes query-planner statistics.
+
+  VACUUM holds the write lock for its whole run — minutes on weak hardware
+  with a large database — so this reserves a quiet window first: it pauses
+  all job queues, waits (indefinitely — a slow indexing run can take hours)
+  for other executing jobs to finish, vacuums, then resumes the queues. The
+  queues are resumed even if the VACUUM fails, and a pause can't outlive a
+  crash since queue pause state doesn't survive a restart.
+
+  The VACUUM only runs if the filesystem has enough headroom for the
+  temporary database copy it builds; otherwise the job fails with a
+  descriptive error so it surfaces in the Failed Jobs section of the
+  diagnostics page. The WAL truncation always runs — it only ever shrinks
+  the files on disk.
+
+  Scheduled (cron) runs only proceed when the user has opted in via the
+  `database_maintenance_enabled` setting; manual runs always proceed. A
+  skipped scheduled run cancels with a reason so the diagnostics card shows
+  why nothing happened rather than silently doing nothing.
+
+  Returns :ok | {:cancel, binary()} | {:error, binary()}
+  """
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"manual" => true}, id: job_id}), do: run_maintenance(job_id)
+
+  def perform(%Oban.Job{id: job_id}) do
+    if Settings.get!(:database_maintenance_enabled) do
+      run_maintenance(job_id)
+    else
+      {:cancel, "Scheduled compaction is turned off — use its tile in the Database section to turn it on"}
+    end
+  end
+
+  defp run_maintenance(job_id) do
+    size_before = DatabaseDiagnostics.get_database_stats().total_bytes
+
+    truncate_wal()
+
+    result =
+      with_paused_queues(fn ->
+        wait_for_other_running_jobs(job_id)
+
+        # Checked inside the reserved window (rather than up front) since free
+        # space can change materially while waiting for jobs to finish
+        case check_disk_space() do
+          :ok -> run_vacuum()
+          error -> error
+        end
+      end)
+
+    case result do
+      :ok ->
+        record_reclaimed_bytes(job_id, size_before)
+
+        :ok
+
+      {:error, message} ->
+        Logger.warning("Skipping database VACUUM: #{message}")
+
+        {:error, message}
+    end
+  end
+
+  # Pausing stops queues from starting new jobs but lets executing ones run to
+  # completion. Resuming in `after` covers vacuum failures; a crashed node
+  # resets pause state on its own since it's held in memory, not the database.
+  defp with_paused_queues(fun) do
+    queues = QueueDiagnostics.queue_names()
+
+    Enum.each(queues, &Oban.pause_queue(queue: &1))
+
+    try do
+      fun.()
+    after
+      Enum.each(queues, &Oban.resume_queue(queue: &1))
+    end
+  end
+
+  defp wait_for_other_running_jobs(job_id) do
+    if other_jobs_running?(job_id) do
+      Logger.info("Database maintenance is waiting for running jobs to finish before vacuuming")
+      Process.sleep(Application.get_env(:pinchflat, :db_maintenance_poll_interval))
+      wait_for_other_running_jobs(job_id)
+    else
+      :ok
+    end
+  end
+
+  # The job ID is nil when run via `Oban.Testing.perform_job/2`
+  defp other_jobs_running?(job_id) do
+    from(j in Oban.Job, where: j.state == "executing")
+    |> then(fn query -> if job_id, do: where(query, [j], j.id != ^job_id), else: query end)
+    |> Repo.aggregate(:count)
+    |> Kernel.>(0)
+  end
+
+  # Flushes the WAL into the main database file and truncates it to zero
+  # length. Safe to run unconditionally — it needs no extra disk space. A
+  # failed checkpoint (eg: the database is briefly locked) isn't fatal;
+  # VACUUM checkpoints on its own anyway.
+  defp truncate_wal do
+    case Repo.query("PRAGMA wal_checkpoint(TRUNCATE)") do
+      {:ok, _result} -> :ok
+      {:error, error} -> Logger.warning("WAL checkpoint failed: #{inspect(error)}")
+    end
+  end
+
+  defp run_vacuum do
+    Repo.query!("VACUUM", [], timeout: @vacuum_timeout)
+    # Refreshes the query planner's statistics — cheap after a full rebuild
+    Repo.query!("PRAGMA optimize")
+    # In WAL mode the VACUUM commits the rebuilt database through the WAL,
+    # which can balloon to the size of the database itself. Checkpoint and
+    # truncate it again so the on-disk footprint shrinks immediately and the
+    # reclaimed-bytes measurement isn't distorted by a fat WAL.
+    truncate_wal()
+
+    :ok
+  end
+
+  # VACUUM builds its temporary copy in SQLite's temp directory and journals
+  # in the database directory, so both filesystems need headroom for a full
+  # copy of the database.
+  defp check_disk_space do
+    required_bytes = DatabaseDiagnostics.file_size(DatabaseDiagnostics.database_filepath()) + @disk_space_margin_bytes
+    directories = Enum.uniq([Path.dirname(DatabaseDiagnostics.database_filepath()), System.tmp_dir!()])
+
+    Enum.reduce_while(directories, :ok, fn directory, :ok ->
+      case disk_space_checker().available_bytes(directory) do
+        {:ok, available} when available >= required_bytes ->
+          {:cont, :ok}
+
+        {:ok, available} ->
+          {:halt,
+           {:error,
+            "Not enough free disk space to safely VACUUM: " <>
+              "#{DatabaseDiagnostics.format_bytes(required_bytes)} needed in #{directory} " <>
+              "but only #{DatabaseDiagnostics.format_bytes(available)} is available"}}
+
+        :error ->
+          {:halt, {:error, "Could not determine free disk space for #{directory} — refusing to VACUUM"}}
+      end
+    end)
+  end
+
+  # Stores the space savings on the job record so the diagnostics page can
+  # report the outcome of the run. The job ID is nil when run via
+  # `Oban.Testing.perform_job/2`, which never persists the job.
+  defp record_reclaimed_bytes(nil, _size_before), do: :ok
+
+  defp record_reclaimed_bytes(job_id, size_before) do
+    size_after = DatabaseDiagnostics.get_database_stats().total_bytes
+    reclaimed = max(size_before - size_after, 0)
+
+    from(j in Oban.Job, where: j.id == ^job_id)
+    |> Repo.update_all(set: [meta: %{"reclaimed_bytes" => reclaimed}])
+  end
+
+  defp disk_space_checker do
+    Application.get_env(:pinchflat, :disk_space_checker, Pinchflat.Diagnostics.DiskSpaceChecker)
+  end
+end

--- a/lib/pinchflat/diagnostics/database_maintenance_worker.ex
+++ b/lib/pinchflat/diagnostics/database_maintenance_worker.ex
@@ -2,12 +2,15 @@ defmodule Pinchflat.Diagnostics.DatabaseMaintenanceWorker do
   @moduledoc false
 
   use Oban.Worker,
-    queue: :local_data,
+    # Keep all full quiet-window operations in one queue. Otherwise this and
+    # ReconcileWorker can each pause queues, see the other executing, and wait
+    # forever.
+    queue: :maintenance,
     # Dedupe on worker alone (not args) so a manual run and a scheduled run
     # can't be queued alongside each other
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :queue]],
     max_attempts: 3,
-    tags: ["local_data", "maintenance"]
+    tags: ["maintenance"]
 
   import Ecto.Query, warn: false
 

--- a/lib/pinchflat/diagnostics/disk_space_behaviour.ex
+++ b/lib/pinchflat/diagnostics/disk_space_behaviour.ex
@@ -1,0 +1,8 @@
+defmodule Pinchflat.Diagnostics.DiskSpaceBehaviour do
+  @moduledoc """
+  Behaviour for checking available disk space, so the real `df`-based
+  implementation can be swapped for a mock in tests.
+  """
+
+  @callback available_bytes(Path.t()) :: {:ok, non_neg_integer()} | :error
+end

--- a/lib/pinchflat/diagnostics/disk_space_checker.ex
+++ b/lib/pinchflat/diagnostics/disk_space_checker.ex
@@ -1,0 +1,38 @@
+defmodule Pinchflat.Diagnostics.DiskSpaceChecker do
+  @moduledoc """
+  Reports the free disk space available at a given path, using POSIX `df`.
+  """
+
+  @behaviour Pinchflat.Diagnostics.DiskSpaceBehaviour
+
+  @doc """
+  Returns the number of bytes available on the filesystem containing `path`,
+  or `:error` if it can't be determined.
+
+  Returns {:ok, non_neg_integer()} | :error
+  """
+  @impl Pinchflat.Diagnostics.DiskSpaceBehaviour
+  def available_bytes(path) do
+    case System.cmd("df", ["-P", "-k", path], stderr_to_stdout: true) do
+      {output, 0} -> parse_available_kilobytes(output)
+      _ -> :error
+    end
+  rescue
+    # eg: `df` not found on the system
+    ErlangError -> :error
+  end
+
+  # POSIX `df -P -k` output looks like:
+  #
+  #   Filesystem 1024-blocks    Used Available Capacity Mounted on
+  #   /dev/vda1     41152812 9412644  29617236      25% /
+  defp parse_available_kilobytes(output) do
+    with [_header, data_line | _] <- String.split(output, "\n", trim: true),
+         columns when length(columns) >= 4 <- String.split(data_line, ~r/\s+/, trim: true),
+         {available_kb, _} <- Integer.parse(Enum.at(columns, 3)) do
+      {:ok, available_kb * 1024}
+    else
+      _ -> :error
+    end
+  end
+end

--- a/lib/pinchflat/diagnostics/queue_diagnostics.ex
+++ b/lib/pinchflat/diagnostics/queue_diagnostics.ex
@@ -290,8 +290,8 @@ defmodule Pinchflat.Diagnostics.QueueDiagnostics do
     %{
       total_pending_downloads: count_pending_downloads(),
       total_downloaded: count_downloaded_media(),
-      total_sources: count_sources(),
-      database_size: get_database_size()
+      total_media_items: count_media_items(),
+      total_sources: count_sources()
     }
   end
 
@@ -331,30 +331,7 @@ defmodule Pinchflat.Diagnostics.QueueDiagnostics do
     Repo.aggregate(Pinchflat.Sources.Source, :count)
   end
 
-  defp get_database_size do
-    db_path = Application.get_env(:pinchflat, Pinchflat.Repo)[:database]
-
-    if db_path && File.exists?(db_path) do
-      # Include the WAL/SHM sidecar files so the figure reflects on-disk usage
-      # rather than just the main database file.
-      [db_path, db_path <> "-wal", db_path <> "-shm"]
-      |> Enum.map(&file_size/1)
-      |> Enum.sum()
-      |> format_bytes()
-    else
-      "Unknown"
-    end
+  defp count_media_items do
+    Repo.aggregate(Pinchflat.Media.MediaItem, :count)
   end
-
-  defp file_size(path) do
-    case File.stat(path) do
-      {:ok, %{size: size}} -> size
-      _ -> 0
-    end
-  end
-
-  defp format_bytes(bytes) when bytes < 1024, do: "#{bytes} B"
-  defp format_bytes(bytes) when bytes < 1024 * 1024, do: "#{Float.round(bytes / 1024, 1)} KiB"
-  defp format_bytes(bytes) when bytes < 1024 * 1024 * 1024, do: "#{Float.round(bytes / 1024 / 1024, 1)} MiB"
-  defp format_bytes(bytes), do: "#{Float.round(bytes / 1024 / 1024 / 1024, 2)} GiB"
 end

--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -41,14 +41,16 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
 
   Returns binary()
   """
-  def build_output_path_for(%Source{} = source_with_preloads) do
-    build_output_path_for(%MediaItem{source: source_with_preloads})
+  def build_output_path_for(struct, template_options \\ %{})
+
+  def build_output_path_for(%Source{} = source_with_preloads, template_options) do
+    build_output_path_for(%MediaItem{source: source_with_preloads}, template_options)
   end
 
-  def build_output_path_for(%MediaItem{} = media_item_with_preloads) do
+  def build_output_path_for(%MediaItem{} = media_item_with_preloads, template_options) do
     output_path_template = Sources.output_path_template(media_item_with_preloads.source)
 
-    build_output_path(output_path_template, media_item_with_preloads)
+    build_output_path(output_path_template, media_item_with_preloads, template_options)
   end
 
   @doc """
@@ -191,8 +193,8 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
     ]
   end
 
-  defp build_output_path(string, media_item_with_preloads) do
-    additional_options_map = output_options_map(media_item_with_preloads)
+  defp build_output_path(string, media_item_with_preloads, template_options) do
+    additional_options_map = Map.merge(output_options_map(media_item_with_preloads), template_options)
     {:ok, output_path} = OutputPathBuilder.build(string, additional_options_map)
     relative_output_path = output_path |> String.trim_leading("/") |> String.trim_leading("\\")
     source_subdirectory = media_item_with_preloads.source.download_subdirectory

--- a/lib/pinchflat/metadata/metadata_file_helpers.ex
+++ b/lib/pinchflat/metadata/metadata_file_helpers.ex
@@ -50,7 +50,12 @@ defmodule Pinchflat.Metadata.MetadataFileHelpers do
   Returns {:ok, map()} | {:error, any}
   """
   def read_compressed_metadata(filepath) do
-    {:ok, json} = File.open(filepath, [:read, :compressed], &IO.read(&1, :eof))
+    # Read the decompressed bytes verbatim. `IO.read` on a non-utf8 device
+    # reinterprets each raw byte as a latin1 codepoint and re-encodes it as
+    # UTF-8, double-encoding every non-ASCII character (an emoji title comes
+    # back as mojibake). `IO.binread` returns the stored UTF-8 bytes as-is for
+    # Jason to decode.
+    {:ok, json} = File.open(filepath, [:read, :compressed, :binary], &IO.binread(&1, :eof))
 
     Phoenix.json_library().decode(json)
   end

--- a/lib/pinchflat/metadata/metadata_file_helpers.ex
+++ b/lib/pinchflat/metadata/metadata_file_helpers.ex
@@ -95,6 +95,13 @@ defmodule Pinchflat.Metadata.MetadataFileHelpers do
     end
   end
 
+  @series_root_marker "__PINCHFLAT_SERIES_ROOT__"
+
+  @doc """
+  Sentinel token placed in an output path template to locate the series directory.
+  """
+  def series_root_marker, do: @series_root_marker
+
   @doc """
   Attempts to determine the series directory from a media filepath.
   The series directory is the "root" directory for a given source
@@ -106,29 +113,34 @@ defmodule Pinchflat.Metadata.MetadataFileHelpers do
   Returns {:ok, binary()} | {:error, :indeterminable}
   """
   def series_directory_from_media_filepath(media_filepath) do
-    # Matches "s" or "season" (case-insensitive)
-    # followed by an optional non-word character (. or _ or <space>, etc)
-    # followed by at least one digit
-    # followed immediately by the end of the string
-    # Example matches: s1, s.1, s01 season 1, Season.01, Season_1, Season 1, Season1
-    # Example non-matches: s01e01, season, series 1,
-    season_regex = ~r/^s(eason)?(\W|_)?\d{1,}$/i
-
-    {series_directory, found_series_directory} =
-      media_filepath
-      |> Path.split()
-      |> Enum.reduce_while({[], false}, fn part, {directory_acc, _} ->
-        if String.match?(part, season_regex) do
-          {:halt, {directory_acc, true}}
-        else
-          {:cont, {directory_acc ++ [part], false}}
-        end
-      end)
-
-    if found_series_directory do
-      {:ok, Path.join(series_directory)}
+    if String.contains?(media_filepath, series_root_marker()) do
+      [series_dir | _] = String.split(media_filepath, series_root_marker())
+      {:ok, String.trim_trailing(series_dir, "/")}
     else
-      {:error, :indeterminable}
+      # Matches "s" or "season" (case-insensitive)
+      # followed by an optional non-word character (. or _ or <space>, etc)
+      # followed by at least one digit
+      # followed immediately by the end of the string
+      # Example matches: s1, s.1, s01 season 1, Season.01, Season_1, Season 1, Season1
+      # Example non-matches: s01e01, season, series 1,
+      season_regex = ~r/^s(eason)?(\W|_)?\d{1,}$/i
+
+      {series_directory, found_series_directory} =
+        media_filepath
+        |> Path.split()
+        |> Enum.reduce_while({[], false}, fn part, {directory_acc, _} ->
+          if String.match?(part, season_regex) do
+            {:halt, {directory_acc, true}}
+          else
+            {:cont, {directory_acc ++ [part], false}}
+          end
+        end)
+
+      if found_series_directory do
+        {:ok, Path.join(series_directory)}
+      else
+        {:error, :indeterminable}
+      end
     end
   end
 

--- a/lib/pinchflat/profiles/media_profile.ex
+++ b/lib/pinchflat/profiles/media_profile.ex
@@ -96,6 +96,13 @@ defmodule Pinchflat.Profiles.MediaProfile do
   end
 
   @doc """
+  Returns true if the media profile is configured for audio-only / podcast downloads.
+  """
+  def podcast?(%MediaProfile{preferred_resolution: :audio}), do: true
+  def podcast?(%MediaProfile{}), do: false
+  def podcast?(_), do: false
+
+  @doc """
   Returns the list of SponsorBlock category identifiers a profile can act on.
 
   Returns [binary()]

--- a/lib/pinchflat/reconciliation/path_predictor.ex
+++ b/lib/pinchflat/reconciliation/path_predictor.ex
@@ -1,0 +1,96 @@
+defmodule Pinchflat.Reconciliation.PathPredictor do
+  @moduledoc """
+  Computes where a media item's files WOULD land under the current path-affecting
+  settings, without any network calls: the item's stored (compressed) metadata is
+  fed back to yt-dlp via `--load-info-json` and the filename is rendered against
+  the current effective output template. Because yt-dlp itself does the rendering,
+  sanitization (`--windows-filenames`, the `restrict_filenames` setting) matches a
+  real download exactly.
+
+  Media items must have `:metadata` and `source: :media_profile` preloaded.
+  """
+
+  alias Pinchflat.Media.MediaItem
+  alias Pinchflat.Downloading.DownloadOptionBuilder
+  alias Pinchflat.Metadata.MetadataFileHelpers
+  alias Pinchflat.YtDlp.Media, as: YtDlpMedia
+  alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
+
+  @doc """
+  Predicts the media item's target filepath under the current settings. The
+  rendered extension is replaced with the actual downloaded file's extension
+  (when known) since post-download merging can change it.
+
+  Returns {:ok, binary()} | {:error, :no_metadata | binary()}
+  """
+  def predict_media_filepath(%MediaItem{} = media_item_with_preloads) do
+    case render_filepath(media_item_with_preloads, %{}) do
+      {:ok, rendered} -> {:ok, substitute_actual_extension(rendered, media_item_with_preloads)}
+      err -> err
+    end
+  end
+
+  @doc """
+  Predicts the source's series directory under the current settings by rendering
+  the output template with the `{{ series_root }}` sentinel attached (the same
+  trick `SourceMetadataStorageWorker` uses, but offline). Falls back to the
+  season-folder heuristic when the template has no marker.
+
+  Returns {:ok, binary()} | {:error, :no_metadata | :indeterminable | binary()}
+  """
+  def predict_series_directory(%MediaItem{} = media_item_with_preloads) do
+    marker_override = %{"series_root" => MetadataFileHelpers.series_root_marker()}
+
+    with {:ok, rendered} <- render_filepath(media_item_with_preloads, marker_override) do
+      MetadataFileHelpers.series_directory_from_media_filepath(rendered)
+    end
+  end
+
+  defp render_filepath(media_item, template_opts) do
+    with {:ok, metadata_map} <- read_stored_metadata(media_item),
+         {:ok, info_json_filepath} <- write_info_json_tmpfile(metadata_map) do
+      output_path = DownloadOptionBuilder.build_output_path_for(media_item, template_opts)
+
+      result =
+        YtDlpMedia.predict_filepath_from_metadata(
+          media_item.original_url,
+          info_json_filepath,
+          output: output_path
+        )
+
+      File.rm(info_json_filepath)
+      normalize_render_result(result)
+    end
+  end
+
+  defp read_stored_metadata(%MediaItem{metadata: %{metadata_filepath: filepath}}) when is_binary(filepath) do
+    if FSUtils.exists_and_nonempty?(filepath) do
+      MetadataFileHelpers.read_compressed_metadata(filepath)
+    else
+      {:error, :no_metadata}
+    end
+  end
+
+  defp read_stored_metadata(_media_item), do: {:error, :no_metadata}
+
+  defp write_info_json_tmpfile(metadata_map) do
+    filepath = FSUtils.generate_metadata_tmpfile(:json)
+
+    with {:ok, json} <- Phoenix.json_library().encode(metadata_map),
+         :ok <- File.write(filepath, json) do
+      {:ok, filepath}
+    end
+  end
+
+  defp normalize_render_result({:ok, filename}) when is_binary(filename) and filename != "", do: {:ok, filename}
+  defp normalize_render_result({:ok, other}), do: {:error, "Unexpected rendered filename: #{inspect(other)}"}
+  defp normalize_render_result({:error, output, _status}), do: {:error, to_string(output)}
+  defp normalize_render_result({:error, reason}), do: {:error, to_string(reason)}
+
+  defp substitute_actual_extension(rendered, %MediaItem{media_filepath: media_filepath}) do
+    case media_filepath && Path.extname(media_filepath) do
+      ext when is_binary(ext) and ext != "" -> Path.rootname(rendered) <> ext
+      _ -> rendered
+    end
+  end
+end

--- a/lib/pinchflat/reconciliation/plan_applier.ex
+++ b/lib/pinchflat/reconciliation/plan_applier.ex
@@ -1,0 +1,465 @@
+defmodule Pinchflat.Reconciliation.PlanApplier do
+  @moduledoc """
+  Executes a reviewed reconcile plan: moves/deletes files, backfills sidecars,
+  and updates the corresponding `*_filepath` columns. Work is grouped per media
+  item so one item failing doesn't abort the run; each plan item's row records
+  what actually happened (done/skipped/failed). Rows whose `from_path` no longer
+  matches the database (e.g. a download ran after planning) are skipped as stale.
+
+  Media files are only ever moved — deletion rows exist solely for sidecars whose
+  profile toggle is off, and the internal compressed metadata blob is never touched.
+  """
+
+  import Ecto.Query, warn: false
+
+  require Logger
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Media
+  alias Pinchflat.Sources
+  alias Pinchflat.Sources.Source
+  alias Pinchflat.Media.MediaItem
+  alias Pinchflat.Reconciliation
+  alias Pinchflat.Metadata.NfoBuilder
+  alias Pinchflat.Reconciliation.ReconcilePlan
+  alias Pinchflat.Reconciliation.ReconcilePlanItem
+  alias Pinchflat.Metadata.MetadataFileHelpers
+  alias Pinchflat.Downloading.MediaDownloadWorker
+  alias Pinchflat.Podcasts.PodcastExportWorker
+  alias Pinchflat.YtDlp.Media, as: YtDlpMedia
+  alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
+  alias Pinchflat.Utils.MapUtils
+
+  @doc """
+  Applies every planned row of the given plan. Returns the plan marked as
+  applied, with `error_count` reflecting rows that failed.
+
+  Returns {:ok, %ReconcilePlan{}}
+  """
+  def apply_plan(%ReconcilePlan{} = plan) do
+    rows =
+      ReconcilePlanItem
+      |> where(reconcile_plan_id: ^plan.id, status: :planned)
+      |> where([rpi], rpi.action in [:move, :backfill, :delete, :redownload])
+      |> order_by(asc: :id)
+      |> Repo.all()
+
+    {media_item_rows, source_rows} = Enum.split_with(rows, & &1.media_item_id)
+
+    media_item_rows
+    |> Enum.group_by(& &1.media_item_id)
+    |> Enum.each(fn {media_item_id, item_rows} -> apply_media_item_rows(media_item_id, item_rows) end)
+
+    source_rows
+    |> Enum.group_by(& &1.source_id)
+    |> Enum.each(fn {source_id, src_rows} -> apply_source_rows(source_id, src_rows) end)
+
+    kickoff_podcast_exports(rows)
+    finalize_plan(plan)
+  end
+
+  # ---- Per-media-item application ----
+
+  defp apply_media_item_rows(media_item_id, rows) do
+    media_item = Repo.preload(Media.get_media_item!(media_item_id), [:metadata, source: :media_profile])
+
+    {changes, _} =
+      Enum.reduce(rows, {%{}, media_item}, fn row, {changes_acc, item} ->
+        case apply_media_item_row(item, row) do
+          {:ok, new_changes} ->
+            mark_row(row, :done)
+            {Map.merge(changes_acc, new_changes, &merge_change/3), item}
+
+          {:skipped, reason} ->
+            mark_row(row, :skipped, reason)
+            {changes_acc, item}
+
+          {:error, reason} ->
+            mark_row(row, :failed, reason)
+            {changes_acc, item}
+        end
+      end)
+
+    persist_media_item_changes(media_item, changes)
+  rescue
+    Ecto.NoResultsError ->
+      Enum.each(rows, &mark_row(&1, :skipped, "Media item no longer exists"))
+  end
+
+  # Subtitle changes accumulate as a map of lang => path-or-nil under :subtitle_changes
+  defp merge_change(:subtitle_changes, existing, new), do: Map.merge(existing, new)
+  defp merge_change(_key, _existing, new), do: new
+
+  defp persist_media_item_changes(_media_item, changes) when changes == %{}, do: :ok
+
+  defp persist_media_item_changes(media_item, changes) do
+    {subtitle_changes, column_changes} = Map.pop(changes, :subtitle_changes, %{})
+
+    attrs =
+      if subtitle_changes == %{} do
+        column_changes
+      else
+        current = MapUtils.from_nested_list(media_item.subtitle_filepaths)
+
+        updated =
+          current
+          |> Map.merge(subtitle_changes)
+          |> Enum.reject(fn {_lang, path} -> is_nil(path) end)
+          |> Enum.map(fn {lang, path} -> [lang, path] end)
+
+        Map.put(column_changes, :subtitle_filepaths, updated)
+      end
+
+    case Media.update_media_item(media_item, attrs) do
+      {:ok, _updated} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.error("Reconcile could not update media item ##{media_item.id}: #{inspect(changeset.errors)}")
+        :ok
+    end
+  end
+
+  defp apply_media_item_row(media_item, %{action: :move} = row) do
+    with :ok <- verify_current_path(media_item, row),
+         :ok <- verify_destination_free(row) do
+      case FSUtils.move_p(row.from_path, row.to_path) do
+        :ok -> {:ok, change_for_attribute(row.attribute, row.to_path)}
+        {:error, reason} -> {:error, "Move failed: #{inspect(reason)}"}
+      end
+    end
+  end
+
+  defp apply_media_item_row(media_item, %{action: :delete} = row) do
+    with :ok <- verify_current_path(media_item, row) do
+      case FSUtils.delete_file_and_remove_empty_directories(row.from_path) do
+        :ok -> {:ok, change_for_attribute(row.attribute, nil)}
+        {:error, reason} -> {:error, "Delete failed: #{inspect(reason)}"}
+      end
+    end
+  end
+
+  defp apply_media_item_row(media_item, %{action: :backfill} = row) do
+    with :ok <- verify_destination_free(row) do
+      backfill_media_item_attribute(media_item, row)
+    end
+  end
+
+  # Enqueues a forced re-download (same path as "Redownload Existing"): it
+  # re-downloads to the current template, fixing both the format and the path,
+  # and cleans up the old file itself. The job is inserted while the queues are
+  # paused, so it waits and runs after the reconcile window closes — never
+  # racing the moves. No filepath columns change here; the download updates them.
+  defp apply_media_item_row(media_item, %{action: :redownload}) do
+    case MediaDownloadWorker.kickoff_with_task(media_item, %{force: true}) do
+      {:ok, _} -> {:ok, %{}}
+      {:error, :duplicate_job} -> {:ok, %{}}
+      {:error, reason} -> {:error, "Could not schedule re-download: #{inspect(reason)}"}
+    end
+  end
+
+  # Rechecks the destination right before writing to close the gap between the
+  # dry run and apply: a file created at the target since planning (Erlang's
+  # rename/copy and File.write all clobber, and there's no exclusive rename) is
+  # left untouched rather than overwritten. A target that is the same file as
+  # the source (symlink/inode) is fine to proceed with.
+  defp verify_destination_free(%{to_path: nil}), do: :ok
+
+  defp verify_destination_free(%{to_path: to_path, from_path: from_path}) do
+    cond do
+      !File.exists?(to_path) -> :ok
+      from_path && FSUtils.filepaths_reference_same_file?(from_path, to_path) -> :ok
+      true -> {:skipped, "Target path is now occupied — re-run the dry run to re-plan"}
+    end
+  end
+
+  # Moves/deletes only apply while the DB still agrees with the plan about where
+  # the file is — a re-download or another process may have relocated it since
+  defp verify_current_path(media_item, row) do
+    current = current_path_for_attribute(media_item, row.attribute)
+
+    cond do
+      current != row.from_path -> {:skipped, "Stale: file has moved since the plan was created"}
+      !File.exists?(row.from_path) -> {:skipped, "File no longer exists on disk"}
+      true -> :ok
+    end
+  end
+
+  defp current_path_for_attribute(media_item, "media"), do: media_item.media_filepath
+  defp current_path_for_attribute(media_item, "thumbnail"), do: media_item.thumbnail_filepath
+  defp current_path_for_attribute(media_item, "metadata"), do: media_item.metadata_filepath
+  defp current_path_for_attribute(media_item, "nfo"), do: media_item.nfo_filepath
+
+  defp current_path_for_attribute(media_item, "subtitle:" <> lang) do
+    media_item.subtitle_filepaths
+    |> MapUtils.from_nested_list()
+    |> Map.get(lang)
+  end
+
+  defp change_for_attribute("media", path), do: %{media_filepath: path}
+  defp change_for_attribute("thumbnail", path), do: %{thumbnail_filepath: path}
+  defp change_for_attribute("metadata", path), do: %{metadata_filepath: path}
+  defp change_for_attribute("nfo", path), do: %{nfo_filepath: path}
+  defp change_for_attribute("subtitle:" <> lang, path), do: %{subtitle_changes: %{lang => path}}
+
+  # ---- Media item backfills ----
+
+  defp backfill_media_item_attribute(media_item, %{attribute: "nfo"} = row) do
+    with {:ok, metadata} <- read_stored_metadata(media_item) do
+      NfoBuilder.build_and_store_for_media_item(row.to_path, metadata)
+      {:ok, %{nfo_filepath: row.to_path}}
+    end
+  end
+
+  defp backfill_media_item_attribute(media_item, %{attribute: "metadata"} = row) do
+    with {:ok, metadata} <- read_stored_metadata(media_item),
+         {:ok, json} <- Phoenix.json_library().encode(metadata),
+         :ok <- FSUtils.write_p(row.to_path, json) do
+      {:ok, %{metadata_filepath: row.to_path}}
+    else
+      {:skipped, reason} -> {:skipped, reason}
+      err -> {:error, "Could not write info.json: #{inspect(err)}"}
+    end
+  end
+
+  defp backfill_media_item_attribute(media_item, %{attribute: "thumbnail"} = row) do
+    rootname = Path.rootname(row.to_path)
+    command_opts = [output: "#{rootname}.%(ext)s"]
+    addl_opts = [use_cookies: Sources.use_cookies?(media_item.source, :metadata)]
+
+    case YtDlpMedia.download_thumbnail(media_item.original_url, command_opts, addl_opts) do
+      {:ok, _} ->
+        if File.exists?(row.to_path) do
+          {:ok, %{thumbnail_filepath: row.to_path}}
+        else
+          {:error, "Thumbnail fetch reported success but no file was written"}
+        end
+
+      {:error, message, _exit_code} ->
+        {:error, "Thumbnail fetch failed: #{inspect(message)}"}
+
+      err ->
+        {:error, "Thumbnail fetch failed: #{inspect(err)}"}
+    end
+  end
+
+  defp backfill_media_item_attribute(media_item, %{attribute: "subtitles"} = row) do
+    profile = media_item.source.media_profile
+    rootname = row.to_path |> Path.rootname() |> Path.rootname()
+
+    # Mirror how a real download names subtitles: yt-dlp derives the sub filename
+    # from the media output template (replacing its extension with `.<lang>.<ext>`),
+    # so pass the `%(ext)s` template shape the thumbnail backfill and downloads use.
+    # `--write-auto-subs` is only added when the profile opts into auto-captions —
+    # exactly as `DownloadOptionBuilder.subtitle_options/1` does — so the backfill
+    # can't fetch subs a normal download wouldn't.
+    command_opts =
+      [sub_langs: profile.sub_langs, output: "#{rootname}.%(ext)s"] ++
+        if(profile.download_auto_subs, do: [:write_auto_subs], else: [])
+
+    addl_opts = [use_cookies: Sources.use_cookies?(media_item.source, :metadata)]
+
+    case YtDlpMedia.download_subtitles(media_item.original_url, command_opts, addl_opts) do
+      {:ok, _} ->
+        case discover_subtitles(rootname) do
+          empty when map_size(empty) == 0 ->
+            # yt-dlp exits 0 even when the video has no subs in the requested
+            # languages — surface that (with a hint) instead of marking it done
+            {:skipped, subtitles_unavailable_detail(profile)}
+
+          subtitle_changes ->
+            {:ok, %{subtitle_changes: subtitle_changes}}
+        end
+
+      {:error, message, _exit_code} ->
+        {:error, "Subtitle fetch failed: #{inspect(message)}"}
+
+      err ->
+        {:error, "Subtitle fetch failed: #{inspect(err)}"}
+    end
+  end
+
+  defp backfill_media_item_attribute(_media_item, row) do
+    {:error, "Unknown backfill attribute: #{row.attribute}"}
+  end
+
+  # Many sources (e.g. most YouTube channels) only publish auto-generated
+  # captions, which need auto-subs enabled; point the user at that toggle
+  defp subtitles_unavailable_detail(%{download_auto_subs: false, sub_langs: langs}) do
+    "No manual #{langs} subtitles were available. If this source only has auto-generated " <>
+      "captions, enable auto-generated subtitles in the media profile."
+  end
+
+  defp subtitles_unavailable_detail(%{sub_langs: langs}) do
+    "yt-dlp found no #{langs} subtitles to download for this video."
+  end
+
+  defp discover_subtitles(rootname) do
+    "#{rootname}.*.srt"
+    |> Path.wildcard()
+    |> Map.new(fn path ->
+      lang = path |> Path.rootname(".srt") |> Path.extname() |> String.trim_leading(".")
+      {lang, path}
+    end)
+  end
+
+  defp read_stored_metadata(%MediaItem{metadata: %{metadata_filepath: filepath}}) when is_binary(filepath) do
+    if FSUtils.exists_and_nonempty?(filepath) do
+      MetadataFileHelpers.read_compressed_metadata(filepath)
+    else
+      {:skipped, "Stored metadata is missing"}
+    end
+  end
+
+  defp read_stored_metadata(_media_item), do: {:skipped, "Stored metadata is missing"}
+
+  # ---- Source-level application ----
+
+  defp apply_source_rows(source_id, rows) do
+    source = Repo.preload(Sources.get_source!(source_id), [:metadata, :media_profile])
+
+    changes =
+      Enum.reduce(rows, %{}, fn row, changes_acc ->
+        case apply_source_row(source, row) do
+          {:ok, new_changes} ->
+            mark_row(row, :done)
+            Map.merge(changes_acc, new_changes)
+
+          {:skipped, reason} ->
+            mark_row(row, :skipped, reason)
+            changes_acc
+
+          {:error, reason} ->
+            mark_row(row, :failed, reason)
+            changes_acc
+        end
+      end)
+
+    persist_source_changes(source, changes)
+  rescue
+    Ecto.NoResultsError ->
+      Enum.each(rows, &mark_row(&1, :skipped, "Source no longer exists"))
+  end
+
+  defp persist_source_changes(_source, changes) when changes == %{}, do: :ok
+
+  defp persist_source_changes(source, changes) do
+    case Sources.update_source(source, changes, run_post_commit_tasks: false) do
+      {:ok, _} ->
+        :ok
+
+      {:error, changeset} ->
+        Logger.error("Reconcile could not update source ##{source.id}: #{inspect(changeset.errors)}")
+        :ok
+    end
+  end
+
+  # Record-only row: the series directory itself moved, no file operation
+  defp apply_source_row(source, %{action: :move, attribute: "series_directory"} = row) do
+    if source.series_directory == row.from_path do
+      {:ok, %{series_directory: row.to_path}}
+    else
+      {:skipped, "Stale: series directory changed since the plan was created"}
+    end
+  end
+
+  defp apply_source_row(source, %{action: :move} = row) do
+    with :ok <- verify_current_source_path(source, row),
+         :ok <- verify_destination_free(row) do
+      case FSUtils.move_p(row.from_path, row.to_path) do
+        :ok -> {:ok, source_change_for_attribute(row.attribute, row.to_path)}
+        {:error, reason} -> {:error, "Move failed: #{inspect(reason)}"}
+      end
+    end
+  end
+
+  defp apply_source_row(source, %{action: :delete} = row) do
+    with :ok <- verify_current_source_path(source, row) do
+      case FSUtils.delete_file_and_remove_empty_directories(row.from_path) do
+        :ok -> {:ok, source_change_for_attribute(row.attribute, nil)}
+        {:error, reason} -> {:error, "Delete failed: #{inspect(reason)}"}
+      end
+    end
+  end
+
+  defp apply_source_row(source, %{action: :backfill, attribute: "source_nfo"} = row) do
+    with :ok <- verify_destination_free(row) do
+      case Repo.preload(source, :metadata).metadata do
+        %{metadata_filepath: filepath} when is_binary(filepath) ->
+          with {:ok, metadata} <- MetadataFileHelpers.read_compressed_metadata(filepath) do
+            NfoBuilder.build_and_store_for_source(row.to_path, metadata)
+            {:ok, %{nfo_filepath: row.to_path}}
+          end
+
+        _ ->
+          {:skipped, "Stored source metadata is missing"}
+      end
+    end
+  end
+
+  # Source images require a metadata fetch, which Refresh Metadata already does
+  defp apply_source_row(source, %{action: :backfill, attribute: "source_images"}) do
+    case Pinchflat.Metadata.SourceMetadataStorageWorker.kickoff_with_task(source) do
+      {:ok, _} -> {:ok, %{}}
+      {:error, :duplicate_job} -> {:ok, %{}}
+      {:error, reason} -> {:error, "Could not schedule metadata refresh: #{inspect(reason)}"}
+    end
+  end
+
+  defp apply_source_row(_source, row) do
+    {:error, "Unknown source action/attribute: #{row.action}/#{row.attribute}"}
+  end
+
+  defp verify_current_source_path(source, row) do
+    current = Map.get(source, source_attribute_column(row.attribute))
+
+    cond do
+      current != row.from_path -> {:skipped, "Stale: file has moved since the plan was created"}
+      !File.exists?(row.from_path) -> {:skipped, "File no longer exists on disk"}
+      true -> :ok
+    end
+  end
+
+  defp source_attribute_column("source_nfo"), do: :nfo_filepath
+  defp source_attribute_column("source_poster"), do: :poster_filepath
+  defp source_attribute_column("source_fanart"), do: :fanart_filepath
+  defp source_attribute_column("source_banner"), do: :banner_filepath
+
+  defp source_change_for_attribute(attribute, path) do
+    %{source_attribute_column(attribute) => path}
+  end
+
+  # ---- Wrap-up ----
+
+  defp mark_row(row, status, detail \\ nil) do
+    attrs = if detail, do: %{status: status, detail: detail}, else: %{status: status}
+    {:ok, _} = Reconciliation.update_plan_item(row, attrs)
+  end
+
+  defp kickoff_podcast_exports(rows) do
+    rows
+    |> Enum.map(& &1.source_id)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.uniq()
+    |> Enum.each(fn source_id ->
+      case Repo.get(Source, source_id) do
+        # kickoff no-ops for sources that aren't published as podcasts
+        %Source{} = source -> PodcastExportWorker.kickoff(source)
+        nil -> :ok
+      end
+    end)
+  end
+
+  defp finalize_plan(plan) do
+    failed_count =
+      ReconcilePlanItem
+      |> where(reconcile_plan_id: ^plan.id, status: :failed)
+      |> Repo.aggregate(:count)
+
+    Reconciliation.update_plan(plan, %{
+      status: :applied,
+      applied_at: DateTime.utc_now(:second),
+      error_count: failed_count
+    })
+  end
+end

--- a/lib/pinchflat/reconciliation/plan_applier.ex
+++ b/lib/pinchflat/reconciliation/plan_applier.ex
@@ -17,7 +17,6 @@ defmodule Pinchflat.Reconciliation.PlanApplier do
   alias Pinchflat.Repo
   alias Pinchflat.Media
   alias Pinchflat.Sources
-  alias Pinchflat.Sources.Source
   alias Pinchflat.Media.MediaItem
   alias Pinchflat.Reconciliation
   alias Pinchflat.Metadata.NfoBuilder
@@ -25,7 +24,6 @@ defmodule Pinchflat.Reconciliation.PlanApplier do
   alias Pinchflat.Reconciliation.ReconcilePlanItem
   alias Pinchflat.Metadata.MetadataFileHelpers
   alias Pinchflat.Downloading.MediaDownloadWorker
-  alias Pinchflat.Podcasts.PodcastExportWorker
   alias Pinchflat.YtDlp.Media, as: YtDlpMedia
   alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
   alias Pinchflat.Utils.MapUtils
@@ -463,19 +461,7 @@ defmodule Pinchflat.Reconciliation.PlanApplier do
     {:ok, _} = Reconciliation.update_plan_item(row, attrs)
   end
 
-  defp kickoff_podcast_exports(rows) do
-    rows
-    |> Enum.map(& &1.source_id)
-    |> Enum.reject(&is_nil/1)
-    |> Enum.uniq()
-    |> Enum.each(fn source_id ->
-      case Repo.get(Source, source_id) do
-        # kickoff no-ops for sources that aren't published as podcasts
-        %Source{} = source -> PodcastExportWorker.kickoff(source)
-        nil -> :ok
-      end
-    end)
-  end
+  defp kickoff_podcast_exports(_rows), do: :ok
 
   defp finalize_plan(plan) do
     failed_count =

--- a/lib/pinchflat/reconciliation/plan_applier.ex
+++ b/lib/pinchflat/reconciliation/plan_applier.ex
@@ -48,14 +48,41 @@ defmodule Pinchflat.Reconciliation.PlanApplier do
 
     media_item_rows
     |> Enum.group_by(& &1.media_item_id)
-    |> Enum.each(fn {media_item_id, item_rows} -> apply_media_item_rows(media_item_id, item_rows) end)
+    |> apply_groups(fn {media_item_id, item_rows} -> apply_media_item_rows(media_item_id, item_rows) end)
 
+    # Source-level rows are few; keep them serial (they run after the media items)
     source_rows
     |> Enum.group_by(& &1.source_id)
     |> Enum.each(fn {source_id, src_rows} -> apply_source_rows(source_id, src_rows) end)
 
     kickoff_podcast_exports(rows)
     finalize_plan(plan)
+  end
+
+  # Media-item groups are independent (keyed by media_item_id, each ending in its
+  # own isolated DB write, with target collisions already filtered out at plan
+  # time), so they can be applied in parallel. The expensive work is the
+  # network-bound online/full backfills — parallelizing them is what turns a
+  # 20-minute serial thumbnail/subtitle backfill into minutes. Concurrency is
+  # bounded (tied to YT_DLP_WORKER_CONCURRENCY) so we don't hammer YouTube.
+  #
+  # At concurrency 1 we stay in-process rather than spawning a Task: the reconcile
+  # apply runs inside the Ecto SQL sandbox in tests, and a spawned process
+  # wouldn't share the sandbox connection. SQLite serializes writes regardless.
+  defp apply_groups(groups, fun) do
+    case backfill_concurrency() do
+      1 ->
+        Enum.each(groups, fun)
+
+      max ->
+        groups
+        |> Task.async_stream(fun, max_concurrency: max, timeout: :infinity, ordered: false)
+        |> Stream.run()
+    end
+  end
+
+  defp backfill_concurrency do
+    Application.get_env(:pinchflat, :reconcile_backfill_concurrency, 1)
   end
 
   # ---- Per-media-item application ----

--- a/lib/pinchflat/reconciliation/plan_builder.ex
+++ b/lib/pinchflat/reconciliation/plan_builder.ex
@@ -1,0 +1,559 @@
+defmodule Pinchflat.Reconciliation.PlanBuilder do
+  @moduledoc """
+  Builds a reconcile plan's items (the dry run): walks every downloaded media
+  item in scope, predicts where its files would land under the current settings
+  (via `PathPredictor` — no network in `:local` mode), and records the moves,
+  backfills, and deletions needed to true up disk + DB. Nothing here touches
+  the filesystem beyond reads; `PlanApplier` executes the plan later.
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Sources
+  alias Pinchflat.Sources.Source
+  alias Pinchflat.Media.MediaItem
+  alias Pinchflat.Media.MediaQuery
+  alias Pinchflat.Profiles.MediaProfile
+  alias Pinchflat.Reconciliation
+  alias Pinchflat.Reconciliation.PathPredictor
+  alias Pinchflat.Reconciliation.ReconcilePlan
+  alias Pinchflat.Downloading.DownloadOptionBuilder
+  alias Pinchflat.YtDlp.Media, as: YtDlpMedia
+  alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
+
+  @doc """
+  Builds and persists the plan's items, then refreshes its counts.
+
+  Returns {:ok, %ReconcilePlan{}}
+  """
+  def build_plan_items(%ReconcilePlan{} = plan) do
+    rows =
+      plan
+      |> sources_in_scope()
+      |> Enum.flat_map(&rows_for_source(plan, &1))
+      |> detect_collisions()
+
+    Reconciliation.create_plan_items(rows)
+    Reconciliation.refresh_plan_counts(plan)
+  end
+
+  defp sources_in_scope(%ReconcilePlan{source_id: nil}) do
+    Repo.all(from(s in Source, where: is_nil(s.marked_for_deletion_at))) |> Repo.preload(:media_profile)
+  end
+
+  defp sources_in_scope(%ReconcilePlan{source_id: source_id}) do
+    [Repo.preload(Sources.get_source!(source_id), :media_profile)]
+  end
+
+  defp rows_for_source(plan, source) do
+    media_items =
+      MediaQuery.new()
+      |> where(^MediaQuery.for_source(source))
+      |> where(^MediaQuery.downloaded())
+      |> Repo.all()
+      |> Repo.preload(:metadata)
+      |> Enum.map(fn %MediaItem{} = media_item -> %MediaItem{media_item | source: source} end)
+
+    item_rows =
+      media_items
+      |> Task.async_stream(&rows_for_media_item(plan, &1),
+        max_concurrency: prediction_concurrency(plan),
+        ordered: true,
+        timeout: :infinity
+      )
+      |> Enum.flat_map(fn {:ok, rows} -> rows end)
+
+    source_rows = rows_for_source_artifacts(plan, source, media_items)
+
+    item_rows ++ source_rows
+  end
+
+  # Path prediction shells out to yt-dlp once per media item — a cold Python start
+  # each time, which serially dominates the scan. In :local mode every call is fully
+  # offline (`--load-info-json`), so we fan them out across schedulers. In network
+  # modes the metadata-missing fallback can hit YouTube, so we keep concurrency low
+  # to avoid tripping yt-dlp's rate limiting / bot detection.
+  defp prediction_concurrency(%{mode: :local}), do: max(System.schedulers_online(), 4)
+  defp prediction_concurrency(_plan), do: 2
+
+  # File extensions that unambiguously indicate an audio-only vs a video file.
+  # Ambiguous containers (webm, ogg, mkv can technically hold either) are left
+  # out of both sets so a mismatch only ever fires when we're certain.
+  @audio_exts ~w(mp3 m4a aac flac wav opus oga wma alac)
+  @video_exts ~w(mp4 mkv avi mov flv wmv m4v ts mpg mpeg 3gp)
+
+  # ---- Per-media-item rows ----
+
+  # "Online mode, plus" — an item always gets its normal move/backfill/delete
+  # rows (relocating and truing up the existing files offline), and in :full mode
+  # a format-mismatched item ALSO gets a re-download row. The moves put the current
+  # file in the right place with no bandwidth; the later re-download replaces it
+  # with the correct format at that same path (cleaning the stale one up itself).
+  defp rows_for_media_item(plan, media_item) do
+    path_rows(plan, media_item) ++ redownload_rows(plan, media_item)
+  end
+
+  defp redownload_rows(plan, media_item) do
+    case redownload_reason(plan, media_item) do
+      nil -> []
+      reason -> [item_row(plan, media_item, :redownload, "media", from_path: media_item.media_filepath, detail: reason)]
+    end
+  end
+
+  # Only in :full mode, and only for the format dimensions we can read straight
+  # off the on-disk extension (audio-vs-video, container) — no JSON parsing
+  # needed, and the extension reflects the real post-remux file.
+  defp redownload_reason(%{mode: :full}, media_item) do
+    profile = media_item.source.media_profile
+    actual_ext = media_item.media_filepath |> Path.extname() |> String.trim_leading(".") |> String.downcase()
+    audio_profile? = profile.preferred_resolution == :audio
+
+    cond do
+      actual_ext == "" -> nil
+      audio_profile? && actual_ext in @video_exts -> "Profile is Audio Only but the file is video (.#{actual_ext})"
+      !audio_profile? && actual_ext in @audio_exts -> "Profile is video but the file is audio-only (.#{actual_ext})"
+      true -> container_mismatch_reason(profile, audio_profile?, actual_ext)
+    end
+  end
+
+  defp redownload_reason(_plan, _media_item), do: nil
+
+  # A downloaded video is remuxed to `media_container` (or mp4 when unset); an
+  # audio download uses `media_container` when set (unset means yt-dlp keeps the
+  # native "best" audio container, which we can't predict, so no trigger there).
+  defp container_mismatch_reason(profile, audio_profile?, actual_ext) do
+    expected = expected_container(profile, audio_profile?)
+
+    cond do
+      is_nil(expected) -> nil
+      actual_ext == expected -> nil
+      true -> "File container .#{actual_ext} doesn't match the profile's .#{expected}"
+    end
+  end
+
+  defp expected_container(profile, true = _audio_profile?), do: normalize_container(profile.media_container)
+  defp expected_container(profile, false = _audio_profile?), do: normalize_container(profile.media_container) || "mp4"
+
+  defp normalize_container(nil), do: nil
+
+  defp normalize_container(container) do
+    case container |> to_string() |> String.trim() |> String.trim_leading(".") |> String.downcase() do
+      "" -> nil
+      normalized -> normalized
+    end
+  end
+
+  defp path_rows(plan, media_item) do
+    case predict_media_filepath(plan, media_item) do
+      {:ok, new_media_filepath} ->
+        media_move_rows(plan, media_item, new_media_filepath) ++
+          sidecar_rows(plan, media_item, Path.rootname(new_media_filepath))
+
+      {:error, :no_metadata} ->
+        [item_row(plan, media_item, :skip, "media", detail: no_metadata_detail(plan))]
+
+      {:error, message} ->
+        [item_row(plan, media_item, :skip, "media", detail: "Path prediction failed: #{message}")]
+    end
+  end
+
+  # Both :online and :full allow light network calls; :local never does
+  defp network_mode?(%{mode: mode}), do: mode in [:online, :full]
+
+  defp predict_media_filepath(plan, media_item) do
+    case PathPredictor.predict_media_filepath(media_item) do
+      {:error, :no_metadata} -> maybe_network_predict(plan, media_item)
+      result -> result
+    end
+  end
+
+  defp maybe_network_predict(plan, media_item) do
+    if network_mode?(plan) do
+      network_predict_media_filepath(media_item)
+    else
+      {:error, :no_metadata}
+    end
+  end
+
+  # Fallback for items missing their stored metadata blob: one metadata-only
+  # yt-dlp call (never the YouTube Data API) to render the filename remotely
+  defp network_predict_media_filepath(media_item) do
+    command_opts =
+      [output: DownloadOptionBuilder.build_output_path_for(media_item)] ++
+        DownloadOptionBuilder.build_quality_options_for(media_item.source)
+
+    addl_opts = [use_cookies: Sources.use_cookies?(media_item.source, :metadata)]
+
+    case YtDlpMedia.get_media_attributes(media_item.original_url, command_opts, addl_opts) do
+      {:ok, %YtDlpMedia{predicted_media_filepath: filepath}} when is_binary(filepath) ->
+        {:ok, Path.rootname(filepath) <> Path.extname(media_item.media_filepath)}
+
+      {:error, message, _exit_code} ->
+        {:error, to_string(message)}
+
+      {:error, message} ->
+        {:error, to_string(message)}
+
+      other ->
+        {:error, inspect(other)}
+    end
+  end
+
+  defp no_metadata_detail(%{mode: :local}) do
+    "No stored metadata to render the new path from — run in Online or Full sync mode to fetch it"
+  end
+
+  defp no_metadata_detail(_plan), do: "No stored metadata and the network fetch failed"
+
+  defp media_move_rows(plan, media_item, new_media_filepath) do
+    move_or_skip_rows(plan, media_item, "media", media_item.media_filepath, new_media_filepath)
+  end
+
+  defp sidecar_rows(plan, media_item, new_rootname) do
+    profile = media_item.source.media_profile
+
+    thumbnail_rows(plan, media_item, profile, new_rootname) ++
+      infojson_rows(plan, media_item, profile, new_rootname) ++
+      nfo_rows(plan, media_item, profile, new_rootname) ++
+      subtitle_rows(plan, media_item, profile, new_rootname)
+  end
+
+  defp thumbnail_rows(plan, media_item, %{download_thumbnail: true}, new_rootname) do
+    current = media_item.thumbnail_filepath
+
+    cond do
+      current && File.exists?(current) ->
+        move_or_skip_rows(plan, media_item, "thumbnail", current, new_rootname <> Path.extname(current))
+
+      network_mode?(plan) ->
+        [item_row(plan, media_item, :backfill, "thumbnail", to_path: new_rootname <> ".jpg", detail: "Fetch thumbnail")]
+
+      true ->
+        [item_row(plan, media_item, :skip, "thumbnail", detail: "Backfill requires Online or Full sync mode")]
+    end
+  end
+
+  defp thumbnail_rows(plan, media_item, _profile, _new_rootname) do
+    delete_rows(plan, media_item, "thumbnail", media_item.thumbnail_filepath)
+  end
+
+  defp infojson_rows(plan, media_item, %{download_metadata: true}, new_rootname) do
+    current = media_item.metadata_filepath
+    target = new_rootname <> ".info.json"
+
+    cond do
+      current && File.exists?(current) ->
+        move_or_skip_rows(plan, media_item, "metadata", current, target)
+
+      stored_metadata?(media_item) ->
+        [item_row(plan, media_item, :backfill, "metadata", to_path: target, detail: "Write from stored metadata")]
+
+      true ->
+        [item_row(plan, media_item, :skip, "metadata", detail: "No stored metadata to write the info.json from")]
+    end
+  end
+
+  defp infojson_rows(plan, media_item, _profile, _new_rootname) do
+    delete_rows(plan, media_item, "metadata", media_item.metadata_filepath)
+  end
+
+  defp nfo_rows(plan, media_item, %{download_nfo: true}, new_rootname) do
+    current = media_item.nfo_filepath
+    target = new_rootname <> ".nfo"
+
+    cond do
+      current && File.exists?(current) ->
+        move_or_skip_rows(plan, media_item, "nfo", current, target)
+
+      stored_metadata?(media_item) ->
+        [item_row(plan, media_item, :backfill, "nfo", to_path: target, detail: "Build from stored metadata")]
+
+      true ->
+        [item_row(plan, media_item, :skip, "nfo", detail: "No stored metadata to build the NFO from")]
+    end
+  end
+
+  defp nfo_rows(plan, media_item, _profile, _new_rootname) do
+    delete_rows(plan, media_item, "nfo", media_item.nfo_filepath)
+  end
+
+  defp subtitle_rows(plan, media_item, profile, new_rootname) do
+    subs_enabled = profile.download_subs || profile.download_auto_subs
+
+    case {subs_enabled, media_item.subtitle_filepaths} do
+      {true, []} ->
+        subtitle_backfill_rows(plan, media_item, profile, new_rootname)
+
+      {true, pairs} ->
+        Enum.flat_map(pairs, fn [lang, path] ->
+          target = "#{new_rootname}.#{lang}#{Path.extname(path)}"
+          move_or_skip_rows(plan, media_item, "subtitle:#{lang}", path, target)
+        end)
+
+      {false, pairs} ->
+        Enum.flat_map(pairs, fn [lang, path] -> delete_rows(plan, media_item, "subtitle:#{lang}", path) end)
+    end
+  end
+
+  defp subtitle_backfill_rows(plan, media_item, profile, new_rootname) do
+    if network_mode?(plan) do
+      [
+        item_row(plan, media_item, :backfill, "subtitles",
+          to_path: "#{new_rootname}.#{profile.sub_langs}.srt",
+          detail: "Fetch subtitles (#{profile.sub_langs})"
+        )
+      ]
+    else
+      [item_row(plan, media_item, :skip, "subtitles", detail: "Backfill requires Online or Full sync mode")]
+    end
+  end
+
+  defp stored_metadata?(%MediaItem{metadata: %{metadata_filepath: filepath}}) when is_binary(filepath) do
+    FSUtils.exists_and_nonempty?(filepath)
+  end
+
+  defp stored_metadata?(_media_item), do: false
+
+  # ---- Source-level artifact rows ----
+
+  defp rows_for_source_artifacts(plan, source, media_items) do
+    profile = source.media_profile
+
+    cond do
+      # Podcasts have no series directory — series-level artifacts left over from a
+      # previous media-center profile can't be placed anywhere, so they're removed
+      MediaProfile.podcast?(profile) ->
+        delete_all_source_artifacts(plan, source)
+
+      profile.download_nfo || profile.download_source_images || any_source_artifact?(source) ->
+        case predict_series_directory(media_items) do
+          {:ok, series_directory} -> source_artifact_rows(plan, source, series_directory)
+          {:error, _} -> source_artifact_error_rows(plan, source)
+        end
+
+      true ->
+        []
+    end
+  end
+
+  defp delete_all_source_artifacts(plan, source) do
+    delete_rows(plan, source, "source_nfo", source.nfo_filepath) ++ source_image_delete_rows(plan, source)
+  end
+
+  defp any_source_artifact?(source) do
+    Source.filepath_attributes()
+    |> Enum.any?(fn attr -> Map.get(source, attr) end)
+  end
+
+  defp predict_series_directory(media_items) do
+    sample = Enum.find(media_items, &stored_metadata?/1)
+
+    if sample do
+      PathPredictor.predict_series_directory(sample)
+    else
+      {:error, :no_metadata}
+    end
+  end
+
+  defp source_artifact_error_rows(plan, source) do
+    if any_source_artifact?(source) do
+      [source_row(plan, source, :skip, "series_directory", detail: "Could not determine the new series directory")]
+    else
+      []
+    end
+  end
+
+  defp source_artifact_rows(plan, source, series_directory) do
+    profile = source.media_profile
+
+    series_directory_rows(plan, source, series_directory) ++
+      source_nfo_rows(plan, source, profile, series_directory) ++
+      source_image_rows(plan, source, profile, series_directory)
+  end
+
+  # A record-only "move": the applier updates source.series_directory, no file op
+  defp series_directory_rows(plan, source, series_directory) do
+    if source.series_directory && source.series_directory != series_directory do
+      [
+        source_row(plan, source, :move, "series_directory",
+          from_path: source.series_directory,
+          to_path: series_directory,
+          detail: "Update the recorded series directory"
+        )
+      ]
+    else
+      []
+    end
+  end
+
+  defp source_nfo_rows(plan, source, %{download_nfo: true}, series_directory) do
+    current = source.nfo_filepath
+    target = Path.join(series_directory, "tvshow.nfo")
+
+    cond do
+      current && File.exists?(current) ->
+        move_or_skip_rows(plan, source, "source_nfo", current, target)
+
+      source_stored_metadata?(source) ->
+        [source_row(plan, source, :backfill, "source_nfo", to_path: target, detail: "Build from stored metadata")]
+
+      true ->
+        [source_row(plan, source, :skip, "source_nfo", detail: "No stored source metadata to build the NFO from")]
+    end
+  end
+
+  defp source_nfo_rows(plan, source, _profile, _series_directory) do
+    delete_rows(plan, source, "source_nfo", source.nfo_filepath)
+  end
+
+  defp source_image_rows(plan, source, %{download_source_images: true}, series_directory) do
+    recorded =
+      [:poster_filepath, :fanart_filepath, :banner_filepath]
+      |> Enum.map(fn attr -> {attr, Map.get(source, attr)} end)
+      |> Enum.filter(fn {_attr, path} -> path end)
+
+    any_missing_on_disk? = Enum.any?(recorded, fn {_attr, path} -> !File.exists?(path) end)
+
+    cond do
+      # Nothing recorded (e.g. images were just enabled) — fetch them all
+      recorded == [] ->
+        source_image_backfill_rows(plan, source)
+
+      # Some recorded artwork has vanished from disk. A metadata refresh both
+      # restores it and re-places every image under the new series directory,
+      # so it supersedes the individual moves. Only available with the network;
+      # in local mode we fall through to moving what's present and skipping the
+      # missing (via move_or_skip_rows).
+      any_missing_on_disk? && network_mode?(plan) ->
+        source_image_backfill_rows(plan, source)
+
+      true ->
+        Enum.flat_map(recorded, fn {attr, path} ->
+          attribute = "source_#{attr |> to_string() |> String.replace("_filepath", "")}"
+          move_or_skip_rows(plan, source, attribute, path, Path.join(series_directory, Path.basename(path)))
+        end)
+    end
+  end
+
+  defp source_image_rows(plan, source, _profile, _series_directory) do
+    source_image_delete_rows(plan, source)
+  end
+
+  defp source_image_delete_rows(plan, source) do
+    [:poster_filepath, :fanart_filepath, :banner_filepath]
+    |> Enum.flat_map(fn attr ->
+      attribute = "source_#{attr |> to_string() |> String.replace("_filepath", "")}"
+      delete_rows(plan, source, attribute, Map.get(source, attr))
+    end)
+  end
+
+  defp source_image_backfill_rows(plan, source) do
+    if network_mode?(plan) do
+      [source_row(plan, source, :backfill, "source_images", detail: "Fetch source images (runs Refresh Metadata)")]
+    else
+      [source_row(plan, source, :skip, "source_images", detail: "Backfill requires Online or Full sync mode")]
+    end
+  end
+
+  defp source_stored_metadata?(source) do
+    case Repo.preload(source, :metadata).metadata do
+      %{metadata_filepath: filepath} when is_binary(filepath) -> FSUtils.exists_and_nonempty?(filepath)
+      _ -> false
+    end
+  end
+
+  # ---- Shared row helpers ----
+
+  defp move_or_skip_rows(plan, record, attribute, from_path, to_path) do
+    cond do
+      from_path == to_path ->
+        []
+
+      !File.exists?(from_path) ->
+        [build_row(plan, record, :skip, attribute, from_path: from_path, detail: missing_on_disk_detail(attribute))]
+
+      File.exists?(to_path) && FSUtils.filepaths_reference_same_file?(from_path, to_path) ->
+        []
+
+      true ->
+        [build_row(plan, record, :move, attribute, from_path: from_path, to_path: to_path)]
+    end
+  end
+
+  defp missing_on_disk_detail("media"), do: "File missing on disk — run Sync Files on Disk first"
+  defp missing_on_disk_detail(_attribute), do: "File missing on disk"
+
+  defp delete_rows(plan, record, attribute, filepath) do
+    if filepath && File.exists?(filepath) do
+      [build_row(plan, record, :delete, attribute, from_path: filepath, detail: "Disabled in the media profile")]
+    else
+      []
+    end
+  end
+
+  defp item_row(plan, media_item, action, attribute, opts) do
+    build_row(plan, media_item, action, attribute, opts)
+  end
+
+  defp source_row(plan, source, action, attribute, opts) do
+    build_row(plan, source, action, attribute, opts)
+  end
+
+  defp build_row(plan, record, action, attribute, opts) do
+    {media_item_id, source_id} =
+      case record do
+        %MediaItem{} = mi -> {mi.id, mi.source_id}
+        %Source{} = s -> {nil, s.id}
+      end
+
+    %{
+      reconcile_plan_id: plan.id,
+      media_item_id: media_item_id,
+      source_id: source_id,
+      action: action,
+      attribute: attribute,
+      from_path: Keyword.get(opts, :from_path),
+      to_path: Keyword.get(opts, :to_path),
+      detail: Keyword.get(opts, :detail),
+      status: :planned
+    }
+  end
+
+  # ---- Collision detection ----
+
+  # A move/backfill whose target is already occupied on disk, or that shares a
+  # target with another row, becomes a collision (both sides). A target occupied
+  # by a file that this same plan would move away still counts — applying the
+  # plan and re-running reconcile resolves those chains one step at a time.
+  defp detect_collisions(rows) do
+    duplicate_targets =
+      rows
+      |> Enum.filter(&(&1.action in [:move, :backfill] && &1.to_path))
+      |> Enum.frequencies_by(& &1.to_path)
+      |> Enum.filter(fn {_target, count} -> count > 1 end)
+      |> MapSet.new(fn {target, _count} -> target end)
+
+    Enum.map(rows, fn row ->
+      cond do
+        row.action not in [:move, :backfill] || is_nil(row.to_path) || row.attribute == "series_directory" ->
+          row
+
+        MapSet.member?(duplicate_targets, row.to_path) ->
+          %{row | action: :collision, detail: "Multiple files resolve to this target path"}
+
+        # Applies to moves and backfills alike: an occupied target would be
+        # clobbered by the rename/copy or the write, so never touch it
+        File.exists?(row.to_path) ->
+          %{
+            row
+            | action: :collision,
+              detail: "Target path already occupied — if a planned move will free it, re-run after applying"
+          }
+
+        true ->
+          row
+      end
+    end)
+  end
+end

--- a/lib/pinchflat/reconciliation/reconcile_plan.ex
+++ b/lib/pinchflat/reconciliation/reconcile_plan.ex
@@ -1,0 +1,59 @@
+defmodule Pinchflat.Reconciliation.ReconcilePlan do
+  @moduledoc """
+  A reconcile plan is one dry-run of the file reconciliation ("true-up") process:
+  the full set of moves, backfills, and deletions that would bring already-downloaded
+  files in line with the current path-affecting settings. Plans are persisted so the
+  user reviews exactly what a later apply will execute.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Pinchflat.Sources.Source
+  alias Pinchflat.Reconciliation.ReconcilePlanItem
+
+  @allowed_fields ~w(
+    mode
+    source_id
+    status
+    move_count
+    backfill_count
+    delete_count
+    redownload_count
+    skip_count
+    collision_count
+    error_count
+    applied_at
+    error_message
+  )a
+
+  @required_fields ~w(mode status)a
+
+  schema "reconcile_plans" do
+    field :mode, Ecto.Enum, values: [:local, :online, :full], default: :local
+    field :status, Ecto.Enum, values: ~w(building ready applying applied failed stale)a, default: :building
+
+    field :move_count, :integer, default: 0
+    field :backfill_count, :integer, default: 0
+    field :delete_count, :integer, default: 0
+    field :redownload_count, :integer, default: 0
+    field :skip_count, :integer, default: 0
+    field :collision_count, :integer, default: 0
+    field :error_count, :integer, default: 0
+
+    field :applied_at, :utc_datetime
+    field :error_message, :string
+
+    belongs_to :source, Source
+    has_many :reconcile_plan_items, ReconcilePlanItem
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(reconcile_plan, attrs) do
+    reconcile_plan
+    |> cast(attrs, @allowed_fields)
+    |> validate_required(@required_fields)
+  end
+end

--- a/lib/pinchflat/reconciliation/reconcile_plan_item.ex
+++ b/lib/pinchflat/reconciliation/reconcile_plan_item.ex
@@ -1,0 +1,52 @@
+defmodule Pinchflat.Reconciliation.ReconcilePlanItem do
+  @moduledoc """
+  One planned action within a reconcile plan: move/backfill/delete a single file
+  (or record why it was skipped). `media_item_id` is null for source-level artifact
+  rows (series NFO/images); `attribute` names which file the row is about.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Pinchflat.Media.MediaItem
+  alias Pinchflat.Sources.Source
+  alias Pinchflat.Reconciliation.ReconcilePlan
+
+  @allowed_fields ~w(
+    reconcile_plan_id
+    media_item_id
+    source_id
+    action
+    attribute
+    from_path
+    to_path
+    status
+    detail
+  )a
+
+  @required_fields ~w(reconcile_plan_id action attribute)a
+
+  schema "reconcile_plan_items" do
+    field :action, Ecto.Enum, values: ~w(move backfill delete redownload skip collision)a
+    # e.g. "media", "thumbnail", "nfo", "metadata", "subtitle:en",
+    # "source_nfo", "source_poster", "source_fanart", "source_banner"
+    field :attribute, :string
+    field :from_path, :string
+    field :to_path, :string
+    field :status, Ecto.Enum, values: ~w(planned done skipped failed)a, default: :planned
+    field :detail, :string
+
+    belongs_to :reconcile_plan, ReconcilePlan
+    belongs_to :media_item, MediaItem
+    belongs_to :source, Source
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(reconcile_plan_item, attrs) do
+    reconcile_plan_item
+    |> cast(attrs, @allowed_fields)
+    |> validate_required(@required_fields)
+  end
+end

--- a/lib/pinchflat/reconciliation/reconcile_worker.ex
+++ b/lib/pinchflat/reconciliation/reconcile_worker.ex
@@ -1,0 +1,183 @@
+defmodule Pinchflat.Reconciliation.ReconcileWorker do
+  @moduledoc false
+
+  use Oban.Worker,
+    queue: :local_data,
+    # Dedupe on worker alone (not args) so a build and an apply can't run
+    # alongside each other — either would invalidate the other's view of disk
+    unique: [period: :infinity, states: :incomplete, fields: [:worker, :queue]],
+    max_attempts: 1,
+    tags: ["local_data", "reconciliation", "show_in_dashboard"]
+
+  import Ecto.Query, warn: false
+
+  require Logger
+
+  alias __MODULE__
+  alias Pinchflat.Repo
+  alias Pinchflat.Tasks
+  alias Pinchflat.Sources
+  alias Pinchflat.Reconciliation
+  alias Pinchflat.Reconciliation.PlanBuilder
+  alias Pinchflat.Reconciliation.PlanApplier
+  alias Pinchflat.Diagnostics.QueueDiagnostics
+
+  @doc """
+  Enqueues a dry-run plan build. Any still-reviewable older plans are marked
+  stale first — only the newest plan can be applied. When scoped to a source,
+  the job is linked to it via a Task so it shows in the source's task list.
+
+  Returns {:ok, %Oban.Job{} | %Task{}} | {:error, :duplicate_job} | {:error, %Ecto.Changeset{}}
+  """
+  def kickoff_build(mode, source \\ nil) do
+    Reconciliation.mark_ready_plans_stale()
+
+    {:ok, plan} =
+      Reconciliation.create_plan(%{
+        mode: mode,
+        source_id: source && source.id,
+        status: :building
+      })
+
+    args = %{"op" => "build", "plan_id" => plan.id}
+
+    result =
+      if source do
+        args |> ReconcileWorker.new() |> Tasks.create_job_with_task(source)
+      else
+        Repo.insert_unique_job(ReconcileWorker.new(args))
+      end
+
+    # A deduped/failed insert would otherwise strand the plan in `building`
+    case result do
+      {:ok, _} -> result
+      {:duplicate, _job} -> handle_failed_insert(plan, {:error, :duplicate_job})
+      err -> handle_failed_insert(plan, err)
+    end
+  end
+
+  defp handle_failed_insert(plan, err) do
+    Repo.delete(plan)
+    err
+  end
+
+  @doc """
+  Enqueues the apply run for a reviewed (ready) plan.
+
+  Returns {:ok, %Oban.Job{} | %Task{}} | {:error, :duplicate_job | :not_ready} | {:error, %Ecto.Changeset{}}
+  """
+  def kickoff_apply(plan) do
+    if plan.status == :ready do
+      args = %{"op" => "apply", "plan_id" => plan.id}
+      source = plan.source_id && Sources.get_source!(plan.source_id)
+
+      result =
+        if source do
+          args |> ReconcileWorker.new() |> Tasks.create_job_with_task(source)
+        else
+          Repo.insert_unique_job(ReconcileWorker.new(args))
+        end
+
+      case result do
+        {:duplicate, _job} -> {:error, :duplicate_job}
+        other -> other
+      end
+    else
+      {:error, :not_ready}
+    end
+  end
+
+  @doc """
+  Builds a plan's items (the dry run — read-only on the filesystem) or applies
+  a reviewed plan. Applying reserves a quiet window first: all job queues are
+  paused and the worker waits for other executing jobs to finish, so nothing
+  can race the file moves and `*_filepath` column updates. Queues are resumed
+  in an `after` block, and pause state is in-memory so a crash can't leave
+  them stuck paused.
+
+  Returns :ok | {:cancel, binary()} | {:error, any()}
+  """
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"op" => "build", "plan_id" => plan_id}}) do
+    plan = Reconciliation.get_plan!(plan_id)
+
+    case PlanBuilder.build_plan_items(plan) do
+      {:ok, built_plan} ->
+        {:ok, _} = Reconciliation.update_plan(built_plan, %{status: :ready})
+        :ok
+
+      err ->
+        {:ok, _} = Reconciliation.update_plan(plan, %{status: :failed, error_message: inspect(err)})
+        {:error, err}
+    end
+  rescue
+    exception ->
+      record_plan_failure(plan_id, exception, __STACKTRACE__)
+  end
+
+  def perform(%Oban.Job{args: %{"op" => "apply", "plan_id" => plan_id}, id: job_id}) do
+    plan = Reconciliation.get_plan!(plan_id)
+
+    if plan.status == :ready do
+      {:ok, _} = Reconciliation.update_plan(plan, %{status: :applying})
+
+      with_paused_queues(fn ->
+        wait_for_other_running_jobs(job_id)
+        {:ok, _} = PlanApplier.apply_plan(plan)
+      end)
+
+      :ok
+    else
+      {:cancel, "Plan ##{plan_id} is #{plan.status} — only a ready plan can be applied"}
+    end
+  rescue
+    exception ->
+      record_plan_failure(plan_id, exception, __STACKTRACE__)
+  end
+
+  defp record_plan_failure(plan_id, exception, stacktrace) do
+    message = Exception.message(exception)
+    Logger.error("Reconcile failed for plan ##{plan_id}: #{Exception.format(:error, exception, stacktrace)}")
+
+    plan = Repo.get(Reconciliation.ReconcilePlan, plan_id)
+
+    if plan do
+      {:ok, _} = Reconciliation.update_plan(plan, %{status: :failed, error_message: message})
+    end
+
+    {:error, message}
+  end
+
+  # Pausing stops queues from starting new jobs but lets executing ones run to
+  # completion; resuming in `after` covers apply failures. Mirrors
+  # DatabaseMaintenanceWorker's quiet-window reservation.
+  defp with_paused_queues(fun) do
+    queues = QueueDiagnostics.queue_names()
+
+    Enum.each(queues, &Oban.pause_queue(queue: &1))
+
+    try do
+      fun.()
+    after
+      Enum.each(queues, &Oban.resume_queue(queue: &1))
+    end
+  end
+
+  defp wait_for_other_running_jobs(job_id) do
+    if other_jobs_running?(job_id) do
+      Logger.info("Reconcile is waiting for running jobs to finish before moving files")
+      Process.sleep(Application.get_env(:pinchflat, :db_maintenance_poll_interval))
+      wait_for_other_running_jobs(job_id)
+    else
+      :ok
+    end
+  end
+
+  # The job ID is nil when run via `Oban.Testing.perform_job/2`
+  defp other_jobs_running?(job_id) do
+    from(j in Oban.Job, where: j.state == "executing")
+    |> then(fn query -> if job_id, do: where(query, [j], j.id != ^job_id), else: query end)
+    |> Repo.aggregate(:count)
+    |> Kernel.>(0)
+  end
+end

--- a/lib/pinchflat/reconciliation/reconcile_worker.ex
+++ b/lib/pinchflat/reconciliation/reconcile_worker.ex
@@ -118,7 +118,11 @@ defmodule Pinchflat.Reconciliation.ReconcileWorker do
   def perform(%Oban.Job{args: %{"op" => "apply", "plan_id" => plan_id}, id: job_id}) do
     plan = Reconciliation.get_plan!(plan_id)
 
-    if plan.status == :ready do
+    # `:applying` means a previous run was interrupted (eg: an ungraceful shutdown
+    # left the plan mid-apply). Resuming is safe: `apply_plan/1` only touches rows
+    # still `:planned` and skips anything stale, so it finishes exactly the work the
+    # interrupted run didn't reach without redoing what already landed.
+    if plan.status in [:ready, :applying] do
       {:ok, _} = Reconciliation.update_plan(plan, %{status: :applying})
 
       with_paused_queues(fn ->
@@ -128,7 +132,7 @@ defmodule Pinchflat.Reconciliation.ReconcileWorker do
 
       :ok
     else
-      {:cancel, "Plan ##{plan_id} is #{plan.status} — only a ready plan can be applied"}
+      {:cancel, "Plan ##{plan_id} is #{plan.status} — only a ready or resuming plan can be applied"}
     end
   rescue
     exception ->

--- a/lib/pinchflat/reconciliation/reconcile_worker.ex
+++ b/lib/pinchflat/reconciliation/reconcile_worker.ex
@@ -2,12 +2,16 @@ defmodule Pinchflat.Reconciliation.ReconcileWorker do
   @moduledoc false
 
   use Oban.Worker,
-    queue: :local_data,
+    # Reconciliation and database maintenance both pause every queue and wait
+    # for executing jobs. They must share this single-concurrency queue: if
+    # they started together, each would see the other as executing and wait
+    # forever.
+    queue: :maintenance,
     # Dedupe on worker alone (not args) so a build and an apply can't run
     # alongside each other — either would invalidate the other's view of disk
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :queue]],
     max_attempts: 1,
-    tags: ["local_data", "reconciliation", "show_in_dashboard"]
+    tags: ["maintenance", "reconciliation", "show_in_dashboard"]
 
   import Ecto.Query, warn: false
 

--- a/lib/pinchflat/reconciliation/reconciliation.ex
+++ b/lib/pinchflat/reconciliation/reconciliation.ex
@@ -1,0 +1,175 @@
+defmodule Pinchflat.Reconciliation do
+  @moduledoc """
+  The Reconciliation context: persisting and querying reconcile plans (dry-run
+  reports of file moves/backfills/deletions) and their items. The heavy lifting
+  lives in `PlanBuilder` (dry run) and `PlanApplier` (execution).
+  """
+
+  import Ecto.Query, warn: false
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Reconciliation.ReconcilePlan
+  alias Pinchflat.Reconciliation.ReconcilePlanItem
+
+  # Old plans are pruned down to this many whenever a new plan is created
+  @plans_to_keep 10
+
+  @doc """
+  Creates a reconcile plan, pruning old plans beyond the retention limit.
+
+  Returns {:ok, %ReconcilePlan{}} | {:error, %Ecto.Changeset{}}
+  """
+  def create_plan(attrs) do
+    result =
+      %ReconcilePlan{}
+      |> ReconcilePlan.changeset(attrs)
+      |> Repo.insert()
+
+    case result do
+      {:ok, _plan} ->
+        prune_old_plans()
+        result
+
+      err ->
+        err
+    end
+  end
+
+  @doc """
+  Updates a reconcile plan.
+
+  Returns {:ok, %ReconcilePlan{}} | {:error, %Ecto.Changeset{}}
+  """
+  def update_plan(%ReconcilePlan{} = plan, attrs) do
+    plan
+    |> ReconcilePlan.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Gets a single reconcile plan.
+
+  Returns %ReconcilePlan{}. Raises `Ecto.NoResultsError` if it does not exist.
+  """
+  def get_plan!(id), do: Repo.get!(ReconcilePlan, id)
+
+  @doc """
+  Returns the most recently created plan (any status), or nil.
+  """
+  def latest_plan do
+    ReconcilePlan
+    |> order_by(desc: :id)
+    |> limit(1)
+    |> Repo.one()
+  end
+
+  @doc """
+  Returns recent plans, newest first.
+  """
+  def list_plans(limit \\ @plans_to_keep) do
+    ReconcilePlan
+    |> order_by(desc: :id)
+    |> limit(^limit)
+    |> Repo.all()
+  end
+
+  @doc """
+  Bulk-inserts plan items. Attrs maps must contain action/attribute/reconcile_plan_id;
+  timestamps are filled in here since `insert_all` doesn't.
+
+  Returns the number of inserted rows.
+  """
+  def create_plan_items(attrs_list) when is_list(attrs_list) do
+    now = DateTime.utc_now(:second)
+
+    attrs_list
+    |> Enum.map(&Map.merge(&1, %{inserted_at: now, updated_at: now}))
+    |> Enum.chunk_every(200)
+    |> Enum.reduce(0, fn chunk, acc ->
+      {count, _} = Repo.insert_all(ReconcilePlanItem, chunk)
+      acc + count
+    end)
+  end
+
+  @doc """
+  Updates a single plan item.
+
+  Returns {:ok, %ReconcilePlanItem{}} | {:error, %Ecto.Changeset{}}
+  """
+  def update_plan_item(%ReconcilePlanItem{} = item, attrs) do
+    item
+    |> ReconcilePlanItem.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  A composable query for a plan's items, optionally filtered to one action,
+  ordered stably for pagination.
+  """
+  def plan_items_query(%ReconcilePlan{} = plan, action \\ nil) do
+    ReconcilePlanItem
+    |> where(reconcile_plan_id: ^plan.id)
+    |> then(fn query ->
+      if action, do: where(query, action: ^action), else: query
+    end)
+    |> order_by(asc: :id)
+  end
+
+  @doc """
+  Returns the plan's items grouped as %{action => count}.
+  """
+  def count_plan_items_by_action(%ReconcilePlan{} = plan) do
+    ReconcilePlanItem
+    |> where(reconcile_plan_id: ^plan.id)
+    |> group_by(:action)
+    |> select([rpi], {rpi.action, count(rpi.id)})
+    |> Repo.all()
+    |> Map.new()
+  end
+
+  @doc """
+  Recomputes and stores the plan's per-action counts from its items.
+
+  Returns {:ok, %ReconcilePlan{}}
+  """
+  def refresh_plan_counts(%ReconcilePlan{} = plan) do
+    counts = count_plan_items_by_action(plan)
+
+    update_plan(plan, %{
+      move_count: Map.get(counts, :move, 0),
+      backfill_count: Map.get(counts, :backfill, 0),
+      delete_count: Map.get(counts, :delete, 0),
+      redownload_count: Map.get(counts, :redownload, 0),
+      skip_count: Map.get(counts, :skip, 0),
+      collision_count: Map.get(counts, :collision, 0)
+    })
+  end
+
+  @doc """
+  Marks any still-reviewable (ready) plans as stale. Used when a new plan
+  supersedes them or path-affecting records change.
+
+  Returns the number of plans marked.
+  """
+  def mark_ready_plans_stale do
+    {count, _} =
+      ReconcilePlan
+      |> where(status: :ready)
+      |> Repo.update_all(set: [status: "stale"])
+
+    count
+  end
+
+  defp prune_old_plans do
+    keeper_ids =
+      ReconcilePlan
+      |> order_by(desc: :id)
+      |> limit(@plans_to_keep)
+      |> select([rp], rp.id)
+      |> Repo.all()
+
+    ReconcilePlan
+    |> where([rp], rp.id not in ^keeper_ids)
+    |> Repo.delete_all()
+  end
+end

--- a/lib/pinchflat/reconciliation/reconciliation.ex
+++ b/lib/pinchflat/reconciliation/reconciliation.ex
@@ -145,6 +145,30 @@ defmodule Pinchflat.Reconciliation do
     })
   end
 
+  # Rows that `PlanApplier` actually executes (skip/collision rows are reported
+  # only), so apply progress is measured against these.
+  @applyable_actions ~w(move backfill delete redownload)a
+
+  @doc """
+  Apply progress for a plan: how many applyable rows have been processed
+  (marked done/skipped/failed) out of the total, plus the rounded percentage.
+  `total` is 0 for a plan with nothing to apply, in which case `percent` is 100.
+
+  Returns %{processed: integer(), total: integer(), percent: integer()}
+  """
+  def apply_progress(%ReconcilePlan{} = plan) do
+    base =
+      ReconcilePlanItem
+      |> where(reconcile_plan_id: ^plan.id)
+      |> where([rpi], rpi.action in ^@applyable_actions)
+
+    total = Repo.aggregate(base, :count, :id)
+    processed = base |> where([rpi], rpi.status != :planned) |> Repo.aggregate(:count, :id)
+    percent = if total > 0, do: round(processed / total * 100), else: 100
+
+    %{processed: processed, total: total, percent: percent}
+  end
+
   @doc """
   Marks any still-reviewable (ready) plans as stale. Used when a new plan
   supersedes them or path-affecting records change.

--- a/lib/pinchflat/settings/setting.ex
+++ b/lib/pinchflat/settings/setting.ex
@@ -25,6 +25,7 @@ defmodule Pinchflat.Settings.Setting do
     :download_throughput_limit,
     :restrict_filenames,
     :ignore_unavailable_media,
+    :database_maintenance_enabled,
     :default_cookie_behaviour,
     :time_format
   ]
@@ -57,6 +58,7 @@ defmodule Pinchflat.Settings.Setting do
     field :download_throughput_limit, :string
     field :restrict_filenames, :boolean, default: false
     field :ignore_unavailable_media, :boolean, default: false
+    field :database_maintenance_enabled, :boolean, default: false
 
     # The cookie behaviour pre-selected when adding a new source:
     # "disabled" | "when_needed" | "all_operations"

--- a/lib/pinchflat/utils/filesystem_utils.ex
+++ b/lib/pinchflat/utils/filesystem_utils.ex
@@ -104,6 +104,40 @@ defmodule Pinchflat.Utils.FilesystemUtils do
   end
 
   @doc """
+  Moves a file, creating the destination's directories as needed and pruning
+  any directories the move left empty. Falls back to copy+delete when the
+  destination is on a different filesystem (`File.rename/2` returns :exdev,
+  e.g. a podcast library on its own volume).
+
+  Returns :ok | {:error, any()}
+  """
+  def move_p(source, destination) do
+    with :ok <- destination |> Path.dirname() |> File.mkdir_p(),
+         :ok <- rename_or_copy(source, destination) do
+      source
+      |> Path.dirname()
+      |> recursively_delete_empty_directories()
+
+      :ok
+    end
+  end
+
+  defp rename_or_copy(source, destination) do
+    case File.rename(source, destination) do
+      :ok ->
+        :ok
+
+      {:error, :exdev} ->
+        with {:ok, _bytes} <- File.copy(source, destination) do
+          File.rm(source)
+        end
+
+      err ->
+        err
+    end
+  end
+
+  @doc """
   Fetches the file size of a media item and saves it to the database.
 
   Returns {:ok, media_item} | {:error, any()}

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -77,6 +77,24 @@ defmodule Pinchflat.YtDlp.Media do
   end
 
   @doc """
+  Downloads subtitles for a single piece of media without downloading the media
+  itself. Used to backfill subtitle sidecars for already-downloaded media.
+
+  Like `download_thumbnail/3`, this runs with `--skip-download`, so there is no
+  media file move to trigger `after_move` output — yt-dlp writes the subtitle
+  files and exits 0 with an empty response. The raw runner result is returned
+  rather than decoded as JSON (decoding an empty response would fail even though
+  the fetch succeeded).
+
+  Returns {:ok, ""} | {:error, any, ...}.
+  """
+  def download_subtitles(url, command_opts \\ [], addl_opts \\ []) do
+    all_command_opts = [:no_simulate, :skip_download, :write_subs, convert_subs: "srt"] ++ command_opts
+
+    backend_runner().run(url, :download_subtitles, all_command_opts, "after_move:%()j", addl_opts)
+  end
+
+  @doc """
   Returns a map representing the media at the given URL.
   Optionally takes a list of additional command options to pass to yt-dlp
   or configuration-related options to pass to the runner.
@@ -91,6 +109,27 @@ defmodule Pinchflat.YtDlp.Media do
            backend_runner().run(url, :get_media_attributes, all_command_opts, output_template, addl_opts),
          {:ok, parsed_json} <- ResponseDecoder.decode(output, :get_media_attributes) do
       {:ok, response_to_struct(parsed_json)}
+    end
+  end
+
+  @doc """
+  Renders the filename a media item would download to under the given output
+  template, using a previously-stored info.json instead of the network. yt-dlp
+  ignores positional URLs when `--load-info-json` is set, so the URL here is
+  informational only (logging/debugging) — no request is made. Sanitization
+  (`--windows-filenames`, the `restrict_filenames` setting) is applied by yt-dlp
+  itself exactly as it would be on a real download.
+
+  Returns {:ok, binary()} | {:error, any, ...}.
+  """
+  def predict_filepath_from_metadata(url, info_json_filepath, command_opts \\ [], addl_opts \\ []) do
+    action = :predict_filepath_from_metadata
+    all_command_opts = [:simulate, :skip_download, load_info_json: info_json_filepath] ++ command_opts
+    runner_opts = Keyword.put_new(addl_opts, :skip_sleep_interval, true)
+
+    with {:ok, output} <- backend_runner().run(url, action, all_command_opts, "%(.{filename})j", runner_opts),
+         {:ok, parsed_json} <- ResponseDecoder.decode(output, action) do
+      {:ok, parsed_json["filename"]}
     end
   end
 

--- a/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
+++ b/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
@@ -28,7 +28,6 @@
       <button class="block lg:hidden" @click.stop="sidebarVisible = !sidebarVisible">
         <.icon name="hero-arrow-left" class="fill-current" />
       </button>
-<<<<<<< HEAD
       <button
         type="button"
         class="theme-outline-button hidden p-1.5 text-theme-on-surface lg:block"
@@ -42,31 +41,6 @@
           x-bind:class="sidebarCollapsed ? 'rotate-180' : ''"
         />
       </button>
-=======
-    </div>
-    <div class="no-scrollbar flex flex-col overflow-y-auto duration-300 ease-linear">
-      <nav class="mt-3 px-4 py-4 lg:px-6">
-        <h3 class="mb-4 ml-4 text-sm font-medium text-bodydark2">
-          <span>MENU</span>
-        </h3>
-        <div class="flex flex-col justify-between">
-          <ul class="mb-6 flex flex-col gap-1.5">
-            <.sidebar_item icon="hero-home" text="Home" href={~p"/"} />
-            <.sidebar_item icon="hero-tv" text="Sources" href={~p"/sources"} />
-            <.sidebar_item icon="hero-adjustments-vertical" text="Media Profiles" href={~p"/media_profiles"} />
-            <.sidebar_submenu
-              icon="hero-cog-6-tooth"
-              text="Tools"
-              current_path={Phoenix.Controller.current_path(@conn)}
-            >
-              <:submenu text="Settings" href={~p"/settings"} />
-              <:submenu text="Reconcile" href={~p"/reconciliation"} />
-              <:submenu text="Diagnostics" href={~p"/diagnostics"} />
-            </.sidebar_submenu>
-          </ul>
-        </div>
-      </nav>
->>>>>>> ad2a66e (feat: relocate and true up downloaded files after settings changes, without re-downloading)
     </div>
   </section>
 
@@ -98,7 +72,7 @@
             current_path={current_path}
           >
             <:submenu text="Settings" href={~p"/settings"} />
-            <:submenu text="File Reconciliation" href={~p"/settings/reconciliation"} />
+            <:submenu text="File Reconciliation" href={~p"/reconciliation"} />
             <:submenu text="Diagnostics" href={~p"/diagnostics"} />
           </.sidebar_submenu>
         </ul>

--- a/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
+++ b/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
@@ -28,6 +28,7 @@
       <button class="block lg:hidden" @click.stop="sidebarVisible = !sidebarVisible">
         <.icon name="hero-arrow-left" class="fill-current" />
       </button>
+<<<<<<< HEAD
       <button
         type="button"
         class="theme-outline-button hidden p-1.5 text-theme-on-surface lg:block"
@@ -41,6 +42,31 @@
           x-bind:class="sidebarCollapsed ? 'rotate-180' : ''"
         />
       </button>
+=======
+    </div>
+    <div class="no-scrollbar flex flex-col overflow-y-auto duration-300 ease-linear">
+      <nav class="mt-3 px-4 py-4 lg:px-6">
+        <h3 class="mb-4 ml-4 text-sm font-medium text-bodydark2">
+          <span>MENU</span>
+        </h3>
+        <div class="flex flex-col justify-between">
+          <ul class="mb-6 flex flex-col gap-1.5">
+            <.sidebar_item icon="hero-home" text="Home" href={~p"/"} />
+            <.sidebar_item icon="hero-tv" text="Sources" href={~p"/sources"} />
+            <.sidebar_item icon="hero-adjustments-vertical" text="Media Profiles" href={~p"/media_profiles"} />
+            <.sidebar_submenu
+              icon="hero-cog-6-tooth"
+              text="Tools"
+              current_path={Phoenix.Controller.current_path(@conn)}
+            >
+              <:submenu text="Settings" href={~p"/settings"} />
+              <:submenu text="Reconcile" href={~p"/reconciliation"} />
+              <:submenu text="Diagnostics" href={~p"/diagnostics"} />
+            </.sidebar_submenu>
+          </ul>
+        </div>
+      </nav>
+>>>>>>> ad2a66e (feat: relocate and true up downloaded files after settings changes, without re-downloading)
     </div>
   </section>
 
@@ -71,7 +97,9 @@
             text="Config"
             current_path={current_path}
           >
-            <:submenu text="Settings" href={~p"/settings"} /> <:submenu text="Diagnostics" href={~p"/diagnostics"} />
+            <:submenu text="Settings" href={~p"/settings"} />
+            <:submenu text="File Reconciliation" href={~p"/settings/reconciliation"} />
+            <:submenu text="Diagnostics" href={~p"/diagnostics"} />
           </.sidebar_submenu>
         </ul>
       </div>

--- a/lib/pinchflat_web/controllers/media_profiles/media_profile_controller.ex
+++ b/lib/pinchflat_web/controllers/media_profiles/media_profile_controller.ex
@@ -5,6 +5,7 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileController do
 
   alias Pinchflat.Repo
   alias Pinchflat.Profiles
+  alias Pinchflat.Reconciliation
   alias Pinchflat.Sources.Source
   alias Pinchflat.Profiles.MediaProfile
   alias Pinchflat.Profiles.MediaProfileDeletionWorker
@@ -93,6 +94,9 @@ defmodule PinchflatWeb.MediaProfiles.MediaProfileController do
 
     case Profiles.update_media_profile(media_profile, media_profile_params) do
       {:ok, media_profile} ->
+        # Profile changes can alter predicted paths, invalidating any staged reconcile plan
+        Reconciliation.mark_ready_plans_stale()
+
         conn
         |> put_flash(:info, "Media profile updated successfully.")
         |> redirect(to: ~p"/media_profiles/#{media_profile}")

--- a/lib/pinchflat_web/controllers/pages/page_html/job_table_live.ex
+++ b/lib/pinchflat_web/controllers/pages/page_html/job_table_live.ex
@@ -263,6 +263,7 @@ defmodule Pinchflat.Pages.JobTableLive do
   defp map_worker_to_task_name("MediaCollectionIndexingWorker"), do: "Indexing Source"
   defp map_worker_to_task_name("MediaQualityUpgradeWorker"), do: "Upgrading Media Quality"
   defp map_worker_to_task_name("SourceMetadataStorageWorker"), do: "Fetching Source Metadata"
+  defp map_worker_to_task_name("ReconcileWorker"), do: "File Reconciliation"
   defp map_worker_to_task_name(other), do: other <> " (Report to Devs)"
 
   defp task_to_record_name(%Task{} = task) do

--- a/lib/pinchflat_web/controllers/settings/diagnostics_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_controller.ex
@@ -1,7 +1,9 @@
 defmodule PinchflatWeb.Settings.DiagnosticsController do
   use PinchflatWeb, :controller
 
+  alias Pinchflat.Settings
   alias Pinchflat.Diagnostics.QueueDiagnostics
+  alias Pinchflat.Diagnostics.DatabaseMaintenanceWorker
 
   def show(conn, _params) do
     render(conn, "show.html")
@@ -64,6 +66,41 @@ defmodule PinchflatWeb.Settings.DiagnosticsController do
         |> put_flash(:error, "Job ##{job_id} could not be deleted. Only discarded jobs can be deleted.")
         |> redirect(to: ~p"/diagnostics")
     end
+  end
+
+  def vacuum_database(conn, _params) do
+    case DatabaseMaintenanceWorker.kickoff() do
+      {:ok, %Oban.Job{conflict?: true}} ->
+        conn
+        |> put_flash(:info, "A database compaction is already queued or running.")
+        |> redirect(to: ~p"/diagnostics")
+
+      {:ok, _job} ->
+        conn
+        |> put_flash(:info, "Database compaction queued. Its progress and outcome will show in the Database section.")
+        |> redirect(to: ~p"/diagnostics")
+
+      {:error, _changeset} ->
+        conn
+        |> put_flash(:error, "Could not queue the database compaction job.")
+        |> redirect(to: ~p"/diagnostics")
+    end
+  end
+
+  def toggle_scheduled_compaction(conn, _params) do
+    now_enabled = !Settings.get!(:database_maintenance_enabled)
+    Settings.set(database_maintenance_enabled: now_enabled)
+
+    message =
+      if now_enabled do
+        "Scheduled compaction turned on. It runs monthly on the 1st at 03:00."
+      else
+        "Scheduled compaction turned off. You can still compact manually with the Compact Now button."
+      end
+
+    conn
+    |> put_flash(:info, message)
+    |> redirect(to: ~p"/diagnostics")
   end
 
   # Guards against non-integer ids in the URL (which would otherwise raise).

--- a/lib/pinchflat_web/controllers/settings/diagnostics_html.ex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_html.ex
@@ -68,28 +68,28 @@ defmodule PinchflatWeb.Settings.DiagnosticsHTML do
     ~H"""
     <%= case @job do %>
       <% nil -> %>
-        <span class="text-bodydark">
+        <span class="text-theme-on-surface-muted">
           Never run. Compaction runs monthly on a schedule, or on demand via the Compact Now button.
         </span>
       <% %{state: "completed"} = job -> %>
-        <span class="text-green-400">
+        <span class="theme-status-success">
           Succeeded at {format_datetime(job.completed_at)}, reclaimed {format_bytes(job.meta["reclaimed_bytes"] || 0)}.
         </span>
       <% %{state: state} = job when state in ["retryable", "discarded"] -> %>
-        <span class="text-red-400">
+        <span class="theme-status-error">
           Failed at {format_datetime(job.attempted_at)}: {extract_last_error(job.errors)}
         </span>
-        <span class="text-bodydark">
+        <span class="text-theme-on-surface-muted">
           {if state == "retryable",
             do: "It will be retried automatically — see Failed Jobs below.",
             else: "It has exhausted its retries — see the Discarded tab under Failed Jobs below."}
         </span>
       <% %{state: "executing"} = job -> %>
-        <span class="text-blue-400">
+        <span class="text-theme-primary">
           In progress since {format_datetime(job.attempted_at)} — waiting for running jobs to finish, then compacting.
         </span>
       <% %{state: "cancelled"} = job -> %>
-        <span class="text-bodydark">
+        <span class="text-theme-on-surface-muted">
           Skipped at {format_datetime(job.cancelled_at)} — {extract_last_error(job.errors)}
         </span>
       <% job -> %>

--- a/lib/pinchflat_web/controllers/settings/diagnostics_html.ex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_html.ex
@@ -3,6 +3,7 @@ defmodule PinchflatWeb.Settings.DiagnosticsHTML do
 
   alias Pinchflat.Settings
   alias Pinchflat.Diagnostics.QueueDiagnostics
+  alias Pinchflat.Diagnostics.DatabaseDiagnostics
 
   embed_templates "diagnostics_html/*"
 
@@ -24,6 +25,77 @@ defmodule PinchflatWeb.Settings.DiagnosticsHTML do
 
   def system_stats do
     QueueDiagnostics.get_system_stats()
+  end
+
+  def database_stats do
+    DatabaseDiagnostics.get_database_stats()
+  end
+
+  def table_row_counts do
+    DatabaseDiagnostics.table_row_counts()
+  end
+
+  def orphaned_task_count do
+    DatabaseDiagnostics.orphaned_task_count()
+  end
+
+  def latest_maintenance_job do
+    DatabaseDiagnostics.latest_maintenance_job()
+  end
+
+  def scheduled_compaction_enabled? do
+    Settings.get!(:database_maintenance_enabled)
+  end
+
+  def format_bytes(bytes) do
+    DatabaseDiagnostics.format_bytes(bytes)
+  end
+
+  def format_table_name(table) do
+    table
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  attr :job, :any, required: true
+
+  @doc """
+  Renders the outcome of the most recent database maintenance run (manual or
+  scheduled), so successful and failed runs are both visible without digging
+  through job records.
+  """
+  def maintenance_status(assigns) do
+    ~H"""
+    <%= case @job do %>
+      <% nil -> %>
+        <span class="text-bodydark">
+          Never run. Compaction runs monthly on a schedule, or on demand via the Compact Now button.
+        </span>
+      <% %{state: "completed"} = job -> %>
+        <span class="text-green-400">
+          Succeeded at {format_datetime(job.completed_at)}, reclaimed {format_bytes(job.meta["reclaimed_bytes"] || 0)}.
+        </span>
+      <% %{state: state} = job when state in ["retryable", "discarded"] -> %>
+        <span class="text-red-400">
+          Failed at {format_datetime(job.attempted_at)}: {extract_last_error(job.errors)}
+        </span>
+        <span class="text-bodydark">
+          {if state == "retryable",
+            do: "It will be retried automatically — see Failed Jobs below.",
+            else: "It has exhausted its retries — see the Discarded tab under Failed Jobs below."}
+        </span>
+      <% %{state: "executing"} = job -> %>
+        <span class="text-blue-400">
+          In progress since {format_datetime(job.attempted_at)} — waiting for running jobs to finish, then compacting.
+        </span>
+      <% %{state: "cancelled"} = job -> %>
+        <span class="text-bodydark">
+          Skipped at {format_datetime(job.cancelled_at)} — {extract_last_error(job.errors)}
+        </span>
+      <% job -> %>
+        <span class="text-bodydark">Queued, will run at {format_datetime(job.scheduled_at)}.</span>
+    <% end %>
+    """
   end
 
   def diagnostic_info_string do

--- a/lib/pinchflat_web/controllers/settings/diagnostics_html/integrity_check_live.ex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_html/integrity_check_live.ex
@@ -1,0 +1,220 @@
+defmodule Pinchflat.Settings.IntegrityCheckLive do
+  @moduledoc """
+  The "Check Integrity" button and its results modal in the Database section of
+  the diagnostics page.
+
+  A LiveView rather than a plain POST because a full `PRAGMA integrity_check`
+  on a large database can outlast the HTTP request timeout. Here the check runs
+  in the LiveView process and the modal shows a spinner until it returns, so it
+  reads as a synchronous action without a request hanging behind it.
+
+  Deliberately report-only: findings are shown verbatim and nothing is
+  repaired. Repairs vary by what's damaged and are safest done with the app
+  stopped, so they stay a manual, documented procedure.
+  """
+
+  use PinchflatWeb, :live_view
+
+  require Logger
+
+  alias Pinchflat.Diagnostics.DatabaseDiagnostics
+
+  @modal_id "integrity-check-modal"
+
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.button
+        color="theme-primary-button"
+        rounding="rounded-m3-sm"
+        class="text-sm"
+        type="button"
+        phx-click={show_modal(@modal_id)}
+      >
+        <.icon name="hero-shield-check" class="h-4 w-4 mr-1" /> Check Integrity
+      </.button>
+
+      <.modal id={@modal_id}>
+        <h3 class="text-xl font-bold text-theme-on-surface mb-2">Database Integrity Check</h3>
+        <p class="text-sm text-theme-on-surface-muted mb-6">
+          Reads the database and reports any corruption SQLite finds. This is read-only — it
+          changes and repairs nothing, and downloads and indexing keep running while it works.
+        </p>
+
+        <div class="flex flex-wrap gap-3 mb-3">
+          <.button
+            color="theme-primary-button"
+            rounding="rounded-m3-sm"
+            class="text-sm"
+            type="button"
+            disabled={@status == :running}
+            phx-click="check"
+            phx-value-mode="quick"
+          >
+            Quick Check
+          </.button>
+          <.button
+            color="theme-primary-button"
+            rounding="rounded-m3-sm"
+            class="text-sm"
+            type="button"
+            disabled={@status == :running}
+            phx-click="check"
+            phx-value-mode="full"
+          >
+            Full Check
+          </.button>
+        </div>
+        <p class="text-xs text-theme-on-surface-muted mb-6">
+          A quick check verifies the structure of every page and the contents of the search index.
+          A full check additionally cross-checks every index entry against its table — more
+          thorough, but considerably slower on a large database or slow storage.
+        </p>
+
+        <%= case @status do %>
+          <% :idle -> %>
+          <% :running -> %>
+            <div class="rounded-m3-md border border-theme-outline bg-theme-surface-3 p-4 flex items-center gap-2">
+              <.icon name="hero-arrow-path" class="h-4 w-4 animate-spin text-theme-on-surface" />
+              <span class="text-sm text-theme-on-surface">
+                Running a {mode_label(@mode)}. On a large database this can take a few minutes —
+                leave this window open.
+              </span>
+            </div>
+          <% :clean -> %>
+            <div class="rounded-m3-md border border-theme-outline bg-theme-surface-2 p-4">
+              <p class="text-sm theme-status-success font-semibold">
+                <.icon name="hero-check-circle" class="h-4 w-4 mr-1" /> No problems found.
+              </p>
+              <p class="text-xs text-theme-on-surface-muted mt-1">
+                {String.capitalize(mode_label(@mode))} completed at {format_time(@checked_at)}.
+              </p>
+            </div>
+          <% :findings -> %>
+            <div class="rounded-m3-md border border-theme-outline bg-theme-surface-2 p-4">
+              <div class="flex justify-between items-start gap-4 mb-3">
+                <div>
+                  <p class="text-sm theme-status-error font-semibold">
+                    <.icon name="hero-exclamation-triangle" class="h-4 w-4 mr-1" />
+                    SQLite reported {length(@findings)} problem(s).
+                  </p>
+                  <p class="text-xs text-theme-on-surface-muted mt-1">
+                    {String.capitalize(mode_label(@mode))} completed at {format_time(@checked_at)}.
+                  </p>
+                </div>
+                <.button
+                  color="theme-primary-button"
+                  rounding="rounded-m3-sm"
+                  class="text-xs whitespace-nowrap"
+                  type="button"
+                  x-data="{ copied: false }"
+                  x-on:click={~s"
+                    copyWithCallbacks(
+                      `#{js_escape(Enum.join(@findings, "\n"))}`,
+                      () => copied = true,
+                      () => copied = false
+                    )
+                  "}
+                >
+                  Copy
+                  <span x-show="copied" x-transition.duration.150ms>
+                    <.icon name="hero-check" class="ml-1 h-3 w-3" />
+                  </span>
+                </.button>
+              </div>
+              <ul class="max-h-64 overflow-y-auto rounded-m3-xs border border-theme-outline/50 bg-theme-surface-1 p-3 space-y-1">
+                <li :for={finding <- @findings} class="text-xs text-theme-on-surface font-mono break-words">
+                  {finding}
+                </li>
+              </ul>
+              <p class="text-xs text-theme-on-surface-muted mt-3">
+                Nothing has been changed. Repairs depend on what's damaged and are safest done with
+                the server stopped, so they aren't automated here — back up your database file before
+                attempting one.
+                <span :if={search_index_finding?(@findings)} class="block mt-1">
+                  Problems naming <span class="font-mono">media_items_search_index</span>
+                  affect only the search index, which is derived from your media and can be rebuilt
+                  without losing anything.
+                </span>
+              </p>
+            </div>
+          <% :error -> %>
+            <div class="rounded-m3-md border border-theme-outline bg-theme-surface-2 p-4">
+              <p class="text-sm theme-status-error font-semibold">The check could not run.</p>
+              <p class="text-xs text-theme-on-surface font-mono mt-2 break-words">{@error}</p>
+            </div>
+        <% end %>
+      </.modal>
+    </div>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    socket =
+      assign(socket,
+        modal_id: @modal_id,
+        status: :idle,
+        mode: nil,
+        findings: [],
+        error: nil,
+        checked_at: nil
+      )
+
+    {:ok, socket}
+  end
+
+  # The check runs via a message to self rather than inline so this event can
+  # return first and paint the spinner. It deliberately blocks the LiveView
+  # while it runs — the buttons are disabled for the duration anyway, and
+  # keeping it in this process avoids a second database connection.
+  def handle_event("check", %{"mode" => mode}, socket) do
+    mode = parse_mode(mode)
+    send(self(), {:run_check, mode})
+
+    {:noreply, assign(socket, status: :running, mode: mode, findings: [], error: nil)}
+  end
+
+  def handle_info({:run_check, mode}, socket) do
+    socket = assign(socket, checked_at: DateTime.utc_now())
+
+    case DatabaseDiagnostics.run_integrity_check(mode) do
+      {:ok, []} ->
+        {:noreply, assign(socket, status: :clean)}
+
+      {:ok, findings} ->
+        Logger.warning("Database #{mode_label(mode)} found #{length(findings)} problem(s): #{inspect(findings)}")
+
+        {:noreply, assign(socket, status: :findings, findings: findings)}
+
+      {:error, message} ->
+        Logger.warning("Database #{mode_label(mode)} could not run: #{message}")
+
+        {:noreply, assign(socket, status: :error, error: message)}
+    end
+  end
+
+  defp parse_mode("full"), do: :full
+  defp parse_mode(_mode), do: :quick
+
+  defp mode_label(:full), do: "full check"
+  defp mode_label(_mode), do: "quick check"
+
+  defp search_index_finding?(findings) do
+    Enum.any?(findings, &String.contains?(&1, "media_items_search_index"))
+  end
+
+  defp format_time(nil), do: "-"
+
+  defp format_time(datetime) do
+    Calendar.strftime(datetime, "%Y-%m-%d %H:%M:%S")
+  end
+
+  # Findings are pasted into a JS template literal for the copy button, so the
+  # three sequences that can break out of one are neutralised.
+  defp js_escape(text) do
+    text
+    |> String.replace("\\", "\\\\")
+    |> String.replace("`", "\\`")
+    |> String.replace("${", "\\${")
+  end
+end

--- a/lib/pinchflat_web/controllers/settings/diagnostics_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_html/show.html.heex
@@ -46,6 +46,89 @@
   </div>
 </div>
 
+<!-- Database -->
+<% db = database_stats() %>
+<div class="theme-surface-raised mb-6 px-5 py-5 sm:px-7.5">
+  <div class="mb-4 flex items-center justify-between">
+    <h3 class="text-lg font-semibold text-theme-on-surface">Database</h3>
+    <.link
+      href={~p"/diagnostics/vacuum_database"}
+      method="post"
+      data-confirm="Compact the database now? Job queues are paused while any running jobs finish, then the database is compacted and the queues resume on their own. With long-running jobs this can take a while."
+    >
+      <.button color="theme-primary-button" rounding="rounded-m3-sm" class="text-sm">
+        <.icon name="hero-circle-stack" class="mr-1 h-4 w-4" /> Compact Now
+      </.button>
+    </.link>
+  </div>
+
+  <div class="mb-4 grid grid-cols-2 gap-4 md:grid-cols-5">
+    <div class="theme-surface-accent p-4">
+      <p class="text-sm text-theme-on-surface-muted">Size on Disk</p>
+      <p class="text-2xl font-bold text-theme-on-surface">{format_bytes(db.total_bytes)}</p>
+      <p class="mt-1 text-xs text-theme-on-surface-muted">
+        {format_bytes(db.main_file_bytes)} database + {format_bytes(db.wal_file_bytes + db.shm_file_bytes)} WAL
+      </p>
+    </div>
+    <div class="theme-surface-accent p-4">
+      <p class="text-sm text-theme-on-surface-muted">Reclaimable Space</p>
+      <p class="text-2xl font-bold text-theme-on-surface">{format_bytes(db.reclaimable_bytes)}</p>
+      <p class="mt-1 text-xs text-theme-on-surface-muted">Freed by compacting</p>
+    </div>
+    <div class="theme-surface-accent p-4">
+      <p class="text-sm text-theme-on-surface-muted">Journal Mode</p>
+      <p class="text-2xl font-bold uppercase text-theme-on-surface">{db.journal_mode}</p>
+    </div>
+    <div class="theme-surface-accent p-4">
+      <p class="text-sm text-theme-on-surface-muted">Orphaned Tasks</p>
+      <p class={"text-2xl font-bold #{if orphaned_task_count() > 0, do: "theme-status-error", else: "text-theme-on-surface"}"}>
+        {orphaned_task_count()}
+      </p>
+      <p class="mt-1 text-xs text-theme-on-surface-muted">Should always be 0</p>
+    </div>
+    <% compaction_enabled = scheduled_compaction_enabled?() %>
+    <div class="theme-surface-accent p-4">
+      <p class="text-sm text-theme-on-surface-muted">Scheduled Compaction</p>
+      <p class={"text-2xl font-bold #{if compaction_enabled, do: "theme-status-success", else: "text-theme-on-surface"}"}>
+        {if compaction_enabled, do: "On", else: "Off"}
+      </p>
+      <p class="mt-1 text-xs text-theme-on-surface-muted">
+        {if compaction_enabled, do: "Monthly on the 1st at 03:00", else: "Manual only"}
+        <.link
+          href={~p"/diagnostics/toggle_scheduled_compaction"}
+          method="post"
+          class="text-theme-primary hover:underline whitespace-nowrap"
+        >
+          Turn {if compaction_enabled, do: "off", else: "on"}
+        </.link>
+      </p>
+    </div>
+  </div>
+
+  <div class="mb-4 grid grid-cols-2 gap-4 md:grid-cols-5">
+    <%= for {table, count} <- table_row_counts() do %>
+      <div class="rounded-m3-sm border border-theme-outline/50 bg-theme-surface-2 p-3">
+        <p class="text-xs text-theme-on-surface-muted">{format_table_name(table)}</p>
+        <p class="text-lg font-semibold text-theme-on-surface">{count}</p>
+      </div>
+    <% end %>
+  </div>
+
+  <p class="text-sm text-theme-on-surface">
+    <span class="text-theme-on-surface-muted">Last compaction:</span>
+    <.maintenance_status job={latest_maintenance_job()} />
+  </p>
+  <p class="mt-2 text-xs text-theme-on-surface-muted">
+    Compacting (a SQLite VACUUM) shrinks the database by returning space left behind by deleted
+    records — old job history, removed media — to the filesystem. The Compact Now button compacts
+    on demand at any time. To avoid disturbing downloads and indexing, it
+    first pauses the job queues and waits for running jobs to finish (however long they take — a large
+    indexing run can be hours), then compacts and resumes the queues on its own. While it waits, the
+    queues above show as Paused. It refuses to compact — and reports an error here and under Failed
+    Jobs — if there isn't enough free disk space to do it safely.
+  </p>
+</div>
+
 <div class="theme-surface-raised mb-6 px-5 py-5 sm:px-7.5">
   <div class="mb-4 flex items-center justify-between">
     <h3 class="text-lg font-semibold text-theme-on-surface">Queue Health</h3>

--- a/lib/pinchflat_web/controllers/settings/diagnostics_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_html/show.html.heex
@@ -40,8 +40,8 @@
       <p class="text-2xl font-bold text-theme-on-surface">{stats.total_sources}</p>
     </div>
     <div class="theme-surface-accent p-4">
-      <p class="text-sm text-theme-on-surface-muted">Database Size</p>
-      <p class="text-2xl font-bold text-theme-on-surface">{stats.database_size}</p>
+      <p class="text-sm text-theme-on-surface-muted">Total Media Items</p>
+      <p class="text-2xl font-bold text-theme-on-surface">{stats.total_media_items}</p>
     </div>
   </div>
 </div>

--- a/lib/pinchflat_web/controllers/settings/diagnostics_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_html/show.html.heex
@@ -51,15 +51,18 @@
 <div class="theme-surface-raised mb-6 px-5 py-5 sm:px-7.5">
   <div class="mb-4 flex items-center justify-between">
     <h3 class="text-lg font-semibold text-theme-on-surface">Database</h3>
-    <.link
-      href={~p"/diagnostics/vacuum_database"}
-      method="post"
-      data-confirm="Compact the database now? Job queues are paused while any running jobs finish, then the database is compacted and the queues resume on their own. With long-running jobs this can take a while."
-    >
-      <.button color="theme-primary-button" rounding="rounded-m3-sm" class="text-sm">
-        <.icon name="hero-circle-stack" class="mr-1 h-4 w-4" /> Compact Now
-      </.button>
-    </.link>
+    <div class="flex items-center gap-3">
+      {live_render(@conn, Pinchflat.Settings.IntegrityCheckLive, id: "integrity-check-live")}
+      <.link
+        href={~p"/diagnostics/vacuum_database"}
+        method="post"
+        data-confirm="Compact the database now? Job queues are paused while any running jobs finish, then the database is compacted and the queues resume on their own. With long-running jobs this can take a while."
+      >
+        <.button color="theme-primary-button" rounding="rounded-m3-sm" class="text-sm">
+          <.icon name="hero-circle-stack" class="mr-1 h-4 w-4" /> Compact Now
+        </.button>
+      </.link>
+    </div>
   </div>
 
   <div class="mb-4 grid grid-cols-2 gap-4 md:grid-cols-5">

--- a/lib/pinchflat_web/controllers/settings/reconciliation_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/reconciliation_controller.ex
@@ -1,0 +1,86 @@
+defmodule PinchflatWeb.Settings.ReconciliationController do
+  use PinchflatWeb, :controller
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Sources
+  alias Pinchflat.Sources.Source
+  alias Pinchflat.Reconciliation
+  alias Pinchflat.Reconciliation.ReconcileWorker
+
+  def show(conn, params) do
+    render(conn, "show.html",
+      sources: list_sources(),
+      plans: Repo.preload(Reconciliation.list_plans(), :source),
+      preselected_source_id: params["source_id"]
+    )
+  end
+
+  def build(conn, %{"plan" => %{"mode" => mode} = plan_params}) when mode in ~w(local online full) do
+    source = find_scope_source(plan_params["source_id"])
+
+    case ReconcileWorker.kickoff_build(String.to_existing_atom(mode), source) do
+      {:ok, _} ->
+        conn
+        |> put_flash(
+          :info,
+          "Scan started. The report below updates as it builds. This can take a long time depending on the number of files and the speed of your storage."
+        )
+        |> redirect(to: ~p"/reconciliation")
+
+      {:error, :duplicate_job} ->
+        conn
+        |> put_flash(:error, "A reconcile run is already queued or running. Wait for it to finish first.")
+        |> redirect(to: ~p"/reconciliation")
+
+      {:error, _} ->
+        conn
+        |> put_flash(:error, "Could not start the dry run.")
+        |> redirect(to: ~p"/reconciliation")
+    end
+  end
+
+  def apply(conn, %{"plan_id" => plan_id}) do
+    plan = Reconciliation.get_plan!(plan_id)
+
+    case ReconcileWorker.kickoff_apply(plan) do
+      {:ok, _} ->
+        conn
+        |> put_flash(
+          :info,
+          "Applying the plan. Job queues are paused while running jobs finish, then files are " <>
+            "moved and the queues resume on their own."
+        )
+        |> redirect(to: ~p"/reconciliation")
+
+      {:error, :not_ready} ->
+        conn
+        |> put_flash(:error, "This plan can no longer be applied — run a fresh dry run.")
+        |> redirect(to: ~p"/reconciliation")
+
+      {:error, :duplicate_job} ->
+        conn
+        |> put_flash(:error, "A reconcile run is already queued or running.")
+        |> redirect(to: ~p"/reconciliation")
+
+      {:error, _} ->
+        conn
+        |> put_flash(:error, "Could not start applying the plan.")
+        |> redirect(to: ~p"/reconciliation")
+    end
+  end
+
+  defp list_sources do
+    Sources.list_sources()
+    |> Enum.reject(& &1.marked_for_deletion_at)
+    |> Enum.sort_by(&String.downcase(&1.custom_name || ""))
+  end
+
+  defp find_scope_source(source_id) when source_id in [nil, "", "all"], do: nil
+
+  defp find_scope_source(source_id) do
+    case Integer.parse(source_id) do
+      {id, ""} -> Repo.get(Source, id)
+      _ -> nil
+    end
+  end
+end

--- a/lib/pinchflat_web/controllers/settings/reconciliation_html.ex
+++ b/lib/pinchflat_web/controllers/settings/reconciliation_html.ex
@@ -1,0 +1,30 @@
+defmodule PinchflatWeb.Settings.ReconciliationHTML do
+  use PinchflatWeb, :html
+
+  embed_templates "reconciliation_html/*"
+
+  def mode_options do
+    [
+      {"Local only", "local"},
+      {"Online mode", "online"},
+      {"Full sync", "full"}
+    ]
+  end
+
+  def source_options(sources) do
+    [{"All sources", "all"}] ++ Enum.map(sources, fn source -> {source.custom_name, to_string(source.id)} end)
+  end
+
+  def plan_scope_name(%{source: %{custom_name: name}}) when is_binary(name), do: name
+  def plan_scope_name(_plan), do: "All sources"
+
+  def plan_status_class(:ready), do: "text-blue-400"
+  def plan_status_class(:applied), do: "text-green-400"
+  def plan_status_class(:failed), do: "text-red-400"
+  def plan_status_class(_status), do: "text-bodydark"
+
+  def humanize_mode(:local), do: "Local only"
+  def humanize_mode(:online), do: "Online mode"
+  def humanize_mode(:full), do: "Full sync"
+  def humanize_mode(other), do: to_string(other)
+end

--- a/lib/pinchflat_web/controllers/settings/reconciliation_html.ex
+++ b/lib/pinchflat_web/controllers/settings/reconciliation_html.ex
@@ -18,10 +18,10 @@ defmodule PinchflatWeb.Settings.ReconciliationHTML do
   def plan_scope_name(%{source: %{custom_name: name}}) when is_binary(name), do: name
   def plan_scope_name(_plan), do: "All sources"
 
-  def plan_status_class(:ready), do: "text-blue-400"
-  def plan_status_class(:applied), do: "text-green-400"
-  def plan_status_class(:failed), do: "text-red-400"
-  def plan_status_class(_status), do: "text-bodydark"
+  def plan_status_class(:ready), do: "text-theme-primary"
+  def plan_status_class(:applied), do: "theme-status-success"
+  def plan_status_class(:failed), do: "theme-status-error"
+  def plan_status_class(_status), do: "text-theme-on-surface-muted"
 
   def humanize_mode(:local), do: "Local only"
   def humanize_mode(:online), do: "Online mode"

--- a/lib/pinchflat_web/controllers/settings/reconciliation_html/reconcile_plan_live.ex
+++ b/lib/pinchflat_web/controllers/settings/reconciliation_html/reconcile_plan_live.ex
@@ -1,0 +1,251 @@
+defmodule Pinchflat.Settings.ReconcilePlanLive do
+  use PinchflatWeb, :live_view
+
+  import Ecto.Query, warn: false
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Reconciliation
+  alias Pinchflat.Utils.NumberUtils
+
+  @limit 20
+  @filters ~w(all move backfill delete redownload skip collision)
+
+  def render(%{plan: nil} = assigns) do
+    ~H"""
+    <div class="rounded-sm border border-stroke bg-white px-5 py-5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 mb-6">
+      <h3 class="text-lg font-semibold text-white mb-2">Latest Run</h3>
+      <p class="text-bodydark text-sm">
+        No reconcile runs yet — scan and build a plan above to see what would change.
+      </p>
+    </div>
+    """
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="rounded-sm border border-stroke bg-white px-5 py-5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 mb-6">
+      <div class="flex justify-between items-center mb-2 flex-wrap gap-3">
+        <h3 class="text-lg font-semibold text-white">
+          Latest Run — {scope_name(@plan)} <span class="text-bodydark text-sm">({humanize_mode(@plan.mode)})</span>
+        </h3>
+        <div class="flex items-center gap-3">
+          <.icon_button icon_name="hero-arrow-path" class="h-10 w-10" phx-click="reload" tooltip="Refresh" />
+          <.link
+            :if={@plan.status == :ready && applyable_count(@plan) > 0}
+            href={~p"/reconciliation/apply/#{@plan.id}"}
+            method="post"
+            data-confirm={apply_confirmation(@plan)}
+          >
+            <.button color="bg-primary" rounding="rounded-lg">
+              <.icon name="hero-play" class="h-4 w-4 mr-1" /> Apply This Plan
+            </.button>
+          </.link>
+        </div>
+      </div>
+
+      <p class="text-sm mb-4">
+        <span class="text-bodydark">Status:</span>
+        <span class={status_class(@plan.status)}>{status_line(@plan)}</span>
+      </p>
+
+      <div class="grid grid-cols-2 md:grid-cols-6 gap-4 mb-4">
+        <div class="bg-meta-4 rounded-lg p-4">
+          <p class="text-sm text-bodydark">Moves</p>
+          <p class="text-2xl font-bold text-white">{@plan.move_count}</p>
+        </div>
+        <div class="bg-meta-4 rounded-lg p-4">
+          <p class="text-sm text-bodydark">Backfills</p>
+          <p class="text-2xl font-bold text-white">{@plan.backfill_count}</p>
+        </div>
+        <div class="bg-meta-4 rounded-lg p-4">
+          <p class="text-sm text-bodydark">Deletions</p>
+          <p class={"text-2xl font-bold #{if @plan.delete_count > 0, do: "text-red-400", else: "text-white"}"}>
+            {@plan.delete_count}
+          </p>
+          <p :if={@plan.delete_count > 0} class="text-xs text-red-400 mt-1">Files will be permanently deleted</p>
+        </div>
+        <div class="bg-meta-4 rounded-lg p-4">
+          <p class="text-sm text-bodydark">Re-downloads</p>
+          <p class={"text-2xl font-bold #{if @plan.redownload_count > 0, do: "text-yellow-500", else: "text-white"}"}>
+            {@plan.redownload_count}
+          </p>
+          <p :if={@plan.redownload_count > 0} class="text-xs text-yellow-500 mt-1">Uses bandwidth</p>
+        </div>
+        <div class="bg-meta-4 rounded-lg p-4">
+          <p class="text-sm text-bodydark">Skipped</p>
+          <p class="text-2xl font-bold text-white">{@plan.skip_count}</p>
+        </div>
+        <div class="bg-meta-4 rounded-lg p-4">
+          <p class="text-sm text-bodydark">Collisions</p>
+          <p class={"text-2xl font-bold #{if @plan.collision_count > 0, do: "text-yellow-500", else: "text-white"}"}>
+            {@plan.collision_count}
+          </p>
+        </div>
+      </div>
+
+      <div class="flex gap-2 mb-4 flex-wrap">
+        <button
+          :for={filter <- filters()}
+          phx-click="filter"
+          phx-value-filter={filter}
+          class={[
+            "px-3 py-1 rounded-full text-sm border",
+            if(@filter == filter,
+              do: "bg-primary text-white border-primary",
+              else: "text-bodydark border-strokedark hover:border-primary"
+            )
+          ]}
+        >
+          {filter_label(filter)}
+        </button>
+      </div>
+
+      <p :if={@records == []} class="text-bodydark text-sm">Nothing here for this filter.</p>
+
+      <div :if={@records != []} class="max-w-full overflow-x-auto">
+        <.table rows={@records} table_class="text-white text-sm">
+          <:col :let={item} label="Action">
+            <span class={action_class(item.action)}>{item.action}</span>
+          </:col>
+          <:col :let={item} label="File">{item.attribute}</:col>
+          <:col :let={item} label="From" class="max-w-lg">
+            <span class="break-all text-xs">{item.from_path}</span>
+          </:col>
+          <:col :let={item} label="To" class="max-w-lg">
+            <span class="break-all text-xs">{item.to_path}</span>
+          </:col>
+          <:col :let={item} label="Status">{item.status}</:col>
+          <:col :let={item} label="Detail" class="max-w-xs">
+            <span class="text-xs text-bodydark">{item.detail}</span>
+          </:col>
+        </.table>
+      </div>
+
+      <section :if={@total_pages > 1} class="flex justify-center mt-5">
+        <.live_pagination_controls page_number={@page} total_pages={@total_pages} />
+      </section>
+    </div>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: PinchflatWeb.Endpoint.subscribe("job:state")
+
+    {:ok, load_assigns(socket, "all", 1)}
+  end
+
+  def handle_info(%{topic: "job:state", event: "change"}, %{assigns: assigns} = socket) do
+    {:noreply, load_assigns(socket, assigns.filter, assigns.page)}
+  end
+
+  def handle_event("reload", _params, %{assigns: assigns} = socket) do
+    {:noreply, load_assigns(socket, assigns.filter, assigns.page)}
+  end
+
+  def handle_event("filter", %{"filter" => filter}, socket) when filter in @filters do
+    {:noreply, load_assigns(socket, filter, 1)}
+  end
+
+  def handle_event("page_change", %{"direction" => direction}, %{assigns: assigns} = socket) do
+    delta = if direction == "inc", do: 1, else: -1
+
+    {:noreply, load_assigns(socket, assigns.filter, assigns.page + delta)}
+  end
+
+  defp load_assigns(socket, filter, page) do
+    case Reconciliation.latest_plan() do
+      nil ->
+        assign(socket, plan: nil, filter: "all", page: 1, records: [], total_pages: 1)
+
+      plan ->
+        plan = Repo.preload(plan, :source)
+        query = Reconciliation.plan_items_query(plan, filter_to_action(filter))
+        total_record_count = Repo.aggregate(query, :count, :id)
+        total_pages = max(ceil(total_record_count / @limit), 1)
+        page = NumberUtils.clamp(page, 1, total_pages)
+        records = query |> limit(^@limit) |> offset(^((page - 1) * @limit)) |> Repo.all()
+
+        assign(socket, plan: plan, filter: filter, page: page, records: records, total_pages: total_pages)
+    end
+  end
+
+  defp filters, do: @filters
+
+  defp filter_to_action("all"), do: nil
+  defp filter_to_action("move"), do: :move
+  defp filter_to_action("backfill"), do: :backfill
+  defp filter_to_action("delete"), do: :delete
+  defp filter_to_action("redownload"), do: :redownload
+  defp filter_to_action("skip"), do: :skip
+  defp filter_to_action("collision"), do: :collision
+
+  defp filter_label("all"), do: "All"
+  defp filter_label("move"), do: "Moves"
+  defp filter_label("backfill"), do: "Backfills"
+  defp filter_label("delete"), do: "Deletions"
+  defp filter_label("redownload"), do: "Re-downloads"
+  defp filter_label("skip"), do: "Skipped"
+  defp filter_label("collision"), do: "Collisions"
+
+  defp scope_name(%{source: %{custom_name: name}}) when is_binary(name), do: name
+  defp scope_name(_plan), do: "All sources"
+
+  defp humanize_mode(:local), do: "Local only"
+  defp humanize_mode(:online), do: "Online mode"
+  defp humanize_mode(:full), do: "Full sync"
+  defp humanize_mode(other), do: to_string(other)
+
+  defp applyable_count(plan) do
+    plan.move_count + plan.backfill_count + plan.delete_count + plan.redownload_count
+  end
+
+  defp apply_confirmation(plan) do
+    base =
+      "Apply this plan? #{plan.move_count} file move(s) and #{plan.backfill_count} backfill(s) will run. " <>
+        "Job queues are paused while running jobs finish, then files are moved and the queues resume on their own."
+
+    base
+    |> maybe_append_delete_warning(plan)
+    |> maybe_append_redownload_warning(plan)
+  end
+
+  defp maybe_append_delete_warning(text, %{delete_count: count}) when count > 0 do
+    text <>
+      " WARNING: #{count} sidecar file(s) whose setting is turned off will be PERMANENTLY DELETED. " <>
+      "Review the Deletions filter before applying. This cannot be undone."
+  end
+
+  defp maybe_append_delete_warning(text, _plan), do: text
+
+  defp maybe_append_redownload_warning(text, %{redownload_count: count}) when count > 0 do
+    text <>
+      " #{count} item(s) will be fully re-downloaded (this uses bandwidth). Review the Re-downloads filter first."
+  end
+
+  defp maybe_append_redownload_warning(text, _plan), do: text
+
+  defp status_line(%{status: :building}), do: "Scan in progress — this report fills in as it builds"
+  defp status_line(%{status: :ready}), do: "Ready to review — nothing has been changed yet"
+  defp status_line(%{status: :applying}), do: "Applying — waiting for running jobs, then moving files"
+
+  defp status_line(%{status: :applied} = plan) do
+    error_suffix = if plan.error_count > 0, do: " (#{plan.error_count} row(s) failed — see details below)", else: ""
+
+    "Applied#{error_suffix}"
+  end
+
+  defp status_line(%{status: :failed} = plan), do: "Failed: #{plan.error_message}"
+  defp status_line(%{status: :stale}), do: "Stale — superseded by a newer run or a settings change"
+
+  defp status_class(:ready), do: "text-blue-400"
+  defp status_class(:applied), do: "text-green-400"
+  defp status_class(:failed), do: "text-red-400"
+  defp status_class(_status), do: "text-bodydark"
+
+  defp action_class(:move), do: "text-blue-400"
+  defp action_class(:backfill), do: "text-green-400"
+  defp action_class(:delete), do: "text-red-400"
+  defp action_class(:redownload), do: "text-yellow-500"
+  defp action_class(:collision), do: "text-yellow-500"
+  defp action_class(_action), do: "text-bodydark"
+end

--- a/lib/pinchflat_web/controllers/settings/reconciliation_html/reconcile_plan_live.ex
+++ b/lib/pinchflat_web/controllers/settings/reconciliation_html/reconcile_plan_live.ex
@@ -15,9 +15,9 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
 
   def render(%{plan: nil} = assigns) do
     ~H"""
-    <div class="rounded-sm border border-stroke bg-white px-5 py-5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 mb-6">
-      <h3 class="text-lg font-semibold text-white mb-2">Latest Run</h3>
-      <p class="text-bodydark text-sm">
+    <div class="theme-surface-raised mb-6 px-5 py-5 sm:px-7.5">
+      <h3 class="text-lg font-semibold text-theme-on-surface mb-2">Latest Run</h3>
+      <p class="text-theme-on-surface-muted text-sm">
         No reconcile runs yet — scan and build a plan above to see what would change.
       </p>
     </div>
@@ -26,10 +26,11 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
 
   def render(assigns) do
     ~H"""
-    <div class="rounded-sm border border-stroke bg-white px-5 py-5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 mb-6">
+    <div class="theme-surface-raised mb-6 px-5 py-5 sm:px-7.5">
       <div class="flex justify-between items-center mb-2 flex-wrap gap-3">
-        <h3 class="text-lg font-semibold text-white">
-          Latest Run — {scope_name(@plan)} <span class="text-bodydark text-sm">({humanize_mode(@plan.mode)})</span>
+        <h3 class="text-lg font-semibold text-theme-on-surface">
+          Latest Run — {scope_name(@plan)}
+          <span class="text-theme-on-surface-muted text-sm">({humanize_mode(@plan.mode)})</span>
         </h3>
         <div class="flex items-center gap-3">
           <.icon_button icon_name="hero-arrow-path" class="h-10 w-10" phx-click="reload" tooltip="Refresh" />
@@ -39,7 +40,7 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
             method="post"
             data-confirm={apply_confirmation(@plan)}
           >
-            <.button color="bg-primary" rounding="rounded-lg">
+            <.button color="theme-primary-button" rounding="rounded-m3-sm">
               <.icon name="hero-play" class="h-4 w-4 mr-1" /> Apply This Plan
             </.button>
           </.link>
@@ -47,52 +48,52 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
       </div>
 
       <p class="text-sm mb-4">
-        <span class="text-bodydark">Status:</span>
+        <span class="text-theme-on-surface-muted">Status:</span>
         <span class={status_class(@plan.status)}>{status_line(@plan)}</span>
       </p>
 
       <div :if={@plan.status == :applying && @progress.total > 0} class="mb-4">
         <div class="flex justify-between text-sm mb-1">
-          <span class="text-bodydark">Progress</span>
-          <span class="text-white font-medium">
+          <span class="text-theme-on-surface-muted">Progress</span>
+          <span class="text-theme-on-surface font-medium">
             {@progress.processed} of {@progress.total} finished ({@progress.percent}%)
           </span>
         </div>
-        <div class="w-full bg-meta-4 rounded-full h-2.5">
-          <div class="bg-primary h-2.5 rounded-full transition-all" style={"width: #{@progress.percent}%"}></div>
+        <div class="w-full bg-theme-surface-4 rounded-full h-2.5">
+          <div class="bg-theme-primary h-2.5 rounded-full transition-all" style={"width: #{@progress.percent}%"}></div>
         </div>
       </div>
 
       <div class="grid grid-cols-2 md:grid-cols-6 gap-4 mb-4">
-        <div class="bg-meta-4 rounded-lg p-4">
-          <p class="text-sm text-bodydark">Moves</p>
-          <p class="text-2xl font-bold text-white">{@plan.move_count}</p>
+        <div class="theme-surface-accent p-4">
+          <p class="text-sm text-theme-on-surface-muted">Moves</p>
+          <p class="text-2xl font-bold text-theme-on-surface">{@plan.move_count}</p>
         </div>
-        <div class="bg-meta-4 rounded-lg p-4">
-          <p class="text-sm text-bodydark">Backfills</p>
-          <p class="text-2xl font-bold text-white">{@plan.backfill_count}</p>
+        <div class="theme-surface-accent p-4">
+          <p class="text-sm text-theme-on-surface-muted">Backfills</p>
+          <p class="text-2xl font-bold text-theme-on-surface">{@plan.backfill_count}</p>
         </div>
-        <div class="bg-meta-4 rounded-lg p-4">
-          <p class="text-sm text-bodydark">Deletions</p>
-          <p class={"text-2xl font-bold #{if @plan.delete_count > 0, do: "text-red-400", else: "text-white"}"}>
+        <div class="theme-surface-accent p-4">
+          <p class="text-sm text-theme-on-surface-muted">Deletions</p>
+          <p class={"text-2xl font-bold #{if @plan.delete_count > 0, do: "theme-status-error", else: "text-theme-on-surface"}"}>
             {@plan.delete_count}
           </p>
-          <p :if={@plan.delete_count > 0} class="text-xs text-red-400 mt-1">Files will be permanently deleted</p>
+          <p :if={@plan.delete_count > 0} class="text-xs theme-status-error mt-1">Files will be permanently deleted</p>
         </div>
-        <div class="bg-meta-4 rounded-lg p-4">
-          <p class="text-sm text-bodydark">Re-downloads</p>
-          <p class={"text-2xl font-bold #{if @plan.redownload_count > 0, do: "text-yellow-500", else: "text-white"}"}>
+        <div class="theme-surface-accent p-4">
+          <p class="text-sm text-theme-on-surface-muted">Re-downloads</p>
+          <p class={"text-2xl font-bold #{if @plan.redownload_count > 0, do: "theme-status-warning", else: "text-theme-on-surface"}"}>
             {@plan.redownload_count}
           </p>
-          <p :if={@plan.redownload_count > 0} class="text-xs text-yellow-500 mt-1">Uses bandwidth</p>
+          <p :if={@plan.redownload_count > 0} class="text-xs theme-status-warning mt-1">Uses bandwidth</p>
         </div>
-        <div class="bg-meta-4 rounded-lg p-4">
-          <p class="text-sm text-bodydark">Skipped</p>
-          <p class="text-2xl font-bold text-white">{@plan.skip_count}</p>
+        <div class="theme-surface-accent p-4">
+          <p class="text-sm text-theme-on-surface-muted">Skipped</p>
+          <p class="text-2xl font-bold text-theme-on-surface">{@plan.skip_count}</p>
         </div>
-        <div class="bg-meta-4 rounded-lg p-4">
-          <p class="text-sm text-bodydark">Collisions</p>
-          <p class={"text-2xl font-bold #{if @plan.collision_count > 0, do: "text-yellow-500", else: "text-white"}"}>
+        <div class="theme-surface-accent p-4">
+          <p class="text-sm text-theme-on-surface-muted">Collisions</p>
+          <p class={"text-2xl font-bold #{if @plan.collision_count > 0, do: "theme-status-warning", else: "text-theme-on-surface"}"}>
             {@plan.collision_count}
           </p>
         </div>
@@ -106,8 +107,8 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
           class={[
             "px-3 py-1 rounded-full text-sm border",
             if(@filter == filter,
-              do: "bg-primary text-white border-primary",
-              else: "text-bodydark border-strokedark hover:border-primary"
+              do: "bg-theme-primary text-theme-on-primary border-theme-primary",
+              else: "text-theme-on-surface-muted border-theme-outline hover:border-theme-primary"
             )
           ]}
         >
@@ -115,10 +116,10 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
         </button>
       </div>
 
-      <p :if={@records == []} class="text-bodydark text-sm">Nothing here for this filter.</p>
+      <p :if={@records == []} class="text-theme-on-surface-muted text-sm">Nothing here for this filter.</p>
 
       <div :if={@records != []} class="max-w-full overflow-x-auto">
-        <.table rows={@records} table_class="text-white text-sm">
+        <.table rows={@records} table_class="text-theme-on-surface text-sm">
           <:col :let={item} label="Action">
             <span class={action_class(item.action)}>{item.action}</span>
           </:col>
@@ -131,7 +132,7 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
           </:col>
           <:col :let={item} label="Status">{item.status}</:col>
           <:col :let={item} label="Detail" class="max-w-xs">
-            <span class="text-xs text-bodydark">{item.detail}</span>
+            <span class="text-xs text-theme-on-surface-muted">{item.detail}</span>
           </:col>
         </.table>
       </div>
@@ -280,15 +281,15 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
   defp status_line(%{status: :failed} = plan), do: "Failed: #{plan.error_message}"
   defp status_line(%{status: :stale}), do: "Stale — superseded by a newer run or a settings change"
 
-  defp status_class(:ready), do: "text-blue-400"
-  defp status_class(:applied), do: "text-green-400"
-  defp status_class(:failed), do: "text-red-400"
-  defp status_class(_status), do: "text-bodydark"
+  defp status_class(:ready), do: "text-theme-primary"
+  defp status_class(:applied), do: "theme-status-success"
+  defp status_class(:failed), do: "theme-status-error"
+  defp status_class(_status), do: "text-theme-on-surface-muted"
 
-  defp action_class(:move), do: "text-blue-400"
-  defp action_class(:backfill), do: "text-green-400"
-  defp action_class(:delete), do: "text-red-400"
-  defp action_class(:redownload), do: "text-yellow-500"
-  defp action_class(:collision), do: "text-yellow-500"
-  defp action_class(_action), do: "text-bodydark"
+  defp action_class(:move), do: "text-theme-primary"
+  defp action_class(:backfill), do: "theme-status-success"
+  defp action_class(:delete), do: "theme-status-error"
+  defp action_class(:redownload), do: "theme-status-warning"
+  defp action_class(:collision), do: "theme-status-warning"
+  defp action_class(_action), do: "text-theme-on-surface-muted"
 end

--- a/lib/pinchflat_web/controllers/settings/reconciliation_html/reconcile_plan_live.ex
+++ b/lib/pinchflat_web/controllers/settings/reconciliation_html/reconcile_plan_live.ex
@@ -9,6 +9,9 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
 
   @limit 20
   @filters ~w(all move backfill delete redownload skip collision)
+  # No Oban job:state broadcasts fire while a single apply job runs, so poll the
+  # DB-backed progress ourselves while a plan is applying (stops once it isn't)
+  @poll_interval_ms 2_000
 
   def render(%{plan: nil} = assigns) do
     ~H"""
@@ -47,6 +50,18 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
         <span class="text-bodydark">Status:</span>
         <span class={status_class(@plan.status)}>{status_line(@plan)}</span>
       </p>
+
+      <div :if={@plan.status == :applying && @progress.total > 0} class="mb-4">
+        <div class="flex justify-between text-sm mb-1">
+          <span class="text-bodydark">Progress</span>
+          <span class="text-white font-medium">
+            {@progress.processed} of {@progress.total} finished ({@progress.percent}%)
+          </span>
+        </div>
+        <div class="w-full bg-meta-4 rounded-full h-2.5">
+          <div class="bg-primary h-2.5 rounded-full transition-all" style={"width: #{@progress.percent}%"}></div>
+        </div>
+      </div>
 
       <div class="grid grid-cols-2 md:grid-cols-6 gap-4 mb-4">
         <div class="bg-meta-4 rounded-lg p-4">
@@ -138,6 +153,12 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
     {:noreply, load_assigns(socket, assigns.filter, assigns.page)}
   end
 
+  # Self-poll tick while a plan is applying — reload, then reschedule only if
+  # it's still applying (maybe_schedule_tick handles the stop condition)
+  def handle_info(:tick, %{assigns: assigns} = socket) do
+    {:noreply, load_assigns(assign(socket, tick_scheduled: false), assigns.filter, assigns.page)}
+  end
+
   def handle_event("reload", _params, %{assigns: assigns} = socket) do
     {:noreply, load_assigns(socket, assigns.filter, assigns.page)}
   end
@@ -155,7 +176,7 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
   defp load_assigns(socket, filter, page) do
     case Reconciliation.latest_plan() do
       nil ->
-        assign(socket, plan: nil, filter: "all", page: 1, records: [], total_pages: 1)
+        assign(socket, plan: nil, filter: "all", page: 1, records: [], total_pages: 1, progress: nil)
 
       plan ->
         plan = Repo.preload(plan, :source)
@@ -165,7 +186,29 @@ defmodule Pinchflat.Settings.ReconcilePlanLive do
         page = NumberUtils.clamp(page, 1, total_pages)
         records = query |> limit(^@limit) |> offset(^((page - 1) * @limit)) |> Repo.all()
 
-        assign(socket, plan: plan, filter: filter, page: page, records: records, total_pages: total_pages)
+        socket
+        |> assign(
+          plan: plan,
+          filter: filter,
+          page: page,
+          records: records,
+          total_pages: total_pages,
+          progress: Reconciliation.apply_progress(plan)
+        )
+        |> maybe_schedule_tick()
+    end
+  end
+
+  # Schedules one progress-poll tick while a plan is applying, guarding against
+  # stacking timers (job:state reloads and ticks both flow through load_assigns)
+  defp maybe_schedule_tick(socket) do
+    applying? = socket.assigns.plan && socket.assigns.plan.status == :applying
+
+    if connected?(socket) && applying? && !socket.assigns[:tick_scheduled] do
+      Process.send_after(self(), :tick, @poll_interval_ms)
+      assign(socket, tick_scheduled: true)
+    else
+      socket
     end
   end
 

--- a/lib/pinchflat_web/controllers/settings/reconciliation_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/settings/reconciliation_html/show.html.heex
@@ -1,17 +1,17 @@
 <div class="mb-6 flex gap-3 flex-row items-center justify-between">
   <div class="flex gap-3 items-center">
-    <h2 class="text-title-md2 font-bold text-white ml-4">
+    <h2 class="text-title-md2 font-bold text-theme-on-surface ml-4">
       Reconcile
     </h2>
   </div>
 </div>
 
-<div class="rounded-sm border border-stroke bg-white px-5 py-5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 mb-6">
-  <h3 class="text-lg font-semibold text-white mb-2">True up files after settings changes</h3>
-  <p class="text-sm text-bodydark mb-4">
+<div class="theme-surface-raised mb-6 px-5 py-5 sm:px-7.5">
+  <h3 class="text-lg font-semibold text-theme-on-surface mb-2">True up files after settings changes</h3>
+  <p class="text-sm text-theme-on-surface-muted mb-4">
     Changing an output path template, toggling podcast mode, or changing sidecar/filename settings
     doesn't touch files that are already downloaded. A reconcile run trues them up <strong>without explicitly re-downloading all media</strong>: it moves and renames existing files to match the
-    current settings, rebuilds missing NFO/info.json sidecars from stored metadata, and <span class="text-red-400">deletes sidecar files whose setting is now turned off</span>.
+    current settings, rebuilds missing NFO/info.json sidecars from stored metadata, and <span class="theme-status-error">deletes sidecar files whose setting is now turned off</span>.
     Nothing changes until you review the report below and apply it. YouTube API is not used for any steps.
   </p>
   <.form :let={f} for={%{}} as={:plan} action={~p"/reconciliation"} method="post" class="max-w-2xl">
@@ -24,7 +24,7 @@
           options={mode_options()}
           value="local"
         />
-        <ul class="mt-2 list-disc pl-5 text-sm text-bodydark flex flex-col gap-1.5">
+        <ul class="mt-2 list-disc pl-5 text-sm text-theme-on-surface-muted flex flex-col gap-1.5">
           <li>
             <strong>Local only</strong> — moves and renames existing files and rebuilds NFO/info.json sidecars
             from stored metadata. No network.
@@ -33,7 +33,7 @@
             <strong>Online mode</strong>
             — everything Local does, plus backfills sidecars that were never downloaded (missing
             thumbnails and subtitles) with one yt-dlp fetch per affected video per missing item.
-            <span class="text-red-400">Note:</span>
+            <span class="theme-status-error">Note:</span>
             Subtitles are rarely available and can easily double the time and effort required to
             implement your plan—consider whether they’re truly necessary.
           </li>
@@ -43,8 +43,8 @@
             format no longer matches the profile (an audio-only vs video switch, or a container change
             — e.g. the profile now produces .mkv but the file is .mp4; a video profile with no explicit
             container produces .mp4). Re-downloads run after the reconcile finishes and
-            <span class="text-red-400">do use bandwidth</span>
-            — review the Re-downloads list before applying. <span class="text-red-400">Note:</span>
+            <span class="theme-status-error">do use bandwidth</span>
+            — review the Re-downloads list before applying. <span class="theme-status-error">Note:</span>
             Changes to resolution or embedded features are not detected; the only way to address this is to force a
             <strong>Redownload Everything</strong>
             at the source level.
@@ -60,7 +60,7 @@
         help="Reconcile one source, or everything at once (e.g. after changing a global setting like restricted filenames)."
       />
       <div>
-        <.button color="bg-primary" rounding="rounded-lg">
+        <.button color="theme-primary-button" rounding="rounded-m3-sm">
           <.icon name="hero-magnifying-glass" class="h-4 w-4 mr-1" /> Scan and Build Plan
         </.button>
       </div>
@@ -72,11 +72,11 @@
 
 <div
   :if={@plans != []}
-  class="rounded-sm border border-stroke bg-white px-5 py-5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 mb-6"
+  class="theme-surface-raised mb-6 px-5 py-5 sm:px-7.5"
 >
-  <h3 class="text-lg font-semibold text-white mb-4">Past Runs</h3>
+  <h3 class="text-lg font-semibold text-theme-on-surface mb-4">Past Runs</h3>
   <div class="max-w-full overflow-x-auto">
-    <.table rows={@plans} table_class="text-white">
+    <.table rows={@plans} table_class="text-theme-on-surface">
       <:col :let={plan} label="ID">{plan.id}</:col>
       <:col :let={plan} label="Scope">{plan_scope_name(plan)}</:col>
       <:col :let={plan} label="Mode">{humanize_mode(plan.mode)}</:col>

--- a/lib/pinchflat_web/controllers/settings/reconciliation_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/settings/reconciliation_html/show.html.heex
@@ -1,0 +1,95 @@
+<div class="mb-6 flex gap-3 flex-row items-center justify-between">
+  <div class="flex gap-3 items-center">
+    <h2 class="text-title-md2 font-bold text-white ml-4">
+      Reconcile
+    </h2>
+  </div>
+</div>
+
+<div class="rounded-sm border border-stroke bg-white px-5 py-5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 mb-6">
+  <h3 class="text-lg font-semibold text-white mb-2">True up files after settings changes</h3>
+  <p class="text-sm text-bodydark mb-4">
+    Changing an output path template, toggling podcast mode, or changing sidecar/filename settings
+    doesn't touch files that are already downloaded. A reconcile run trues them up <strong>without explicitly re-downloading all media</strong>: it moves and renames existing files to match the
+    current settings, rebuilds missing NFO/info.json sidecars from stored metadata, and <span class="text-red-400">deletes sidecar files whose setting is now turned off</span>.
+    Nothing changes until you review the report below and apply it. YouTube API is not used for any steps.
+  </p>
+  <.form :let={f} for={%{}} as={:plan} action={~p"/reconciliation"} method="post" class="max-w-2xl">
+    <div class="flex flex-col gap-4">
+      <div>
+        <.input
+          field={f[:mode]}
+          type="select"
+          label="Mode"
+          options={mode_options()}
+          value="local"
+        />
+        <ul class="mt-2 list-disc pl-5 text-sm text-bodydark flex flex-col gap-1.5">
+          <li>
+            <strong>Local only</strong> — moves and renames existing files and rebuilds NFO/info.json sidecars
+            from stored metadata. No network.
+          </li>
+          <li>
+            <strong>Online mode</strong>
+            — everything Local does, plus backfills sidecars that were never downloaded (missing
+            thumbnails and subtitles) with one yt-dlp fetch per affected video per missing item.
+            <span class="text-red-400">Note:</span>
+            Subtitles are rarely available and can easily double the time and effort required to
+            implement your plan—consider whether they’re truly necessary.
+          </li>
+          <li>
+            <strong>Full sync</strong>
+            — everything Online does, plus schedules a full media re-download for items whose on-disk
+            format no longer matches the profile (an audio-only vs video switch, or a container change
+            — e.g. the profile now produces .mkv but the file is .mp4; a video profile with no explicit
+            container produces .mp4). Re-downloads run after the reconcile finishes and
+            <span class="text-red-400">do use bandwidth</span>
+            — review the Re-downloads list before applying. <span class="text-red-400">Note:</span>
+            Changes to resolution or embedded features are not detected; the only way to address this is to force a
+            <strong>Redownload Everything</strong>
+            at the source level.
+          </li>
+        </ul>
+      </div>
+      <.input
+        field={f[:source_id]}
+        type="select"
+        label="Scope"
+        options={source_options(@sources)}
+        value={@preselected_source_id || "all"}
+        help="Reconcile one source, or everything at once (e.g. after changing a global setting like restricted filenames)."
+      />
+      <div>
+        <.button color="bg-primary" rounding="rounded-lg">
+          <.icon name="hero-magnifying-glass" class="h-4 w-4 mr-1" /> Scan and Build Plan
+        </.button>
+      </div>
+    </div>
+  </.form>
+</div>
+
+{live_render(@conn, Pinchflat.Settings.ReconcilePlanLive, id: "reconcile-plan-live")}
+
+<div
+  :if={@plans != []}
+  class="rounded-sm border border-stroke bg-white px-5 py-5 shadow-default dark:border-strokedark dark:bg-boxdark sm:px-7.5 mb-6"
+>
+  <h3 class="text-lg font-semibold text-white mb-4">Past Runs</h3>
+  <div class="max-w-full overflow-x-auto">
+    <.table rows={@plans} table_class="text-white">
+      <:col :let={plan} label="ID">{plan.id}</:col>
+      <:col :let={plan} label="Scope">{plan_scope_name(plan)}</:col>
+      <:col :let={plan} label="Mode">{humanize_mode(plan.mode)}</:col>
+      <:col :let={plan} label="Status">
+        <span class={plan_status_class(plan.status)}>{plan.status}</span>
+      </:col>
+      <:col :let={plan} label="Moves">{plan.move_count}</:col>
+      <:col :let={plan} label="Backfills">{plan.backfill_count}</:col>
+      <:col :let={plan} label="Deletions">{plan.delete_count}</:col>
+      <:col :let={plan} label="Re-downloads">{plan.redownload_count}</:col>
+      <:col :let={plan} label="Created">
+        <.datetime_in_zone datetime={plan.inserted_at} format="%Y-%m-%d %H:%M" />
+      </:col>
+    </.table>
+  </div>
+</div>

--- a/lib/pinchflat_web/controllers/settings/setting_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_controller.ex
@@ -2,6 +2,7 @@ defmodule PinchflatWeb.Settings.SettingController do
   use PinchflatWeb, :controller
 
   alias Pinchflat.Settings
+  alias Pinchflat.Reconciliation
   alias Pinchflat.Settings.CookieFile
   alias Pinchflat.YtDlp.UpdateWorker
 
@@ -20,6 +21,9 @@ defmodule PinchflatWeb.Settings.SettingController do
     case Settings.update_setting(setting, setting_params) do
       {:ok, updated_setting} ->
         maybe_apply_yt_dlp_policy(setting, updated_setting)
+        # A settings change can alter predicted paths, so any staged reconcile
+        # plan may no longer be accurate — mark it stale so it must be rebuilt
+        Reconciliation.mark_ready_plans_stale()
 
         conn
         |> put_flash(:info, "Settings updated successfully.")

--- a/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
@@ -68,7 +68,6 @@
         label="Ignore Unavailable Media"
         help="Mark members-only, private, and removed videos as skipped instead of repeatedly erroring. They stay in the database but won't be retried"
       />
-<<<<<<< HEAD
       <div
         x-data={"{ is12h: #{f[:time_format].value == "12h"} }"}
         phx-update="ignore"

--- a/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
@@ -68,6 +68,7 @@
         label="Ignore Unavailable Media"
         help="Mark members-only, private, and removed videos as skipped instead of repeatedly erroring. They stay in the database but won't be retried"
       />
+<<<<<<< HEAD
       <div
         x-data={"{ is12h: #{f[:time_format].value == "12h"} }"}
         phx-update="ignore"
@@ -103,6 +104,13 @@
           <.help>Clock used when displaying timestamps in the UI</.help>
         </div>
       </div>
+
+      <.input
+        field={f[:database_maintenance_enabled]}
+        type="toggle"
+        label="Scheduled Database Compaction"
+        help="Automatically compact the database once a month to reclaim disk space. Job queues are paused while running jobs finish, then processing resumes. You can always compact manually from the Diagnostics page"
+      />
     </section>
   </section>
 

--- a/lib/pinchflat_web/controllers/sources/source_controller.ex
+++ b/lib/pinchflat_web/controllers/sources/source_controller.ex
@@ -9,6 +9,7 @@ defmodule PinchflatWeb.Sources.SourceController do
   alias Pinchflat.Media
   alias Pinchflat.Tasks.Task
   alias Pinchflat.Sources
+  alias Pinchflat.Reconciliation
   alias Pinchflat.Sources.Source
   alias Pinchflat.Profiles.MediaProfile
   alias Pinchflat.Media.FileSyncingWorker
@@ -190,11 +191,32 @@ defmodule PinchflatWeb.Sources.SourceController do
     source = Sources.get_source!(id)
     changeset = Sources.change_source(source)
 
+<<<<<<< HEAD
     render(
       conn,
       :edit,
       Keyword.merge(
         [
+=======
+    render(conn, :edit, source: source, changeset: changeset, media_profiles: media_profiles())
+  end
+
+  def update(conn, %{"id" => id, "source" => source_params}) do
+    source = Sources.get_source!(id)
+
+    case Sources.update_source(source, source_params) do
+      {:ok, source} ->
+        # Source changes (e.g. an output-path override) can alter predicted paths,
+        # invalidating any staged reconcile plan
+        Reconciliation.mark_ready_plans_stale()
+
+        conn
+        |> put_flash(:info, "Source updated successfully.")
+        |> redirect(to: ~p"/sources/#{source}")
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        render(conn, :edit,
+>>>>>>> ad2a66e (feat: relocate and true up downloaded files after settings changes, without re-downloading)
           source: source,
           changeset: changeset,
           media_profiles: media_profiles(),

--- a/lib/pinchflat_web/controllers/sources/source_controller.ex
+++ b/lib/pinchflat_web/controllers/sources/source_controller.ex
@@ -191,32 +191,11 @@ defmodule PinchflatWeb.Sources.SourceController do
     source = Sources.get_source!(id)
     changeset = Sources.change_source(source)
 
-<<<<<<< HEAD
     render(
       conn,
       :edit,
       Keyword.merge(
         [
-=======
-    render(conn, :edit, source: source, changeset: changeset, media_profiles: media_profiles())
-  end
-
-  def update(conn, %{"id" => id, "source" => source_params}) do
-    source = Sources.get_source!(id)
-
-    case Sources.update_source(source, source_params) do
-      {:ok, source} ->
-        # Source changes (e.g. an output-path override) can alter predicted paths,
-        # invalidating any staged reconcile plan
-        Reconciliation.mark_ready_plans_stale()
-
-        conn
-        |> put_flash(:info, "Source updated successfully.")
-        |> redirect(to: ~p"/sources/#{source}")
-
-      {:error, %Ecto.Changeset{} = changeset} ->
-        render(conn, :edit,
->>>>>>> ad2a66e (feat: relocate and true up downloaded files after settings changes, without re-downloading)
           source: source,
           changeset: changeset,
           media_profiles: media_profiles(),
@@ -495,6 +474,8 @@ defmodule PinchflatWeb.Sources.SourceController do
   defp do_update(conn, source, source_params) do
     case Sources.update_source(source, source_params) do
       {:ok, source} ->
+        Reconciliation.mark_ready_plans_stale()
+
         case get_format(conn) do
           "json" ->
             source = Sources.preload_api_assocs(source)

--- a/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
@@ -83,7 +83,7 @@
   </:option>
 
   <:option>
-    <.link href={~p"/settings/reconciliation?source_id=#{@source.id}"}>
+    <.link href={~p"/reconciliation?source_id=#{@source.id}"}>
       Reconcile Files
     </.link>
   </:option>

--- a/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/actions_dropdown.html.heex
@@ -83,6 +83,11 @@
   </:option>
 
   <:option>
+    <.link href={~p"/settings/reconciliation?source_id=#{@source.id}"}>
+      Reconcile Files
+    </.link>
+  </:option>
+  <:option>
     <div class="h-px w-full bg-theme-outline/70"></div>
   </:option>
 

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -59,6 +59,8 @@ defmodule PinchflatWeb.Router do
     post "/diagnostics/reset_job/:id", Settings.DiagnosticsController, :reset_job
     post "/diagnostics/requeue_job/:id", Settings.DiagnosticsController, :requeue_job
     post "/diagnostics/delete_job/:id", Settings.DiagnosticsController, :delete_job
+    post "/diagnostics/vacuum_database", Settings.DiagnosticsController, :vacuum_database
+    post "/diagnostics/toggle_scheduled_compaction", Settings.DiagnosticsController, :toggle_scheduled_compaction
 
     resources "/sources", Sources.SourceController do
       post "/restore_automatic_downloads", Sources.SourceController, :restore_automatic_downloads

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -54,6 +54,10 @@ defmodule PinchflatWeb.Router do
     get "/settings/cookies", Settings.SettingController, :download_cookies
     get "/download_logs", Settings.SettingController, :download_logs
 
+    get "/reconciliation", Settings.ReconciliationController, :show
+    post "/reconciliation", Settings.ReconciliationController, :build
+    post "/reconciliation/apply/:plan_id", Settings.ReconciliationController, :apply
+
     get "/diagnostics", Settings.DiagnosticsController, :show
     post "/diagnostics/reset_retryable_jobs", Settings.DiagnosticsController, :reset_retryable_jobs
     post "/diagnostics/reset_job/:id", Settings.DiagnosticsController, :reset_job

--- a/priv/repo/migrations/20260717130000_add_database_maintenance_enabled_to_settings.exs
+++ b/priv/repo/migrations/20260717130000_add_database_maintenance_enabled_to_settings.exs
@@ -1,0 +1,10 @@
+defmodule Pinchflat.Repo.Migrations.AddDatabaseMaintenanceEnabledToSettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:settings) do
+      # Opt-in while the feature matures — intended to become opt-out later
+      add :database_maintenance_enabled, :boolean, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260723130000_create_reconcile_plans.exs
+++ b/priv/repo/migrations/20260723130000_create_reconcile_plans.exs
@@ -1,0 +1,46 @@
+defmodule Pinchflat.Repo.Migrations.CreateReconcilePlans do
+  use Ecto.Migration
+
+  def change do
+    create table(:reconcile_plans) do
+      # local: zero-network (moves + backfills possible from stored metadata)
+      # online: additionally backfills missing thumbnails/subtitles via light yt-dlp fetches
+      # full: additionally re-downloads format-mismatched media
+      add :mode, :string, null: false
+      # Null source means the plan covers every source
+      add :source_id, references(:sources, on_delete: :delete_all), null: true
+      add :status, :string, null: false, default: "building"
+      add :move_count, :integer, null: false, default: 0
+      add :backfill_count, :integer, null: false, default: 0
+      add :delete_count, :integer, null: false, default: 0
+      add :skip_count, :integer, null: false, default: 0
+      add :collision_count, :integer, null: false, default: 0
+      add :error_count, :integer, null: false, default: 0
+      add :redownload_count, :integer, null: false, default: 0
+      add :applied_at, :utc_datetime, null: true
+      add :error_message, :text, null: true
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create table(:reconcile_plan_items) do
+      add :reconcile_plan_id, references(:reconcile_plans, on_delete: :delete_all), null: false
+      # Null for source-level artifact rows (series NFO/images)
+      add :media_item_id, references(:media_items, on_delete: :delete_all), null: true
+      add :source_id, references(:sources, on_delete: :delete_all), null: true
+      add :action, :string, null: false
+      add :attribute, :string, null: false
+      add :from_path, :text, null: true
+      add :to_path, :text, null: true
+      add :status, :string, null: false, default: "planned"
+      add :detail, :text, null: true
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:reconcile_plans, [:source_id])
+    create index(:reconcile_plan_items, [:reconcile_plan_id, :action])
+    create index(:reconcile_plan_items, [:media_item_id])
+    create index(:reconcile_plan_items, [:source_id])
+  end
+end

--- a/test/pinchflat/boot/pre_job_startup_tasks_test.exs
+++ b/test/pinchflat/boot/pre_job_startup_tasks_test.exs
@@ -40,6 +40,40 @@ defmodule Pinchflat.Boot.PreJobStartupTasksTest do
     end
   end
 
+  describe "revive_stalled_reconcile_jobs" do
+    test "resets a stalled reconcile job left at its attempt ceiling" do
+      {:ok, job} =
+        %{"op" => "apply", "plan_id" => 1}
+        |> Pinchflat.Reconciliation.ReconcileWorker.new()
+        |> Oban.insert()
+
+      # Mimic an apply that was executing at an ungraceful shutdown: reset_executing_jobs
+      # will flip it executing -> retryable, leaving it at attempt == max_attempts (1)
+      Repo.update_all(Oban.Job, set: [state: "executing", attempt: 1])
+
+      PreJobStartupTasks.init(%{})
+
+      reloaded = Repo.reload!(job)
+      assert reloaded.state == "available"
+      assert reloaded.attempt == 0
+    end
+
+    test "leaves a healthy pending reconcile job untouched" do
+      {:ok, job} =
+        %{"op" => "build", "plan_id" => 1}
+        |> Pinchflat.Reconciliation.ReconcileWorker.new()
+        |> Oban.insert()
+
+      assert Repo.reload!(job).state == "available"
+      assert Repo.reload!(job).attempt == 0
+
+      PreJobStartupTasks.init(%{})
+
+      # attempt 0 < max_attempts 1, so it isn't stalled and isn't disturbed
+      assert Repo.reload!(job).state == "available"
+    end
+  end
+
   describe "create_blank_yt_dlp_files" do
     test "creates a blank cookie file" do
       base_dir = Application.get_env(:pinchflat, :extras_directory)

--- a/test/pinchflat/diagnostics/database_diagnostics_test.exs
+++ b/test/pinchflat/diagnostics/database_diagnostics_test.exs
@@ -1,0 +1,80 @@
+defmodule Pinchflat.Diagnostics.DatabaseDiagnosticsTest do
+  use Pinchflat.DataCase
+
+  alias Pinchflat.Diagnostics.DatabaseDiagnostics
+  alias Pinchflat.Diagnostics.DatabaseMaintenanceWorker
+
+  import Pinchflat.MediaFixtures
+  import Pinchflat.TasksFixtures
+
+  describe "get_database_stats/0" do
+    test "returns file sizes for the database and its sidecars" do
+      stats = DatabaseDiagnostics.get_database_stats()
+
+      assert stats.main_file_bytes > 0
+      assert stats.total_bytes == stats.main_file_bytes + stats.wal_file_bytes + stats.shm_file_bytes
+    end
+
+    test "returns page-level statistics" do
+      stats = DatabaseDiagnostics.get_database_stats()
+
+      assert stats.page_size > 0
+      assert stats.page_count > 0
+      assert stats.reclaimable_bytes == stats.freelist_count * stats.page_size
+    end
+
+    test "returns the journal mode" do
+      assert DatabaseDiagnostics.get_database_stats().journal_mode in ["wal", "delete", "truncate", "memory"]
+    end
+  end
+
+  describe "table_row_counts/0" do
+    test "returns counts for the tracked tables" do
+      counts = Map.new(DatabaseDiagnostics.table_row_counts())
+
+      assert Map.has_key?(counts, "media_items")
+      assert Map.has_key?(counts, "sources")
+      assert Map.has_key?(counts, "media_profiles")
+      assert Map.has_key?(counts, "tasks")
+      assert Map.has_key?(counts, "oban_jobs")
+    end
+
+    test "counts reflect existing records" do
+      media_item_fixture()
+
+      counts = Map.new(DatabaseDiagnostics.table_row_counts())
+
+      assert counts["sources"] == 1
+      assert counts["media_items"] == 1
+    end
+  end
+
+  describe "orphaned_task_count/0" do
+    test "returns 0 when all tasks have a job" do
+      task_fixture()
+
+      assert DatabaseDiagnostics.orphaned_task_count() == 0
+    end
+  end
+
+  describe "latest_maintenance_job/0" do
+    test "returns nil when no maintenance job has run" do
+      assert DatabaseDiagnostics.latest_maintenance_job() == nil
+    end
+
+    test "returns the most recent maintenance job" do
+      {:ok, job} = DatabaseMaintenanceWorker.kickoff()
+
+      assert DatabaseDiagnostics.latest_maintenance_job().id == job.id
+    end
+  end
+
+  describe "format_bytes/1" do
+    test "formats byte counts in binary units" do
+      assert DatabaseDiagnostics.format_bytes(512) == "512 B"
+      assert DatabaseDiagnostics.format_bytes(2048) == "2.0 KiB"
+      assert DatabaseDiagnostics.format_bytes(5 * 1024 * 1024) == "5.0 MiB"
+      assert DatabaseDiagnostics.format_bytes(3 * 1024 * 1024 * 1024) == "3.0 GiB"
+    end
+  end
+end

--- a/test/pinchflat/diagnostics/database_diagnostics_test.exs
+++ b/test/pinchflat/diagnostics/database_diagnostics_test.exs
@@ -69,6 +69,49 @@ defmodule Pinchflat.Diagnostics.DatabaseDiagnosticsTest do
     end
   end
 
+  describe "run_integrity_check/1" do
+    test "reports no findings for a healthy database in quick mode" do
+      assert {:ok, []} = DatabaseDiagnostics.run_integrity_check(:quick)
+    end
+
+    test "reports no findings for a healthy database in full mode" do
+      assert {:ok, []} = DatabaseDiagnostics.run_integrity_check(:full)
+    end
+
+    test "sees the FTS5 search index" do
+      media_item_fixture(title: "integrity check subject")
+
+      # The check calls each virtual table's xIntegrity method, so a healthy
+      # result here means the search index was checked and is intact
+      assert {:ok, []} = DatabaseDiagnostics.run_integrity_check(:quick)
+    end
+
+    test "does not modify the database" do
+      before_count = Map.new(DatabaseDiagnostics.table_row_counts())
+
+      DatabaseDiagnostics.run_integrity_check(:full)
+
+      assert Map.new(DatabaseDiagnostics.table_row_counts()) == before_count
+    end
+
+    test "returns SQLite's findings verbatim when the search index is corrupt" do
+      media_item_fixture(title: "a title to index")
+      corrupt_search_index()
+
+      assert {:ok, findings} = DatabaseDiagnostics.run_integrity_check(:quick)
+      assert findings != []
+      assert Enum.any?(findings, &String.contains?(&1, "media_items_search_index"))
+    end
+
+    test "a full check also reports search index corruption" do
+      media_item_fixture(title: "a title to index")
+      corrupt_search_index()
+
+      assert {:ok, findings} = DatabaseDiagnostics.run_integrity_check(:full)
+      assert Enum.any?(findings, &String.contains?(&1, "media_items_search_index"))
+    end
+  end
+
   describe "format_bytes/1" do
     test "formats byte counts in binary units" do
       assert DatabaseDiagnostics.format_bytes(512) == "512 B"

--- a/test/pinchflat/diagnostics/database_maintenance_worker_test.exs
+++ b/test/pinchflat/diagnostics/database_maintenance_worker_test.exs
@@ -1,0 +1,85 @@
+defmodule Pinchflat.Diagnostics.DatabaseMaintenanceWorkerTest do
+  use Pinchflat.DataCase
+
+  alias Pinchflat.Settings
+  alias Pinchflat.Diagnostics.DatabaseMaintenanceWorker
+  alias Pinchflat.JobFixtures.TestJobWorker
+
+  describe "kickoff/0" do
+    test "enqueues a manual maintenance job" do
+      assert {:ok, %Oban.Job{}} = DatabaseMaintenanceWorker.kickoff()
+
+      assert [job] = all_enqueued(worker: DatabaseMaintenanceWorker)
+      assert job.args == %{"manual" => true}
+    end
+
+    test "does not enqueue a duplicate job" do
+      assert {:ok, _} = DatabaseMaintenanceWorker.kickoff()
+      assert {:ok, %Oban.Job{conflict?: true}} = DatabaseMaintenanceWorker.kickoff()
+
+      assert [_] = all_enqueued(worker: DatabaseMaintenanceWorker)
+    end
+  end
+
+  describe "perform/1 opt-in gate" do
+    test "scheduled runs are skipped when the setting is disabled" do
+      assert {:cancel, message} = perform_job(DatabaseMaintenanceWorker, %{})
+      assert message =~ "Scheduled compaction is turned off"
+    end
+
+    test "scheduled runs proceed when the setting is enabled" do
+      Settings.set(database_maintenance_enabled: true)
+      stub(DiskSpaceCheckerMock, :available_bytes, fn _path -> {:ok, 0} end)
+
+      # Reaching the disk space check proves the gate let the run through
+      assert {:error, message} = perform_job(DatabaseMaintenanceWorker, %{})
+      assert message =~ "Not enough free disk space"
+    end
+
+    test "manual runs proceed even when the setting is disabled" do
+      stub(DiskSpaceCheckerMock, :available_bytes, fn _path -> {:ok, 0} end)
+
+      assert {:error, message} = perform_job(DatabaseMaintenanceWorker, %{"manual" => true})
+      assert message =~ "Not enough free disk space"
+    end
+  end
+
+  describe "perform/1 when other jobs are running" do
+    test "waits for them to finish before proceeding" do
+      stub(DiskSpaceCheckerMock, :available_bytes, fn _path -> {:ok, 0} end)
+      {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+      Repo.update_all(from(j in Oban.Job, where: j.id == ^job.id), set: [state: "executing"])
+
+      # Flip the executing job to completed shortly after the worker starts
+      # waiting, so the wait loop has to take at least one lap
+      test_pid = self()
+
+      Task.start(fn ->
+        Process.sleep(50)
+        Repo.update_all(from(j in Oban.Job, where: j.id == ^job.id), set: [state: "completed"])
+        send(test_pid, :job_completed)
+      end)
+
+      # Reaching the (stubbed, failing) disk space check proves the wait ended
+      assert {:error, message} = perform_job(DatabaseMaintenanceWorker, %{"manual" => true})
+      assert message =~ "Not enough free disk space"
+      assert_received :job_completed
+    end
+  end
+
+  describe "perform/1 when disk space is insufficient" do
+    test "fails with a descriptive error instead of vacuuming" do
+      stub(DiskSpaceCheckerMock, :available_bytes, fn _path -> {:ok, 0} end)
+
+      assert {:error, message} = perform_job(DatabaseMaintenanceWorker, %{"manual" => true})
+      assert message =~ "Not enough free disk space"
+    end
+
+    test "fails when free disk space cannot be determined" do
+      stub(DiskSpaceCheckerMock, :available_bytes, fn _path -> :error end)
+
+      assert {:error, message} = perform_job(DatabaseMaintenanceWorker, %{"manual" => true})
+      assert message =~ "Could not determine free disk space"
+    end
+  end
+end

--- a/test/pinchflat/diagnostics/database_maintenance_worker_vacuum_test.exs
+++ b/test/pinchflat/diagnostics/database_maintenance_worker_vacuum_test.exs
@@ -1,0 +1,31 @@
+defmodule Pinchflat.Diagnostics.DatabaseMaintenanceWorkerVacuumTest do
+  # VACUUM can't run inside a transaction, so this test opts out of the SQL
+  # sandbox and runs against the test database on a raw connection. The
+  # maintenance run doesn't modify any data, so there's nothing to roll back.
+  use ExUnit.Case, async: false
+  use Oban.Testing, repo: Pinchflat.Repo, engine: Oban.Engines.Lite
+
+  import Mox
+
+  alias Pinchflat.Diagnostics.DatabaseDiagnostics
+  alias Pinchflat.Diagnostics.DatabaseMaintenanceWorker
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Pinchflat.Repo, sandbox: false)
+    # The connection is automatically checked back in when the test process exits
+
+    stub(DiskSpaceCheckerMock, :available_bytes, fn _path -> {:ok, 1024 * 1024 * 1024 * 1024} end)
+
+    :ok
+  end
+
+  test "truncates the WAL and vacuums the database when disk space allows" do
+    # Manual args so the run doesn't depend on the opt-in setting's DB state
+    assert :ok = perform_job(DatabaseMaintenanceWorker, %{"manual" => true})
+
+    # The final checkpoint must leave the WAL empty — in WAL mode the VACUUM
+    # itself inflates the WAL to roughly the size of the database, which would
+    # otherwise negate the vacuum's disk savings
+    assert DatabaseDiagnostics.get_database_stats().wal_file_bytes == 0
+  end
+end

--- a/test/pinchflat/diagnostics/queue_diagnostics_test.exs
+++ b/test/pinchflat/diagnostics/queue_diagnostics_test.exs
@@ -3,8 +3,10 @@ defmodule Pinchflat.Diagnostics.QueueDiagnosticsTest do
 
   alias Pinchflat.Tasks
   alias Pinchflat.Diagnostics.QueueDiagnostics
+  alias Pinchflat.Diagnostics.DatabaseMaintenanceWorker
   alias Pinchflat.JobFixtures.TestJobWorker
   alias Pinchflat.FastIndexing.FastIndexingWorker
+  alias Pinchflat.Reconciliation.ReconcileWorker
 
   import Pinchflat.MediaFixtures
   import Pinchflat.SourcesFixtures
@@ -15,6 +17,13 @@ defmodule Pinchflat.Diagnostics.QueueDiagnosticsTest do
     test "returns the queue names from the Oban config" do
       assert :default in QueueDiagnostics.queue_names()
       assert :media_fetching in QueueDiagnostics.queue_names()
+      assert :maintenance in QueueDiagnostics.queue_names()
+    end
+
+    test "serializes workers that reserve a full quiet window" do
+      assert Ecto.Changeset.get_change(ReconcileWorker.new(%{}), :queue) == "maintenance"
+      assert Ecto.Changeset.get_change(DatabaseMaintenanceWorker.new(%{}), :queue) == "maintenance"
+      assert Application.fetch_env!(:pinchflat, Oban)[:queues][:maintenance] == 1
     end
 
     test "returns an empty list when no queues are configured" do

--- a/test/pinchflat/diagnostics/queue_diagnostics_test.exs
+++ b/test/pinchflat/diagnostics/queue_diagnostics_test.exs
@@ -9,6 +9,230 @@ defmodule Pinchflat.Diagnostics.QueueDiagnosticsTest do
   import Pinchflat.MediaFixtures
   import Pinchflat.SourcesFixtures
 
+<<<<<<< HEAD
+=======
+  describe "queue_names/0" do
+    test "returns the queue names from the Oban config" do
+      assert :default in QueueDiagnostics.queue_names()
+      assert :media_fetching in QueueDiagnostics.queue_names()
+    end
+
+    test "returns an empty list when no queues are configured" do
+      original = Application.get_env(:pinchflat, Oban, [])
+      on_exit(fn -> Application.put_env(:pinchflat, Oban, original) end)
+
+      Application.put_env(:pinchflat, Oban, Keyword.delete(original, :queues))
+
+      assert QueueDiagnostics.queue_names() == []
+    end
+  end
+
+  describe "get_all_queue_stats/0" do
+    test "returns an entry per configured queue without crashing when queues aren't running" do
+      stats = QueueDiagnostics.get_all_queue_stats()
+
+      assert length(stats) == length(QueueDiagnostics.queue_names())
+      assert %{name: :default, running: 0, limit: 0, paused: false} = Enum.find(stats, &(&1.name == :default))
+    end
+
+    test "counts jobs in the queue by state" do
+      {:ok, _available} = Oban.insert(TestJobWorker.new(%{"id" => 1}))
+      {:ok, _also_available} = Oban.insert(TestJobWorker.new(%{"id" => 2}))
+      {:ok, retryable} = Oban.insert(TestJobWorker.new(%{"id" => 3}))
+      set_job_state(retryable, "retryable")
+
+      default_stats = Enum.find(QueueDiagnostics.get_all_queue_stats(), &(&1.name == :default))
+
+      assert %{available: 2, retryable: 1, scheduled: 0, executing: 0} = default_stats
+    end
+  end
+
+  describe "get_retryable_jobs/1" do
+    test "returns only retryable jobs" do
+      {:ok, retryable} = Oban.insert(TestJobWorker.new(%{"id" => 1}))
+      {:ok, _available} = Oban.insert(TestJobWorker.new(%{"id" => 2}))
+      set_job_state(retryable, "retryable")
+
+      assert [%{id: id, args: %{"id" => 1}, state: "retryable"}] = QueueDiagnostics.get_retryable_jobs()
+      assert id == retryable.id
+    end
+
+    test "orders jobs by most recently attempted first" do
+      {:ok, older} = Oban.insert(TestJobWorker.new(%{}))
+      {:ok, newer} = Oban.insert(TestJobWorker.new(%{}))
+      set_job_state(older, "retryable", attempted_at: hours_ago(2))
+      set_job_state(newer, "retryable", attempted_at: hours_ago(1))
+
+      assert [%{id: first}, %{id: second}] = QueueDiagnostics.get_retryable_jobs()
+      assert first == newer.id
+      assert second == older.id
+    end
+
+    test "respects the limit" do
+      Enum.each(1..3, fn _ ->
+        {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+        set_job_state(job, "retryable")
+      end)
+
+      assert length(QueueDiagnostics.get_retryable_jobs(2)) == 2
+    end
+  end
+
+  describe "get_discarded_jobs/1" do
+    test "returns only discarded jobs" do
+      {:ok, discarded} = Oban.insert(TestJobWorker.new(%{"id" => 1}))
+      {:ok, _available} = Oban.insert(TestJobWorker.new(%{"id" => 2}))
+      set_job_state(discarded, "discarded")
+
+      assert [%{id: id, args: %{"id" => 1}, state: "discarded"}] = QueueDiagnostics.get_discarded_jobs()
+      assert id == discarded.id
+    end
+
+    test "orders jobs by most recently discarded first" do
+      {:ok, older} = Oban.insert(TestJobWorker.new(%{}))
+      {:ok, newer} = Oban.insert(TestJobWorker.new(%{}))
+      set_job_state(older, "discarded", discarded_at: hours_ago(2))
+      set_job_state(newer, "discarded", discarded_at: hours_ago(1))
+
+      assert [%{id: first}, %{id: second}] = QueueDiagnostics.get_discarded_jobs()
+      assert first == newer.id
+      assert second == older.id
+    end
+
+    test "respects the limit" do
+      Enum.each(1..3, fn _ ->
+        {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+        set_job_state(job, "discarded")
+      end)
+
+      assert length(QueueDiagnostics.get_discarded_jobs(2)) == 2
+    end
+  end
+
+  describe "get_stuck_jobs/1" do
+    test "returns executing jobs older than the threshold" do
+      {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+      set_job_state(job, "executing", attempted_at: hours_ago(1))
+
+      assert [%{id: id}] = QueueDiagnostics.get_stuck_jobs(30)
+      assert id == job.id
+    end
+
+    test "does not return executing jobs within the threshold" do
+      {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+      set_job_state(job, "executing", attempted_at: DateTime.utc_now())
+
+      assert QueueDiagnostics.get_stuck_jobs(30) == []
+    end
+
+    test "does not return non-executing jobs no matter how old" do
+      {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+      set_job_state(job, "retryable", attempted_at: hours_ago(10))
+
+      assert QueueDiagnostics.get_stuck_jobs(30) == []
+    end
+  end
+
+  describe "reset_retryable_jobs/0" do
+    test "makes retryable jobs available again and returns the count" do
+      {:ok, job_one} = Oban.insert(TestJobWorker.new(%{"id" => 1}))
+      {:ok, job_two} = Oban.insert(TestJobWorker.new(%{"id" => 2}))
+      set_job_state(job_one, "retryable", attempt: 3, errors: [%{"error" => "boom"}])
+      set_job_state(job_two, "retryable")
+
+      assert QueueDiagnostics.reset_retryable_jobs() == 2
+
+      assert %{state: "available", attempt: 1, errors: []} = Repo.get(Oban.Job, job_one.id)
+      assert %{state: "available"} = Repo.get(Oban.Job, job_two.id)
+    end
+
+    test "does not touch jobs in other states" do
+      {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+      set_job_state(job, "discarded")
+
+      assert QueueDiagnostics.reset_retryable_jobs() == 0
+      assert %{state: "discarded"} = Repo.get(Oban.Job, job.id)
+    end
+  end
+
+  describe "reset_job/1" do
+    test "resets a retryable job" do
+      {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+      set_job_state(job, "retryable", attempt: 5, errors: [%{"error" => "boom"}])
+
+      assert QueueDiagnostics.reset_job(job.id) == 1
+      assert %{state: "available", attempt: 1, errors: []} = Repo.get(Oban.Job, job.id)
+    end
+
+    test "resets a discarded job" do
+      {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+      set_job_state(job, "discarded")
+
+      assert QueueDiagnostics.reset_job(job.id) == 1
+      assert %{state: "available"} = Repo.get(Oban.Job, job.id)
+    end
+
+    test "refuses to reset an executing job to prevent double execution" do
+      {:ok, job} = Oban.insert(TestJobWorker.new(%{}))
+      set_job_state(job, "executing")
+
+      assert QueueDiagnostics.reset_job(job.id) == 0
+      assert %{state: "executing"} = Repo.get(Oban.Job, job.id)
+    end
+
+    test "returns 0 when the job does not exist" do
+      assert QueueDiagnostics.reset_job(-1) == 0
+    end
+  end
+
+  describe "get_system_stats/0" do
+    test "counts pending and downloaded media items separately" do
+      source = source_fixture()
+      _pending = media_item_fixture(%{source_id: source.id, media_filepath: nil})
+      _downloaded = media_item_fixture(%{source_id: source.id})
+
+      stats = QueueDiagnostics.get_system_stats()
+
+      assert stats.total_pending_downloads == 1
+      assert stats.total_downloaded == 1
+    end
+
+    test "excludes media that the profile's rules would never download from the pending count" do
+      source = source_fixture(title_filter_regex: "^Keep")
+      _matching = media_item_fixture(%{source_id: source.id, media_filepath: nil, title: "Keep me"})
+      _filtered = media_item_fixture(%{source_id: source.id, media_filepath: nil, title: "Skip me"})
+
+      assert QueueDiagnostics.get_system_stats().total_pending_downloads == 1
+    end
+
+    test "counts sources" do
+      source_fixture()
+      source_fixture()
+
+      assert QueueDiagnostics.get_system_stats().total_sources == 2
+    end
+
+    test "counts all media items regardless of state" do
+      source = source_fixture()
+      media_item_fixture(%{source_id: source.id, media_filepath: nil})
+      media_item_fixture(%{source_id: source.id})
+
+      assert QueueDiagnostics.get_system_stats().total_media_items == 2
+    end
+  end
+
+  defp set_job_state(job, state, extra_fields \\ []) do
+    Repo.update_all(
+      from(j in Oban.Job, where: j.id == ^job.id),
+      set: [{:state, state} | extra_fields]
+    )
+  end
+
+  defp hours_ago(hours) do
+    DateTime.add(DateTime.utc_now(), -hours * 60 * 60, :second)
+  end
+
+>>>>>>> ee741db (feat: add database insights and safe compaction maintenance to the diagnostics page)
   describe "get_jobs_for_queue/2" do
     test "returns jobs sitting in the given queue" do
       {:ok, job} = Oban.insert(TestJobWorker.new(%{"id" => 42}))

--- a/test/pinchflat/diagnostics/queue_diagnostics_test.exs
+++ b/test/pinchflat/diagnostics/queue_diagnostics_test.exs
@@ -11,8 +11,6 @@ defmodule Pinchflat.Diagnostics.QueueDiagnosticsTest do
   import Pinchflat.MediaFixtures
   import Pinchflat.SourcesFixtures
 
-<<<<<<< HEAD
-=======
   describe "queue_names/0" do
     test "returns the queue names from the Oban config" do
       assert :default in QueueDiagnostics.queue_names()
@@ -241,7 +239,6 @@ defmodule Pinchflat.Diagnostics.QueueDiagnosticsTest do
     DateTime.add(DateTime.utc_now(), -hours * 60 * 60, :second)
   end
 
->>>>>>> ee741db (feat: add database insights and safe compaction maintenance to the diagnostics page)
   describe "get_jobs_for_queue/2" do
     test "returns jobs sitting in the given queue" do
       {:ok, job} = Oban.insert(TestJobWorker.new(%{"id" => 42}))

--- a/test/pinchflat/metadata/metadata_file_helpers_test.exs
+++ b/test/pinchflat/metadata/metadata_file_helpers_test.exs
@@ -58,6 +58,17 @@ defmodule Pinchflat.Metadata.MetadataFileHelpersTest do
 
       assert decoded_json == metadata_map
     end
+
+    test "round-trips non-ASCII characters without mangling them", %{media_item: media_item} do
+      # Regression: reading via a latin1 IO device double-encoded UTF-8, so an
+      # emoji title came back as mojibake and flowed into rendered filepaths
+      metadata_map = %{"title" => "EPISODE 100!!! Our SEXIEST Reveal Yet 🔥"}
+
+      filepath = Helpers.compress_and_store_metadata_for(media_item, metadata_map)
+      {:ok, decoded_json} = Helpers.read_compressed_metadata(filepath)
+
+      assert decoded_json == metadata_map
+    end
   end
 
   describe "download_and_store_thumbnail_for/2" do

--- a/test/pinchflat/reconciliation/path_predictor_test.exs
+++ b/test/pinchflat/reconciliation/path_predictor_test.exs
@@ -1,0 +1,94 @@
+defmodule Pinchflat.Reconciliation.PathPredictorTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.MediaFixtures
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Media
+  alias Pinchflat.Metadata.MetadataFileHelpers
+  alias Pinchflat.Reconciliation.PathPredictor
+
+  setup do
+    media_item = downloaded_media_item_with_stored_metadata()
+
+    {:ok, media_item: media_item}
+  end
+
+  describe "predict_media_filepath/1" do
+    test "renders the filename offline via --load-info-json", %{media_item: media_item} do
+      expect(YtDlpRunnerMock, :run, fn url, action, opts, ot, addl ->
+        assert url == media_item.original_url
+        assert action == :predict_filepath_from_metadata
+        assert :simulate in opts
+        assert :skip_download in opts
+        assert Keyword.has_key?(opts, :load_info_json)
+        assert Keyword.has_key?(opts, :output)
+        assert ot == "%(.{filename})j"
+        assert Keyword.get(addl, :skip_sleep_interval)
+
+        {:ok, ~s({"filename": "/downloads/new home/video.mp4"})}
+      end)
+
+      assert {:ok, "/downloads/new home/video.mp4"} = PathPredictor.predict_media_filepath(media_item)
+    end
+
+    test "substitutes the actual downloaded extension", %{media_item: media_item} do
+      expect(YtDlpRunnerMock, :run, fn _url, _action, _opts, _ot, _addl ->
+        {:ok, ~s({"filename": "/downloads/new home/video.webm"})}
+      end)
+
+      # The fixture's downloaded file is an .mp4
+      assert {:ok, "/downloads/new home/video.mp4"} = PathPredictor.predict_media_filepath(media_item)
+    end
+
+    test "returns :no_metadata when the item has no stored metadata" do
+      media_item = Repo.preload(media_item_with_attachments(), [:metadata, source: :media_profile])
+
+      assert {:error, :no_metadata} = PathPredictor.predict_media_filepath(media_item)
+    end
+
+    test "normalizes runner errors", %{media_item: media_item} do
+      expect(YtDlpRunnerMock, :run, fn _url, _action, _opts, _ot, _addl ->
+        {:error, "big bad", 1}
+      end)
+
+      assert {:error, "big bad"} = PathPredictor.predict_media_filepath(media_item)
+    end
+  end
+
+  describe "predict_series_directory/1" do
+    test "derives the series directory from the rendered filepath", %{media_item: media_item} do
+      expect(YtDlpRunnerMock, :run, fn _url, _action, _opts, _ot, _addl ->
+        {:ok, ~s({"filename": "/downloads/Cool Channel/Season 1/video.mp4"})}
+      end)
+
+      assert {:ok, "/downloads/Cool Channel"} = PathPredictor.predict_series_directory(media_item)
+    end
+
+    test "returns an error when the directory can't be determined", %{media_item: media_item} do
+      expect(YtDlpRunnerMock, :run, fn _url, _action, _opts, _ot, _addl ->
+        {:ok, ~s({"filename": "/downloads/video.mp4"})}
+      end)
+
+      assert {:error, :indeterminable} = PathPredictor.predict_series_directory(media_item)
+    end
+  end
+
+  defp downloaded_media_item_with_stored_metadata do
+    media_item = Repo.preload(media_item_with_attachments(), :metadata)
+
+    metadata_filepath =
+      MetadataFileHelpers.compress_and_store_metadata_for(media_item, %{
+        "id" => media_item.media_id,
+        "title" => media_item.title,
+        "upload_date" => "20240101"
+      })
+
+    {:ok, media_item} =
+      Media.update_media_item(media_item, %{
+        metadata: %{metadata_filepath: metadata_filepath, thumbnail_filepath: media_item.thumbnail_filepath}
+      })
+
+    Repo.preload(media_item, [:metadata, source: :media_profile], force: true)
+  end
+end

--- a/test/pinchflat/reconciliation/plan_applier_test.exs
+++ b/test/pinchflat/reconciliation/plan_applier_test.exs
@@ -1,0 +1,242 @@
+defmodule Pinchflat.Reconciliation.PlanApplierTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.MediaFixtures
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Media
+  alias Pinchflat.Reconciliation
+  alias Pinchflat.Reconciliation.PlanApplier
+  alias Pinchflat.Reconciliation.ReconcilePlanItem
+  alias Pinchflat.Metadata.MetadataFileHelpers
+
+  describe "apply_plan/1 (moves)" do
+    test "moves the file, updates the column, and marks the row done" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+      target = new_target_path()
+
+      create_row(plan, media_item, :move, "media", from_path: media_item.media_filepath, to_path: target)
+
+      assert {:ok, applied} = PlanApplier.apply_plan(plan)
+
+      assert applied.status == :applied
+      assert File.exists?(target)
+      refute File.exists?(media_item.media_filepath)
+      assert Repo.reload(media_item).media_filepath == target
+      assert [%{status: :done}] = list_rows(plan)
+    end
+
+    test "moves subtitle files and updates the language entry" do
+      media_item = downloaded_media_item()
+      [["en", subtitle_path]] = media_item.subtitle_filepaths
+      plan = ready_plan(media_item.source_id)
+      target = Path.rootname(new_target_path()) <> ".en.srt"
+
+      create_row(plan, media_item, :move, "subtitle:en", from_path: subtitle_path, to_path: target)
+
+      assert {:ok, _} = PlanApplier.apply_plan(plan)
+
+      assert File.exists?(target)
+      assert Repo.reload(media_item).subtitle_filepaths == [["en", target]]
+    end
+
+    test "skips a move whose destination became occupied after planning" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+      target = new_target_path()
+      # Something landed at the target between the dry run and apply
+      Pinchflat.Utils.FilesystemUtils.write_p!(target, "someone else's file")
+
+      create_row(plan, media_item, :move, "media", from_path: media_item.media_filepath, to_path: target)
+
+      assert {:ok, _} = PlanApplier.apply_plan(plan)
+
+      assert [%{status: :skipped, detail: detail}] = list_rows(plan)
+      assert detail =~ "occupied"
+      # Neither the occupant nor the source file was touched
+      assert File.read!(target) == "someone else's file"
+      assert File.exists?(media_item.media_filepath)
+      assert Repo.reload(media_item).media_filepath == media_item.media_filepath
+    end
+
+    test "skips rows that have gone stale" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+
+      create_row(plan, media_item, :move, "media",
+        from_path: "/somewhere/else/entirely.mp4",
+        to_path: new_target_path()
+      )
+
+      assert {:ok, _} = PlanApplier.apply_plan(plan)
+
+      assert [%{status: :skipped, detail: detail}] = list_rows(plan)
+      assert detail =~ "Stale"
+      assert Repo.reload(media_item).media_filepath == media_item.media_filepath
+    end
+  end
+
+  describe "apply_plan/1 (deletes and backfills)" do
+    test "deletes now-unwanted sidecars and nils the column" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+
+      create_row(plan, media_item, :delete, "thumbnail", from_path: media_item.thumbnail_filepath)
+
+      assert {:ok, _} = PlanApplier.apply_plan(plan)
+
+      refute File.exists?(media_item.thumbnail_filepath)
+      assert Repo.reload(media_item).thumbnail_filepath == nil
+    end
+
+    test "backfills an NFO from stored metadata without any network calls" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+      target = Path.rootname(new_target_path()) <> ".nfo"
+
+      create_row(plan, media_item, :backfill, "nfo", to_path: target)
+
+      assert {:ok, _} = PlanApplier.apply_plan(plan)
+
+      assert File.exists?(target)
+      assert File.read!(target) =~ "<episodedetails>"
+      assert Repo.reload(media_item).nfo_filepath == target
+    end
+
+    test "backfills the info.json from stored metadata" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+      target = Path.rootname(new_target_path()) <> ".info.json"
+
+      create_row(plan, media_item, :backfill, "metadata", to_path: target)
+
+      assert {:ok, _} = PlanApplier.apply_plan(plan)
+
+      assert File.exists?(target)
+      assert Phoenix.json_library().decode!(File.read!(target))["id"] == media_item.media_id
+      assert Repo.reload(media_item).metadata_filepath == target
+    end
+
+    test "backfills subtitles that yt-dlp writes and records the language entry" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+      target = Path.rootname(new_target_path()) <> ".en.srt"
+
+      # yt-dlp names the sub off the media output template — write the file it would
+      expect(YtDlpRunnerMock, :run, fn _url, :download_subtitles, opts, _ot, _addl ->
+        srt = opts |> Keyword.fetch!(:output) |> String.replace_suffix(".%(ext)s", ".en.srt")
+        Pinchflat.Utils.FilesystemUtils.write_p!(srt, "1\n00:00 --> 00:01\nhi\n")
+        {:ok, ""}
+      end)
+
+      create_row(plan, media_item, :backfill, "subtitles", to_path: target)
+
+      assert {:ok, _} = PlanApplier.apply_plan(plan)
+
+      assert [%{status: :done}] = list_rows(plan)
+      assert [["en", srt_path]] = Media.get_media_item!(media_item.id).subtitle_filepaths
+      assert srt_path =~ ".en.srt"
+      assert File.exists?(srt_path)
+    end
+
+    test "skips the subtitle backfill when yt-dlp writes nothing" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+      target = Path.rootname(new_target_path()) <> ".en.srt"
+
+      # Video only has auto-captions and the profile wants manual subs — exit 0, no file
+      expect(YtDlpRunnerMock, :run, fn _url, :download_subtitles, _opts, _ot, _addl -> {:ok, ""} end)
+
+      create_row(plan, media_item, :backfill, "subtitles", to_path: target)
+
+      assert {:ok, _} = PlanApplier.apply_plan(plan)
+
+      assert [%{status: :skipped, detail: detail}] = list_rows(plan)
+      assert detail =~ "auto-generated subtitles"
+    end
+
+    test "records failures without aborting the run" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+      target = new_target_path()
+
+      # An unknown attribute fails its row; the valid move still applies
+      create_row(plan, media_item, :backfill, "bogus", to_path: "/tmp/whatever")
+      create_row(plan, media_item, :move, "media", from_path: media_item.media_filepath, to_path: target)
+
+      assert {:ok, applied} = PlanApplier.apply_plan(plan)
+
+      assert applied.error_count == 1
+      assert File.exists?(target)
+      statuses = plan |> list_rows() |> Enum.map(& &1.status) |> Enum.sort()
+      assert statuses == [:done, :failed]
+    end
+  end
+
+  describe "apply_plan/1 (re-downloads)" do
+    test "schedules a forced re-download and leaves filepaths untouched" do
+      media_item = downloaded_media_item()
+      plan = ready_plan(media_item.source_id)
+
+      create_row(plan, media_item, :redownload, "media", from_path: media_item.media_filepath)
+
+      assert {:ok, applied} = PlanApplier.apply_plan(plan)
+
+      assert applied.status == :applied
+      assert [%{status: :done}] = list_rows(plan)
+      assert [_job] = all_enqueued(worker: Pinchflat.Downloading.MediaDownloadWorker)
+      # The download job (not the applier) updates paths, so the file is untouched here
+      assert File.exists?(media_item.media_filepath)
+      assert Repo.reload(media_item).media_filepath == media_item.media_filepath
+    end
+  end
+
+  defp downloaded_media_item do
+    media_item = Repo.preload(media_item_with_attachments(), :metadata)
+
+    metadata_filepath =
+      MetadataFileHelpers.compress_and_store_metadata_for(media_item, %{
+        "id" => media_item.media_id,
+        "title" => media_item.title,
+        "description" => "a description",
+        "upload_date" => "20240101"
+      })
+
+    {:ok, media_item} =
+      Media.update_media_item(media_item, %{
+        metadata: %{metadata_filepath: metadata_filepath, thumbnail_filepath: media_item.thumbnail_filepath}
+      })
+
+    media_item
+  end
+
+  defp ready_plan(source_id) do
+    {:ok, plan} = Reconciliation.create_plan(%{mode: :local, source_id: source_id, status: :ready})
+
+    plan
+  end
+
+  defp create_row(plan, media_item, action, attribute, opts) do
+    Reconciliation.create_plan_items([
+      %{
+        reconcile_plan_id: plan.id,
+        media_item_id: media_item.id,
+        source_id: media_item.source_id,
+        action: action,
+        attribute: attribute,
+        from_path: Keyword.get(opts, :from_path),
+        to_path: Keyword.get(opts, :to_path),
+        status: :planned
+      }
+    ])
+  end
+
+  defp list_rows(plan) do
+    Repo.all(from(rpi in ReconcilePlanItem, where: rpi.reconcile_plan_id == ^plan.id, order_by: rpi.id))
+  end
+
+  defp new_target_path do
+    Path.join([Application.get_env(:pinchflat, :media_directory), "new-home-#{:rand.uniform(1_000_000)}", "video.mp4"])
+  end
+end

--- a/test/pinchflat/reconciliation/plan_builder_test.exs
+++ b/test/pinchflat/reconciliation/plan_builder_test.exs
@@ -1,0 +1,417 @@
+defmodule Pinchflat.Reconciliation.PlanBuilderTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.MediaFixtures
+  import Pinchflat.SourcesFixtures
+  import Pinchflat.ProfilesFixtures
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Media
+  alias Pinchflat.Reconciliation
+  alias Pinchflat.Reconciliation.PlanBuilder
+  alias Pinchflat.Reconciliation.ReconcilePlanItem
+  alias Pinchflat.Metadata.MetadataFileHelpers
+
+  describe "build_plan_items/1 (moves and deletes)" do
+    test "plans a move when the predicted media path differs" do
+      media_item = downloaded_media_item()
+      plan = create_plan(media_item.source_id)
+      target = new_target_path()
+
+      stub_prediction(target)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      move = fetch_item(plan, :move, "media")
+      assert move.from_path == media_item.media_filepath
+      assert move.to_path == target
+      assert plan.move_count >= 1
+    end
+
+    test "emits no move when the path already matches" do
+      media_item = downloaded_media_item()
+      plan = create_plan(media_item.source_id)
+
+      stub_prediction(media_item.media_filepath)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      refute find_item(plan, :move, "media")
+    end
+
+    test "plans deletion of sidecars whose profile toggle is off" do
+      # The fixture's profile has download_thumbnail/download_subs off, but the
+      # attachment fixture puts a thumbnail and a subtitle on disk
+      media_item = downloaded_media_item()
+      plan = create_plan(media_item.source_id)
+
+      stub_prediction(new_target_path())
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      assert fetch_item(plan, :delete, "thumbnail").from_path == media_item.thumbnail_filepath
+      assert [["en", subtitle_path]] = media_item.subtitle_filepaths
+      assert fetch_item(plan, :delete, "subtitle:en").from_path == subtitle_path
+      assert plan.delete_count == 2
+    end
+
+    test "plans sidecar moves alongside the media file when toggles are on" do
+      media_item = downloaded_media_item(%{download_thumbnail: true})
+      plan = create_plan(media_item.source_id)
+      target = new_target_path()
+
+      stub_prediction(target)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      thumbnail_move = fetch_item(plan, :move, "thumbnail")
+      assert thumbnail_move.from_path == media_item.thumbnail_filepath
+      assert thumbnail_move.to_path == Path.rootname(target) <> ".jpg"
+    end
+  end
+
+  describe "build_plan_items/1 (backfills and skips)" do
+    test "plans an NFO backfill from stored metadata in local mode" do
+      media_item = downloaded_media_item(%{download_nfo: true})
+      plan = create_plan(media_item.source_id)
+      target = new_target_path()
+
+      stub_prediction(target)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      backfill = fetch_item(plan, :backfill, "nfo")
+      assert backfill.to_path == Path.rootname(target) <> ".nfo"
+    end
+
+    test "skips network-needing backfills in local mode" do
+      media_item = downloaded_media_item(%{download_thumbnail: true})
+      # Remove the thumbnail from disk and the record so a backfill is needed
+      File.rm!(media_item.thumbnail_filepath)
+      {:ok, _} = Media.update_media_item(media_item, %{thumbnail_filepath: nil})
+      plan = create_plan(media_item.source_id)
+
+      stub_prediction(new_target_path())
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      skip = fetch_item(plan, :skip, "thumbnail")
+      assert skip.detail =~ "Online"
+    end
+
+    test "plans network backfills in online mode" do
+      media_item = downloaded_media_item(%{download_thumbnail: true})
+      File.rm!(media_item.thumbnail_filepath)
+      {:ok, _} = Media.update_media_item(media_item, %{thumbnail_filepath: nil})
+      plan = create_plan(media_item.source_id, :online)
+      target = new_target_path()
+
+      stub_prediction(target)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      backfill = fetch_item(plan, :backfill, "thumbnail")
+      assert backfill.to_path == Path.rootname(target) <> ".jpg"
+    end
+
+    test "skips items without stored metadata in local mode" do
+      media_item = media_item_fixture()
+      plan = create_plan(media_item.source_id)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      skip = fetch_item(plan, :skip, "media")
+      assert skip.detail =~ "No stored metadata"
+      assert plan.skip_count == 1
+    end
+
+    test "skips items whose media file is missing on disk" do
+      media_item = downloaded_media_item()
+      File.rm!(media_item.media_filepath)
+      plan = create_plan(media_item.source_id)
+
+      stub_prediction(new_target_path())
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      skip = fetch_item(plan, :skip, "media")
+      assert skip.detail =~ "Sync Files on Disk"
+    end
+  end
+
+  describe "build_plan_items/1 (collisions)" do
+    test "marks rows whose targets clash as collisions" do
+      media_item = downloaded_media_item()
+      _second_item = media_item_with_attachments(%{source_id: media_item.source_id}) |> add_stored_metadata()
+      plan = create_plan(media_item.source_id)
+      target = new_target_path()
+
+      expect(YtDlpRunnerMock, :run, 2, fn _url, _action, _opts, _ot, _addl ->
+        {:ok, ~s({"filename": "#{target}"})}
+      end)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      collisions = list_items(plan, :collision, "media")
+      assert length(collisions) == 2
+      assert plan.collision_count >= 2
+    end
+
+    test "marks a move whose target already exists on disk as a collision" do
+      media_item = downloaded_media_item()
+      plan = create_plan(media_item.source_id)
+      target = new_target_path()
+      Pinchflat.Utils.FilesystemUtils.write_p!(target, "occupied by some other file")
+
+      stub_prediction(target)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      collision = fetch_item(plan, :collision, "media")
+      assert collision.to_path == target
+      assert collision.detail =~ "already occupied"
+      assert plan.collision_count == 1
+    end
+
+    test "marks a backfill whose target is occupied as a collision" do
+      media_item = downloaded_media_item(%{download_nfo: true})
+      plan = create_plan(media_item.source_id)
+      target = new_target_path()
+      # An unrelated file already sits where the NFO backfill would be written
+      nfo_target = Path.rootname(target) <> ".nfo"
+      Pinchflat.Utils.FilesystemUtils.write_p!(nfo_target, "someone else's nfo")
+
+      stub_prediction(target)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      collision = fetch_item(plan, :collision, "nfo")
+      assert collision.to_path == nfo_target
+      refute find_item(plan, :backfill, "nfo")
+    end
+  end
+
+  describe "build_plan_items/1 (:full mode)" do
+    test "flags an audio-only profile whose file is still video, alongside the normal move plan" do
+      media_item = downloaded_media_item(%{preferred_resolution: :audio})
+      plan = create_plan(media_item.source_id, :full)
+      target = new_target_path()
+
+      stub_prediction(target)
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      row = fetch_item(plan, :redownload, "media")
+      assert row.detail =~ "Audio Only"
+      assert plan.redownload_count == 1
+      # Full sync is "Online mode, plus" — the media still gets its normal move row
+      move = fetch_item(plan, :move, "media")
+      assert move.to_path == Path.rootname(target) <> Path.extname(media_item.media_filepath)
+    end
+
+    test "flags a container mismatch" do
+      # The fixture file is .mp4; ask for .mkv
+      media_item = downloaded_media_item(%{media_container: "mkv"})
+      plan = create_plan(media_item.source_id, :full)
+
+      stub_prediction(new_target_path())
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      row = fetch_item(plan, :redownload, "media")
+      assert row.detail =~ "container"
+      assert plan.redownload_count == 1
+    end
+
+    test "does not flag a file that already matches the profile" do
+      # Default video profile with no container produces .mp4, and the fixture is .mp4
+      media_item = downloaded_media_item()
+      plan = create_plan(media_item.source_id, :full)
+
+      stub_prediction(new_target_path())
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      refute find_item(plan, :redownload, "media")
+      assert plan.redownload_count == 0
+    end
+
+    test "never flags re-downloads outside :full mode" do
+      media_item = downloaded_media_item(%{preferred_resolution: :audio})
+      plan = create_plan(media_item.source_id, :local)
+
+      stub_prediction(new_target_path())
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      refute find_item(plan, :redownload, "media")
+    end
+  end
+
+  describe "build_plan_items/1 (source-level artifacts)" do
+    test "deletes leftover source artifacts when switching to a podcast profile" do
+      profile = media_profile_fixture(%{podcast_enabled: true, preferred_resolution: :audio})
+      source = source_fixture(%{media_profile_id: profile.id})
+
+      series_dir =
+        Path.join(Application.get_env(:pinchflat, :media_directory), "old-series-#{:rand.uniform(1_000_000)}")
+
+      nfo = Path.join(series_dir, "tvshow.nfo")
+      poster = Path.join(series_dir, "poster.jpg")
+      fanart = Path.join(series_dir, "fanart.jpg")
+      banner = Path.join(series_dir, "banner.jpg")
+      Enum.each([nfo, poster, fanart, banner], &Pinchflat.Utils.FilesystemUtils.write_p!(&1, "x"))
+
+      {:ok, _} =
+        Pinchflat.Sources.update_source(
+          source,
+          %{
+            series_directory: series_dir,
+            nfo_filepath: nfo,
+            poster_filepath: poster,
+            fanart_filepath: fanart,
+            banner_filepath: banner
+          },
+          run_post_commit_tasks: false
+        )
+
+      _media_item = media_item_with_attachments(%{source_id: source.id}) |> add_stored_metadata()
+      plan = create_plan(source.id)
+
+      stub_prediction(new_target_path())
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      assert fetch_item(plan, :delete, "source_nfo").from_path == nfo
+      assert fetch_item(plan, :delete, "source_poster").from_path == poster
+      assert fetch_item(plan, :delete, "source_fanart").from_path == fanart
+      assert fetch_item(plan, :delete, "source_banner").from_path == banner
+    end
+
+    test "schedules a source-image refresh when recorded artwork is missing on disk (online mode)" do
+      {source, poster, _fanart} = source_with_partial_artwork()
+      _media_item = media_item_with_attachments(%{source_id: source.id}) |> add_stored_metadata()
+      plan = create_plan(source.id, :online)
+
+      stub_prediction(series_style_path())
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      # The refresh restores + relocates everything, so it supersedes per-image moves
+      assert find_item(plan, :backfill, "source_images")
+      refute find_item(plan, :move, "source_poster")
+      assert File.exists?(poster)
+    end
+
+    test "in local mode, moves present artwork and skips the missing (no refresh)" do
+      {source, _poster, _fanart} = source_with_partial_artwork()
+      _media_item = media_item_with_attachments(%{source_id: source.id}) |> add_stored_metadata()
+      plan = create_plan(source.id, :local)
+
+      stub_prediction(series_style_path())
+
+      assert {:ok, plan} = PlanBuilder.build_plan_items(plan)
+
+      refute find_item(plan, :backfill, "source_images")
+      assert find_item(plan, :move, "source_poster")
+      assert find_item(plan, :skip, "source_fanart")
+    end
+  end
+
+  # A source with a present poster and a recorded-but-missing-on-disk fanart
+  defp source_with_partial_artwork do
+    profile = media_profile_fixture(%{download_source_images: true})
+    source = source_fixture(%{media_profile_id: profile.id})
+
+    series_dir =
+      Path.join(Application.get_env(:pinchflat, :media_directory), "art-series-#{:rand.uniform(1_000_000)}")
+
+    poster = Path.join(series_dir, "poster.jpg")
+    fanart = Path.join(series_dir, "fanart.jpg")
+    Pinchflat.Utils.FilesystemUtils.write_p!(poster, "x")
+
+    {:ok, source} =
+      Pinchflat.Sources.update_source(
+        source,
+        %{series_directory: series_dir, poster_filepath: poster, fanart_filepath: fanart},
+        run_post_commit_tasks: false
+      )
+
+    {source, poster, fanart}
+  end
+
+  # A predicted media path with a Season folder so the series directory resolves
+  defp series_style_path do
+    Path.join([
+      Application.get_env(:pinchflat, :media_directory),
+      "Chan-#{:rand.uniform(1_000_000)}",
+      "Season 1",
+      "video.mp4"
+    ])
+  end
+
+  defp downloaded_media_item(profile_attrs \\ %{}) do
+    profile = media_profile_fixture(profile_attrs)
+    source = source_fixture(%{media_profile_id: profile.id})
+
+    media_item_with_attachments(%{source_id: source.id})
+    |> add_stored_metadata()
+  end
+
+  defp add_stored_metadata(media_item) do
+    media_item = Repo.preload(media_item, :metadata)
+
+    metadata_filepath =
+      MetadataFileHelpers.compress_and_store_metadata_for(media_item, %{
+        "id" => media_item.media_id,
+        "title" => media_item.title,
+        "upload_date" => "20240101"
+      })
+
+    {:ok, media_item} =
+      Media.update_media_item(media_item, %{
+        metadata: %{metadata_filepath: metadata_filepath, thumbnail_filepath: media_item.thumbnail_filepath}
+      })
+
+    media_item
+  end
+
+  defp create_plan(source_id, mode \\ :local) do
+    {:ok, plan} = Reconciliation.create_plan(%{mode: mode, source_id: source_id, status: :building})
+
+    plan
+  end
+
+  defp new_target_path do
+    Path.join([Application.get_env(:pinchflat, :media_directory), "new-home-#{:rand.uniform(1_000_000)}", "video.mp4"])
+  end
+
+  defp stub_prediction(target) do
+    stub(YtDlpRunnerMock, :run, fn _url, _action, _opts, _ot, _addl ->
+      {:ok, ~s({"filename": "#{target}"})}
+    end)
+  end
+
+  defp fetch_item(plan, action, attribute) do
+    item = find_item(plan, action, attribute)
+    assert item, "expected a #{action}/#{attribute} plan item"
+    item
+  end
+
+  defp find_item(plan, action, attribute) do
+    Repo.one(
+      from(rpi in ReconcilePlanItem,
+        where: rpi.reconcile_plan_id == ^plan.id and rpi.action == ^action and rpi.attribute == ^attribute,
+        limit: 1
+      )
+    )
+  end
+
+  defp list_items(plan, action, attribute) do
+    Repo.all(
+      from(rpi in ReconcilePlanItem,
+        where: rpi.reconcile_plan_id == ^plan.id and rpi.action == ^action and rpi.attribute == ^attribute
+      )
+    )
+  end
+end

--- a/test/pinchflat/reconciliation/reconcile_worker_test.exs
+++ b/test/pinchflat/reconciliation/reconcile_worker_test.exs
@@ -1,0 +1,87 @@
+defmodule Pinchflat.Reconciliation.ReconcileWorkerTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.SourcesFixtures
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Reconciliation
+  alias Pinchflat.Reconciliation.ReconcilePlan
+  alias Pinchflat.Reconciliation.ReconcileWorker
+
+  describe "kickoff_build/2" do
+    test "creates a plan and enqueues a build job" do
+      assert {:ok, _} = ReconcileWorker.kickoff_build(:local)
+
+      assert [%ReconcilePlan{mode: :local, status: :building, source_id: nil}] = Repo.all(ReconcilePlan)
+      assert [_job] = all_enqueued(worker: ReconcileWorker)
+    end
+
+    test "links the job to the source via a task when scoped" do
+      source = source_fixture()
+
+      assert {:ok, task} = ReconcileWorker.kickoff_build(:local, source)
+
+      assert task.source_id == source.id
+      assert [%ReconcilePlan{source_id: source_id}] = Repo.all(ReconcilePlan)
+      assert source_id == source.id
+    end
+
+    test "deletes the plan when the job is a duplicate" do
+      assert {:ok, _} = ReconcileWorker.kickoff_build(:local)
+      assert {:error, :duplicate_job} = ReconcileWorker.kickoff_build(:local)
+
+      assert [%ReconcilePlan{}] = Repo.all(ReconcilePlan)
+    end
+
+    test "marks older ready plans stale" do
+      {:ok, old_plan} = Reconciliation.create_plan(%{mode: :local, status: :ready})
+
+      assert {:ok, _} = ReconcileWorker.kickoff_build(:local)
+
+      assert Repo.reload(old_plan).status == :stale
+    end
+  end
+
+  describe "kickoff_apply/1" do
+    test "refuses to apply a plan that isn't ready" do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :building})
+
+      assert {:error, :not_ready} = ReconcileWorker.kickoff_apply(plan)
+    end
+
+    test "enqueues an apply job for a ready plan" do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :ready})
+
+      assert {:ok, _} = ReconcileWorker.kickoff_apply(plan)
+      assert [_job] = all_enqueued(worker: ReconcileWorker)
+    end
+  end
+
+  describe "perform/1 (build)" do
+    test "builds the plan and marks it ready" do
+      source = source_fixture()
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, source_id: source.id, status: :building})
+
+      assert :ok = perform_job(ReconcileWorker, %{"op" => "build", "plan_id" => plan.id})
+
+      assert Repo.reload(plan).status == :ready
+    end
+  end
+
+  describe "perform/1 (apply)" do
+    test "applies a ready plan" do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :ready})
+
+      assert :ok = perform_job(ReconcileWorker, %{"op" => "apply", "plan_id" => plan.id})
+
+      assert Repo.reload(plan).status == :applied
+    end
+
+    test "cancels when the plan is not ready" do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :stale})
+
+      assert {:cancel, message} = perform_job(ReconcileWorker, %{"op" => "apply", "plan_id" => plan.id})
+      assert message =~ "only a ready plan can be applied"
+    end
+  end
+end

--- a/test/pinchflat/reconciliation/reconcile_worker_test.exs
+++ b/test/pinchflat/reconciliation/reconcile_worker_test.exs
@@ -81,7 +81,15 @@ defmodule Pinchflat.Reconciliation.ReconcileWorkerTest do
       {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :stale})
 
       assert {:cancel, message} = perform_job(ReconcileWorker, %{"op" => "apply", "plan_id" => plan.id})
-      assert message =~ "only a ready plan can be applied"
+      assert message =~ "only a ready or resuming plan can be applied"
+    end
+
+    test "resumes an interrupted apply (plan left in :applying)" do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :applying})
+
+      assert :ok = perform_job(ReconcileWorker, %{"op" => "apply", "plan_id" => plan.id})
+
+      assert Repo.reload(plan).status == :applied
     end
   end
 end

--- a/test/pinchflat/reconciliation_test.exs
+++ b/test/pinchflat/reconciliation_test.exs
@@ -1,0 +1,51 @@
+defmodule Pinchflat.ReconciliationTest do
+  use Pinchflat.DataCase
+
+  alias Pinchflat.Reconciliation
+
+  describe "apply_progress/1" do
+    test "reports 100% for a plan with nothing applyable" do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :ready})
+
+      assert %{processed: 0, total: 0, percent: 100} = Reconciliation.apply_progress(plan)
+    end
+
+    test "counts only applyable rows and ignores skip/collision rows" do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :applying})
+
+      Reconciliation.create_plan_items([
+        row(plan, :move, :done),
+        row(plan, :backfill, :done),
+        row(plan, :delete, :planned),
+        row(plan, :redownload, :planned),
+        # Not applyable — must not inflate the total
+        row(plan, :skip, :planned),
+        row(plan, :collision, :planned)
+      ])
+
+      assert %{processed: 2, total: 4, percent: 50} = Reconciliation.apply_progress(plan)
+    end
+
+    test "treats skipped and failed rows as processed" do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :applying})
+
+      Reconciliation.create_plan_items([
+        row(plan, :move, :done),
+        row(plan, :move, :skipped),
+        row(plan, :backfill, :failed),
+        row(plan, :backfill, :planned)
+      ])
+
+      assert %{processed: 3, total: 4, percent: 75} = Reconciliation.apply_progress(plan)
+    end
+  end
+
+  defp row(plan, action, status) do
+    %{
+      reconcile_plan_id: plan.id,
+      action: action,
+      attribute: "media",
+      status: status
+    }
+  end
+end

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -183,6 +183,50 @@ defmodule Pinchflat.YtDlp.MediaTest do
     end
   end
 
+  describe "download_subtitles/3" do
+    test "calls the backend runner with the expected arguments and does not decode the response" do
+      expect(YtDlpRunnerMock, :run, fn @media_url, :download_subtitles, opts, ot, _addl ->
+        assert opts == [:no_simulate, :skip_download, :write_subs, {:convert_subs, "srt"}]
+        assert ot == "after_move:%()j"
+
+        # With --skip-download there's no after_move output; an empty response must
+        # NOT be treated as a decode failure the way `download/3` would
+        {:ok, ""}
+      end)
+
+      assert {:ok, ""} = Media.download_subtitles(@media_url)
+    end
+
+    test "passes along custom command args" do
+      expect(YtDlpRunnerMock, :run, fn _url, :download_subtitles, opts, _ot, _addl ->
+        assert {:sub_langs, "en"} in opts
+        assert :write_auto_subs in opts
+
+        {:ok, ""}
+      end)
+
+      assert {:ok, _} = Media.download_subtitles(@media_url, [:write_auto_subs, sub_langs: "en"])
+    end
+
+    test "passes along additional options" do
+      expect(YtDlpRunnerMock, :run, fn _url, :download_subtitles, _opts, _ot, addl ->
+        assert [addl_arg: true] = addl
+
+        {:ok, ""}
+      end)
+
+      assert {:ok, _} = Media.download_subtitles(@media_url, [], addl_arg: true)
+    end
+
+    test "returns errors" do
+      expect(YtDlpRunnerMock, :run, fn _url, :download_subtitles, _opt, _ot, _addl ->
+        {:error, "something"}
+      end)
+
+      assert {:error, "something"} = Media.download_subtitles(@media_url)
+    end
+  end
+
   describe "get_media_attributes/1" do
     test "returns a list of video attributes" do
       expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->

--- a/test/pinchflat_web/controllers/diagnostics_controller_test.exs
+++ b/test/pinchflat_web/controllers/diagnostics_controller_test.exs
@@ -101,4 +101,43 @@ defmodule PinchflatWeb.DiagnosticsControllerTest do
       assert conn.assigns[:flash]["error"] == "invalid is not a valid job ID."
     end
   end
+
+  describe "vacuum_database" do
+    test "enqueues a maintenance job and redirects", %{conn: conn} do
+      conn = post(conn, ~p"/diagnostics/vacuum_database")
+
+      assert redirected_to(conn) == ~p"/diagnostics"
+      assert conn.assigns[:flash]["info"] =~ "Database compaction queued"
+      assert [_] = all_enqueued(worker: Pinchflat.Diagnostics.DatabaseMaintenanceWorker)
+    end
+
+    test "reports when a maintenance job is already queued", %{conn: conn} do
+      post(conn, ~p"/diagnostics/vacuum_database")
+      conn = post(conn, ~p"/diagnostics/vacuum_database")
+
+      assert redirected_to(conn) == ~p"/diagnostics"
+      assert conn.assigns[:flash]["info"] =~ "already queued or running"
+      assert [_] = all_enqueued(worker: Pinchflat.Diagnostics.DatabaseMaintenanceWorker)
+    end
+  end
+
+  describe "toggle_scheduled_compaction" do
+    test "turns scheduled compaction on", %{conn: conn} do
+      conn = post(conn, ~p"/diagnostics/toggle_scheduled_compaction")
+
+      assert redirected_to(conn) == ~p"/diagnostics"
+      assert conn.assigns[:flash]["info"] =~ "Scheduled compaction turned on"
+      assert Pinchflat.Settings.get!(:database_maintenance_enabled) == true
+    end
+
+    test "turns scheduled compaction off when it is on", %{conn: conn} do
+      Pinchflat.Settings.set(database_maintenance_enabled: true)
+
+      conn = post(conn, ~p"/diagnostics/toggle_scheduled_compaction")
+
+      assert redirected_to(conn) == ~p"/diagnostics"
+      assert conn.assigns[:flash]["info"] =~ "Scheduled compaction turned off"
+      assert Pinchflat.Settings.get!(:database_maintenance_enabled) == false
+    end
+  end
 end

--- a/test/pinchflat_web/controllers/media_profile_controller_test.exs
+++ b/test/pinchflat_web/controllers/media_profile_controller_test.exs
@@ -131,6 +131,14 @@ defmodule PinchflatWeb.MediaProfileControllerTest do
       conn = put(conn, ~p"/media_profiles/#{media_profile}", media_profile: @invalid_attrs)
       assert html_response(conn, 200) =~ "Editing \"#{media_profile.name}\""
     end
+
+    test "marks a staged reconcile plan stale", %{conn: conn, media_profile: media_profile} do
+      {:ok, plan} = Pinchflat.Reconciliation.create_plan(%{mode: :local, status: :ready})
+
+      put(conn, ~p"/media_profiles/#{media_profile}", media_profile: @update_attrs)
+
+      assert Pinchflat.Reconciliation.get_plan!(plan.id).status == :stale
+    end
   end
 
   describe "delete media_profile in all cases" do

--- a/test/pinchflat_web/controllers/setting_controller_test.exs
+++ b/test/pinchflat_web/controllers/setting_controller_test.exs
@@ -22,6 +22,72 @@ defmodule PinchflatWeb.SettingControllerTest do
       assert html_response(conn, 200) =~ update_attrs[:apprise_server]
       assert html_response(conn, 200) =~ update_attrs[:external_base_url]
     end
+
+    test "re-renders the form when data is invalid", %{conn: conn} do
+      conn = put(conn, ~p"/settings", setting: %{yt_dlp_update_policy: "bogus"})
+
+      assert html_response(conn, 200) =~ "Settings"
+    end
+
+    test "kicks off a yt-dlp update when the update policy changes", %{conn: conn} do
+      conn = put(conn, ~p"/settings", setting: %{yt_dlp_update_policy: "nightly"})
+
+      assert redirected_to(conn) == ~p"/settings"
+      assert_enqueued(worker: Pinchflat.YtDlp.UpdateWorker, args: %{"apply_policy" => true})
+    end
+
+    test "does not kick off a yt-dlp update when unrelated settings change", %{conn: conn} do
+      conn = put(conn, ~p"/settings", setting: %{apprise_server: "test://server"})
+
+      assert redirected_to(conn) == ~p"/settings"
+      refute_enqueued(worker: Pinchflat.YtDlp.UpdateWorker)
+    end
+
+    test "marks a staged reconcile plan stale", %{conn: conn} do
+      {:ok, plan} = Pinchflat.Reconciliation.create_plan(%{mode: :local, status: :ready})
+
+      put(conn, ~p"/settings", setting: %{apprise_server: "test://server"})
+
+      assert Pinchflat.Reconciliation.get_plan!(plan.id).status == :stale
+    end
+  end
+
+  describe "download_cookies" do
+    setup do
+      base_dir =
+        Path.join([
+          System.tmp_dir!(),
+          "setting_controller_test",
+          Integer.to_string(:erlang.unique_integer([:positive]))
+        ])
+
+      File.mkdir_p!(base_dir)
+      original = Application.get_env(:pinchflat, :extras_directory)
+      Application.put_env(:pinchflat, :extras_directory, base_dir)
+
+      on_exit(fn ->
+        Application.put_env(:pinchflat, :extras_directory, original)
+        File.rm_rf!(base_dir)
+      end)
+
+      :ok
+    end
+
+    test "sends the cookies file when one exists", %{conn: conn} do
+      File.write!(Pinchflat.Settings.CookieFile.filepath(), "some-cookies")
+
+      conn = get(conn, ~p"/settings/cookies")
+
+      assert response(conn, 200) =~ "some-cookies"
+    end
+
+    test "redirects with an error when no cookies file exists", %{conn: conn} do
+      conn = get(conn, ~p"/settings/cookies")
+
+      assert redirected_to(conn) == ~p"/settings"
+      assert conn.assigns[:flash]["error"] == "No cookies file has been uploaded"
+>>>>>>> ad2a66e (feat: relocate and true up downloaded files after settings changes, without re-downloading)
+    end
   end
 
   describe "download_logs" do

--- a/test/pinchflat_web/controllers/setting_controller_test.exs
+++ b/test/pinchflat_web/controllers/setting_controller_test.exs
@@ -86,7 +86,6 @@ defmodule PinchflatWeb.SettingControllerTest do
 
       assert redirected_to(conn) == ~p"/settings"
       assert conn.assigns[:flash]["error"] == "No cookies file has been uploaded"
->>>>>>> ad2a66e (feat: relocate and true up downloaded files after settings changes, without re-downloading)
     end
   end
 

--- a/test/pinchflat_web/controllers/settings/integrity_check_live_test.exs
+++ b/test/pinchflat_web/controllers/settings/integrity_check_live_test.exs
@@ -1,0 +1,94 @@
+defmodule PinchflatWeb.Settings.IntegrityCheckLiveTest do
+  use PinchflatWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Pinchflat.MediaFixtures
+
+  alias Pinchflat.Settings.IntegrityCheckLive
+
+  describe "initial rendering" do
+    test "renders the button and both check modes", %{conn: conn} do
+      {:ok, _view, html} = live_isolated(conn, IntegrityCheckLive)
+
+      assert html =~ "Check Integrity"
+      assert html =~ "Quick Check"
+      assert html =~ "Full Check"
+    end
+
+    test "shows no results before a check has been run", %{conn: conn} do
+      {:ok, _view, html} = live_isolated(conn, IntegrityCheckLive)
+
+      refute html =~ "No problems found"
+      refute html =~ "problem(s)"
+    end
+  end
+
+  describe "running a check" do
+    test "reports a clean quick check", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, IntegrityCheckLive)
+
+      render_click(view, "check", %{"mode" => "quick"})
+
+      html = render(view)
+      assert html =~ "No problems found"
+      assert html =~ "Quick check completed at"
+    end
+
+    test "reports a clean full check", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, IntegrityCheckLive)
+
+      render_click(view, "check", %{"mode" => "full"})
+
+      html = render(view)
+      assert html =~ "No problems found"
+      assert html =~ "Full check completed at"
+    end
+
+    test "falls back to a quick check for an unknown mode", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, IntegrityCheckLive)
+
+      render_click(view, "check", %{"mode" => "something-else"})
+
+      assert render(view) =~ "Quick check completed at"
+    end
+  end
+
+  describe "when the database has problems" do
+    setup do
+      media_item_fixture(title: "a title to index")
+      corrupt_search_index()
+
+      :ok
+    end
+
+    test "reports the findings verbatim", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, IntegrityCheckLive)
+
+      render_click(view, "check", %{"mode" => "quick"})
+
+      html = render(view)
+      assert html =~ "SQLite reported"
+      assert html =~ "problem(s)"
+      assert html =~ "media_items_search_index"
+      refute html =~ "No problems found"
+    end
+
+    test "says nothing was changed and points at a manual repair", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, IntegrityCheckLive)
+
+      render_click(view, "check", %{"mode" => "quick"})
+
+      html = render(view)
+      assert html =~ "Nothing has been changed"
+      assert html =~ "back up your database file"
+    end
+
+    test "notes that search index problems are rebuildable", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, IntegrityCheckLive)
+
+      render_click(view, "check", %{"mode" => "quick"})
+
+      assert render(view) =~ "can be rebuilt"
+    end
+  end
+end

--- a/test/pinchflat_web/controllers/settings/reconciliation_controller_test.exs
+++ b/test/pinchflat_web/controllers/settings/reconciliation_controller_test.exs
@@ -1,0 +1,73 @@
+defmodule PinchflatWeb.Settings.ReconciliationControllerTest do
+  use PinchflatWeb.ConnCase
+
+  import Pinchflat.SourcesFixtures
+
+  alias Pinchflat.Repo
+  alias Pinchflat.Reconciliation
+  alias Pinchflat.Reconciliation.ReconcilePlan
+  alias Pinchflat.Reconciliation.ReconcileWorker
+
+  describe "show" do
+    test "renders the page", %{conn: conn} do
+      conn = get(conn, ~p"/reconciliation")
+
+      assert html_response(conn, 200) =~ "Scan and Build Plan"
+    end
+
+    test "renders with an existing plan and a preselected source", %{conn: conn} do
+      source = source_fixture()
+      {:ok, _plan} = Reconciliation.create_plan(%{mode: :local, source_id: source.id, status: :ready})
+
+      conn = get(conn, ~p"/reconciliation?source_id=#{source.id}")
+
+      assert html_response(conn, 200) =~ "Past Runs"
+    end
+  end
+
+  describe "build" do
+    test "starts a dry run and redirects", %{conn: conn} do
+      conn = post(conn, ~p"/reconciliation", plan: %{mode: "local", source_id: "all"})
+
+      assert redirected_to(conn) == ~p"/reconciliation"
+      assert conn.assigns[:flash]["info"] =~ "Scan started"
+      assert [%ReconcilePlan{source_id: nil, mode: :local}] = Repo.all(ReconcilePlan)
+    end
+
+    test "scopes the run to a source when given", %{conn: conn} do
+      source = source_fixture()
+
+      post(conn, ~p"/reconciliation", plan: %{mode: "full", source_id: to_string(source.id)})
+
+      assert [%ReconcilePlan{mode: :full, source_id: source_id}] = Repo.all(ReconcilePlan)
+      assert source_id == source.id
+    end
+
+    test "shows an error when a run is already queued", %{conn: conn} do
+      {:ok, _} = ReconcileWorker.kickoff_build(:local)
+
+      conn = post(conn, ~p"/reconciliation", plan: %{mode: "local", source_id: "all"})
+
+      assert conn.assigns[:flash]["error"] =~ "already queued or running"
+    end
+  end
+
+  describe "apply" do
+    test "kicks off the apply job for a ready plan", %{conn: conn} do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :ready})
+
+      conn = post(conn, ~p"/reconciliation/apply/#{plan.id}")
+
+      assert redirected_to(conn) == ~p"/reconciliation"
+      assert conn.assigns[:flash]["info"] =~ "Applying the plan"
+    end
+
+    test "shows an error for a stale plan", %{conn: conn} do
+      {:ok, plan} = Reconciliation.create_plan(%{mode: :local, status: :stale})
+
+      conn = post(conn, ~p"/reconciliation/apply/#{plan.id}")
+
+      assert conn.assigns[:flash]["error"] =~ "no longer be applied"
+    end
+  end
+end

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -347,95 +347,6 @@ defmodule PinchflatWeb.SourceControllerTest do
       assert html_response(conn, 200) =~ "Editing \"#{source.custom_name}\""
     end
 
-<<<<<<< HEAD
-    test "previews a source directory move before saving", %{conn: conn} do
-      media_root = Application.get_env(:pinchflat, :media_directory)
-      old_subdirectory = Path.join(["TV Shows", "Preview Old #{System.unique_integer([:positive])}"])
-      new_subdirectory = Path.join(["TV Shows", "Preview New #{System.unique_integer([:positive])}"])
-      old_directory = Path.join(media_root, old_subdirectory)
-      old_filepath = Path.join(old_directory, "tvshow.nfo")
-
-      FilesystemUtils.write_p!(old_filepath, "source nfo")
-
-      source =
-        source_fixture(%{
-          download_subdirectory: old_subdirectory,
-          series_directory: old_directory,
-          nfo_filepath: old_filepath
-        })
-
-      conn = put(conn, ~p"/sources/#{source}", source: %{download_subdirectory: new_subdirectory})
-      response = html_response(conn, 200)
-
-      assert response =~ "Confirm Source Folder Move"
-      assert response =~ old_directory
-      assert response =~ Path.join(media_root, new_subdirectory)
-      assert response =~ "Save and Move Files"
-      assert File.exists?(old_filepath)
-      assert Repo.reload!(source).download_subdirectory == old_subdirectory
-    end
-
-    test "confirmed source directory move saves and moves files", %{conn: conn} do
-      media_root = Application.get_env(:pinchflat, :media_directory)
-      old_subdirectory = Path.join(["TV Shows", "Confirm Old #{System.unique_integer([:positive])}"])
-      new_subdirectory = Path.join(["TV Shows", "Confirm New #{System.unique_integer([:positive])}"])
-      old_directory = Path.join(media_root, old_subdirectory)
-      new_directory = Path.join(media_root, new_subdirectory)
-      old_filepath = Path.join(old_directory, "tvshow.nfo")
-
-      FilesystemUtils.write_p!(old_filepath, "source nfo")
-
-      source =
-        source_fixture(%{
-          download_subdirectory: old_subdirectory,
-          series_directory: old_directory,
-          nfo_filepath: old_filepath
-        })
-
-      conn =
-        put(conn, ~p"/sources/#{source}", %{
-          "confirm_directory_move" => "true",
-          "source" => %{"download_subdirectory" => new_subdirectory}
-        })
-
-      assert redirected_to(conn) == ~p"/sources/#{source}"
-      source = Repo.reload!(source)
-      assert source.download_subdirectory == new_subdirectory
-      assert source.series_directory == new_directory
-      assert source.nfo_filepath == Path.join(new_directory, "tvshow.nfo")
-      assert File.exists?(Path.join(new_directory, "tvshow.nfo"))
-      refute File.exists?(old_directory)
-    end
-
-    test "source directory move preview shows conflicts and withholds confirmation", %{conn: conn} do
-      media_root = Application.get_env(:pinchflat, :media_directory)
-      old_subdirectory = Path.join(["TV Shows", "Conflict Old #{System.unique_integer([:positive])}"])
-      new_subdirectory = Path.join(["TV Shows", "Conflict New #{System.unique_integer([:positive])}"])
-      old_directory = Path.join(media_root, old_subdirectory)
-      new_directory = Path.join(media_root, new_subdirectory)
-      old_filepath = Path.join(old_directory, "tvshow.nfo")
-      conflicting_filepath = Path.join(new_directory, "tvshow.nfo")
-
-      FilesystemUtils.write_p!(old_filepath, "source nfo")
-      FilesystemUtils.write_p!(conflicting_filepath, "existing nfo")
-
-      source =
-        source_fixture(%{
-          download_subdirectory: old_subdirectory,
-          series_directory: old_directory,
-          nfo_filepath: old_filepath
-        })
-
-      conn = put(conn, ~p"/sources/#{source}", source: %{download_subdirectory: new_subdirectory})
-      response = html_response(conn, 200)
-
-      assert response =~ "File conflicts need attention"
-      assert response =~ conflicting_filepath
-      refute response =~ "Save and Move Files"
-      assert Repo.reload!(source).download_subdirectory == old_subdirectory
-      assert File.exists?(old_filepath)
-      assert File.read!(conflicting_filepath) == "existing nfo"
-=======
     test "marks a staged reconcile plan stale", %{conn: conn, source: source, update_attrs: update_attrs} do
       expect(YtDlpRunnerMock, :run, 1, &runner_function_mock/5)
       {:ok, plan} = Pinchflat.Reconciliation.create_plan(%{mode: :local, status: :ready})
@@ -443,7 +354,6 @@ defmodule PinchflatWeb.SourceControllerTest do
       put(conn, ~p"/sources/#{source}", source: update_attrs)
 
       assert Pinchflat.Reconciliation.get_plan!(plan.id).status == :stale
->>>>>>> ad2a66e (feat: relocate and true up downloaded files after settings changes, without re-downloading)
     end
   end
 

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -347,6 +347,7 @@ defmodule PinchflatWeb.SourceControllerTest do
       assert html_response(conn, 200) =~ "Editing \"#{source.custom_name}\""
     end
 
+<<<<<<< HEAD
     test "previews a source directory move before saving", %{conn: conn} do
       media_root = Application.get_env(:pinchflat, :media_directory)
       old_subdirectory = Path.join(["TV Shows", "Preview Old #{System.unique_integer([:positive])}"])
@@ -434,6 +435,15 @@ defmodule PinchflatWeb.SourceControllerTest do
       assert Repo.reload!(source).download_subdirectory == old_subdirectory
       assert File.exists?(old_filepath)
       assert File.read!(conflicting_filepath) == "existing nfo"
+=======
+    test "marks a staged reconcile plan stale", %{conn: conn, source: source, update_attrs: update_attrs} do
+      expect(YtDlpRunnerMock, :run, 1, &runner_function_mock/5)
+      {:ok, plan} = Pinchflat.Reconciliation.create_plan(%{mode: :local, status: :ready})
+
+      put(conn, ~p"/sources/#{source}", source: update_attrs)
+
+      assert Pinchflat.Reconciliation.get_plan!(plan.id).status == :stale
+>>>>>>> ad2a66e (feat: relocate and true up downloaded files after settings changes, without re-downloading)
     end
   end
 

--- a/test/support/testing_helper_methods.ex
+++ b/test/support/testing_helper_methods.ex
@@ -55,6 +55,26 @@ defmodule Pinchflat.TestingHelperMethods do
     |> Phoenix.json_library().decode!()
   end
 
+  @doc """
+  Damages the FTS5 search index the way a real fault does — by mangling the
+  inverted index behind it — so integrity checks have something genuine to
+  report. Rolled back with the test's sandbox transaction.
+
+  The explicit 'rebuild' first is load-bearing: FTS5 buffers index writes in
+  memory, so without it the shadow table may hold nothing to corrupt yet and
+  the damage silently doesn't happen. The assertion catches that case rather
+  than letting a test pass against an intact index.
+  """
+  def corrupt_search_index do
+    Pinchflat.Repo.query!("INSERT INTO media_items_search_index(media_items_search_index) VALUES('rebuild')")
+
+    result = Pinchflat.Repo.query!("UPDATE media_items_search_index_data SET block = zeroblob(8) WHERE id > 1")
+
+    assert result.num_rows > 0, "expected the search index to have shadow rows to corrupt"
+
+    :ok
+  end
+
   def create_platform_directories do
     File.mkdir_p!(Application.get_env(:pinchflat, :media_directory))
     File.mkdir_p!(Application.get_env(:pinchflat, :metadata_directory))

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -10,6 +10,11 @@ Application.put_env(:pinchflat, :http_client, HTTPClientMock)
 Mox.defmock(UserScriptRunnerMock, for: Pinchflat.Lifecycle.UserScripts.UserScriptCommandRunner)
 Application.put_env(:pinchflat, :user_script_runner, UserScriptRunnerMock)
 
+Mox.defmock(YoutubeApiMock, for: Pinchflat.FastIndexing.YoutubeBehaviour)
+Application.put_env(:pinchflat, :youtube_api, YoutubeApiMock)
+
+Mox.defmock(DiskSpaceCheckerMock, for: Pinchflat.Diagnostics.DiskSpaceBehaviour)
+Application.put_env(:pinchflat, :disk_space_checker, DiskSpaceCheckerMock)
 ExUnit.start()
 Ecto.Adapters.SQL.Sandbox.mode(Pinchflat.Repo, :manual)
 Faker.start()


### PR DESCRIPTION
### Summary
This PR brings over Batch 3 improvements for database maintenance and file reconciliation:
- **Database Insights & Compaction**: Add safe database compaction (SQLite VACUUM with disk space check and queue pausing), scheduled monthly compaction setting, table row stats, journal mode and orphaned tasks tracking, and SQLite integrity checking directly from the Diagnostics page.
- **File Reconciliation**: Move and true up existing media and sidecars (NFOs, JSON metadata, thumbnails, subtitles) after settings or output path changes without re-downloading media. Includes local, online, and full sync modes, live progress tracking, parallel online backfilling, quiet-window serialization, and crash-recovery safeguards.
- **Material Design 3 Styling**: Complete adherence to semantic tokens and UI theming across all reconciliation views and diagnostics components.