### PR TITLE
Restore ARM64 Docker images for 2026.8.21

### DIFF
--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -10,6 +10,7 @@ on:
         default: 'linux/amd64'
         options:
           - 'linux/amd64'
+          - 'linux/amd64,linux/arm64'
       docker_tags:
         type: string
         description: 'Docker tag to publish alongside latest'
@@ -46,13 +47,12 @@ jobs:
       - name: Determine build matrix
         id: set-matrix
         run: |
-          # Release events build amd64 only to control Actions usage
-          # Pushes to tags also build amd64 only
+          # Published releases and tag pushes build both architectures
           # workflow_dispatch uses the selected platforms input
 
           if [[ "${{ github.event_name }}" == "release" ]]; then
-            echo 'matrix={"include":[{"platform":"linux/amd64","runner":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
-            echo "is_multi_arch=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]}' >> "$GITHUB_OUTPUT"
+            echo "is_multi_arch=true" >> "$GITHUB_OUTPUT"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             PLATFORMS="${{ inputs.platforms }}"
             if [[ "$PLATFORMS" == *"arm64"* ]]; then
@@ -63,9 +63,8 @@ jobs:
               echo "is_multi_arch=false" >> "$GITHUB_OUTPUT"
             fi
           else
-            # Tag pushes - only amd64 for faster versioned builds
-            echo 'matrix={"include":[{"platform":"linux/amd64","runner":"ubuntu-latest"}]}' >> "$GITHUB_OUTPUT"
-            echo "is_multi_arch=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[{"platform":"linux/amd64","runner":"ubuntu-latest"},{"platform":"linux/arm64","runner":"ubuntu-24.04-arm"}]}' >> "$GITHUB_OUTPUT"
+            echo "is_multi_arch=true" >> "$GITHUB_OUTPUT"
           fi
 
   build:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ For installation, configuration, and the base feature set, use the actual upstre
 - Upstream README: <https://github.com/kieraneglin/pinchflat/blob/master/README.md>
 - Upstream wiki: <https://github.com/kieraneglin/pinchflat/wiki>
 
+## Docker Images
+
+PinchYT images are published to `ghcr.io/thebadfella/pinchyt` as multi-platform Linux images:
+
+- `linux/amd64` for 64-bit Intel and AMD systems
+- `linux/arm64` for 64-bit ARM systems, including Raspberry Pi devices running a 64-bit OS
+
+Docker automatically pulls the correct architecture from a multi-platform tag. Use `latest` for the newest published
+release or a version tag when you want to pin a deployment.
+
 ## What PinchYT Adds over Pinchflat (As a Fork)
 
 ### Sources

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pinchflat.MixProject do
   def project do
     [
       app: :pinchflat,
-      version: "2026.8.17",
+      version: "2026.8.21",
       elixir: "~> 1.17",
       elixirc_paths: elixirc_paths(Mix.env()),
       elixirc_options: [warnings_as_errors: System.get_env("EX_CHECK") == "1"],


### PR DESCRIPTION
## Summary

- restore published Docker images for `linux/arm64` alongside `linux/amd64`
- restore the manual multi-platform build option
- document the available GHCR image architectures
- bump the application version to `2026.8.21`

## Motivation

I've seen users forking PinchYT just to add ARM64 builds, so I thought I'd publish those builds directly and make the fork useful on more systems, including 64-bit Raspberry Pi devices.

## Validation

- `docker compose run --rm phx mix check`
- 1,515 tests, 0 failures
- `actionlint .github/workflows/docker_release.yml`
- Docker-based Prettier checks