### PR TITLE
Add sorting to Home history

### DIFF
--- a/lib/pinchflat_web/components/custom_components/table_components.ex
+++ b/lib/pinchflat_web/components/custom_components/table_components.ex
@@ -16,8 +16,8 @@ defmodule PinchflatWeb.CustomComponents.TableComponents do
   """
   attr :rows, :list, required: true
   attr :table_class, :string, default: ""
-  attr :sort_key, :string, default: nil
-  attr :sort_direction, :string, default: nil
+  attr :sort_key, :atom, default: nil
+  attr :sort_direction, :atom, default: nil
 
   attr :row_item, :any,
     default: &Function.identity/1,
@@ -41,18 +41,26 @@ defmodule PinchflatWeb.CustomComponents.TableComponents do
             <tr class="border-b border-theme-outline/70 bg-theme-surface-3 text-left">
               <th
                 :for={col <- @col}
-                class={["px-4 py-4 font-medium text-theme-on-surface", col[:sort_key] && "cursor-pointer"]}
-                phx-click={col[:sort_key] && "sort_update"}
-                phx-value-sort_key={col[:sort_key]}
+                class="px-4 py-4 font-medium text-theme-on-surface"
+                aria-sort={column_sort(@sort_key, @sort_direction, col[:sort_key])}
               >
-                <div class="relative">
+                <button
+                  :if={col[:sort_key]}
+                  type="button"
+                  class="inline-flex items-center gap-1 text-left"
+                  phx-click="sort_update"
+                  phx-value-sort_key={col[:sort_key]}
+                  aria-label={sort_button_label(col[:label], @sort_key, @sort_direction, col[:sort_key])}
+                >
                   {col[:label]}
                   <.icon
                     :if={to_string(@sort_key) == col[:sort_key]}
                     name={if @sort_direction == :asc, do: "hero-chevron-up", else: "hero-chevron-down"}
-                    class="w-3 h-3 mt-2 ml-1 absolute"
+                    class="h-3 w-3"
+                    aria-hidden="true"
                   />
-                </div>
+                </button>
+                <span :if={!col[:sort_key]}>{col[:label]}</span>
               </th>
             </tr>
           </thead>
@@ -74,6 +82,24 @@ defmodule PinchflatWeb.CustomComponents.TableComponents do
       </div>
     </div>
     """
+  end
+
+  defp column_sort(sort_key, sort_direction, column_key) do
+    if to_string(sort_key) == column_key do
+      if sort_direction == :asc, do: "ascending", else: "descending"
+    else
+      "none"
+    end
+  end
+
+  defp sort_button_label(label, sort_key, sort_direction, column_key) do
+    if to_string(sort_key) == column_key do
+      direction = if sort_direction == :asc, do: "ascending", else: "descending"
+      next_direction = if sort_direction == :asc, do: "descending", else: "ascending"
+      "Sort by #{label}, currently #{direction}. Activate to sort #{next_direction}."
+    else
+      "Sort by #{label}"
+    end
   end
 
   @doc """

--- a/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
+++ b/lib/pinchflat_web/controllers/pages/page_html/history_table_live.ex
@@ -2,6 +2,7 @@ defmodule Pinchflat.Pages.HistoryTableLive do
   use PinchflatWeb, :live_view
   use Pinchflat.Media.MediaQuery
   import Ecto.Query, warn: false
+  import PinchflatWeb.Helpers.SortingHelpers
 
   alias Pinchflat.Repo
   alias Pinchflat.Media
@@ -13,6 +14,11 @@ defmodule Pinchflat.Pages.HistoryTableLive do
   alias PinchflatWeb.CustomComponents.TextComponents
 
   @limit System.get_env("PAGINATION_HISTORY_LIMIT", System.get_env("PAGINATION_LIMIT", "10")) |> String.to_integer()
+  @sort_fields %{
+    "uploaded_at" => :uploaded_at,
+    "inserted_at" => :inserted_at,
+    "media_downloaded_at" => :media_downloaded_at
+  }
 
   def render(%{records: []} = assigns) do
     ~H"""
@@ -125,7 +131,7 @@ defmodule Pinchflat.Pages.HistoryTableLive do
       <div class="hidden md:block">
         <div class="max-w-full overflow-visible">
           <div class="overflow-x-auto overflow-y-hidden">
-            <.table rows={@records}>
+            <.table rows={@records} sort_key={@sort_key} sort_direction={@sort_direction}>
               <:col :let={media_item} label="Title" class="max-w-sm">
                 <section class="space-y-2">
                   <div class="flex items-start space-x-1 gap-2">
@@ -155,15 +161,21 @@ defmodule Pinchflat.Pages.HistoryTableLive do
                 </section>
               </:col>
 
-              <:col :let={media_item} label="Upload Date">{DateTime.to_date(media_item.uploaded_at)}</:col>
+              <:col :let={media_item} label="Upload Date" sort_key="uploaded_at">
+                {DateTime.to_date(media_item.uploaded_at)}
+              </:col>
 
               <:col :let={media_item} label="Size / Progress">
                 <.progress_details media_item={media_item} task={Map.get(@tasks_by_media_item_id, media_item.id)} />
               </:col>
 
-              <:col :let={media_item} label="Indexed At">{format_datetime(media_item.inserted_at)}</:col>
+              <:col :let={media_item} label="Indexed At" sort_key="inserted_at">
+                {format_datetime(media_item.inserted_at)}
+              </:col>
 
-              <:col :let={media_item} label="Downloaded At">{format_datetime(media_item.media_downloaded_at)}</:col>
+              <:col :let={media_item} label="Downloaded At" sort_key="media_downloaded_at">
+                {format_datetime(media_item.media_downloaded_at)}
+              </:col>
 
               <:col :let={media_item} label="Source" class="max-w-sm">
                 <.subtle_link href={~p"/sources/#{media_item.source_id}"}>
@@ -205,22 +217,70 @@ defmodule Pinchflat.Pages.HistoryTableLive do
 
     page = 1
     media_state = session["media_state"]
+    sort_key = nil
+    sort_direction = :desc
     base_query = generate_base_query(media_state)
-    pagination_attrs = fetch_pagination_attributes(base_query, page, media_state)
+    pagination_attrs = fetch_pagination_attributes(base_query, page, media_state, sort_key, sort_direction)
 
-    {:ok, assign(socket, Map.merge(pagination_attrs, %{base_query: base_query, media_state: media_state}))}
+    {:ok,
+     assign(
+       socket,
+       Map.merge(pagination_attrs, %{
+         base_query: base_query,
+         media_state: media_state,
+         sort_key: sort_key,
+         sort_direction: sort_direction
+       })
+     )}
   end
 
   def handle_event("page_change", %{"direction" => direction}, %{assigns: assigns} = socket) do
     direction = if direction == "inc", do: 1, else: -1
     new_page = assigns.page + direction
-    new_assigns = fetch_pagination_attributes(assigns.base_query, new_page, assigns.media_state)
+
+    new_assigns =
+      fetch_pagination_attributes(
+        assigns.base_query,
+        new_page,
+        assigns.media_state,
+        assigns.sort_key,
+        assigns.sort_direction
+      )
 
     {:noreply, assign(socket, new_assigns)}
   end
 
+  def handle_event("sort_update", %{"sort_key" => sort_key}, %{assigns: assigns} = socket) do
+    case Map.fetch(@sort_fields, sort_key) do
+      {:ok, new_sort_key} ->
+        new_sort_direction = get_sort_direction(assigns.sort_key, new_sort_key, assigns.sort_direction)
+
+        new_assigns =
+          fetch_pagination_attributes(
+            assigns.base_query,
+            1,
+            assigns.media_state,
+            new_sort_key,
+            new_sort_direction
+          )
+
+        {:noreply,
+         assign(socket, Map.merge(new_assigns, %{sort_key: new_sort_key, sort_direction: new_sort_direction}))}
+
+      :error ->
+        {:noreply, socket}
+    end
+  end
+
   def handle_event("reload_page", _params, %{assigns: assigns} = socket) do
-    new_assigns = fetch_pagination_attributes(assigns.base_query, assigns.page, assigns.media_state)
+    new_assigns =
+      fetch_pagination_attributes(
+        assigns.base_query,
+        assigns.page,
+        assigns.media_state,
+        assigns.sort_key,
+        assigns.sort_direction
+      )
 
     {:noreply, assign(socket, new_assigns)}
   end
@@ -229,14 +289,29 @@ defmodule Pinchflat.Pages.HistoryTableLive do
     media_item = Media.get_media_item!(media_id)
     MediaDownloadWorker.kickoff_with_task(media_item, %{force: true, reset_last_error: true})
 
-    new_assigns = fetch_pagination_attributes(assigns.base_query, assigns.page, assigns.media_state)
+    new_assigns =
+      fetch_pagination_attributes(
+        assigns.base_query,
+        assigns.page,
+        assigns.media_state,
+        assigns.sort_key,
+        assigns.sort_direction
+      )
 
     {:noreply, assign(socket, new_assigns)}
   end
 
   def handle_event("retry_all_failed", _params, %{assigns: assigns} = socket) do
     DownloadingHelpers.retry_failed_download_tasks()
-    new_assigns = fetch_pagination_attributes(assigns.base_query, assigns.page, assigns.media_state)
+
+    new_assigns =
+      fetch_pagination_attributes(
+        assigns.base_query,
+        assigns.page,
+        assigns.media_state,
+        assigns.sort_key,
+        assigns.sort_direction
+      )
 
     {:noreply, assign(socket, new_assigns)}
   end
@@ -248,7 +323,14 @@ defmodule Pinchflat.Pages.HistoryTableLive do
       {:ok, _task} = Tasks.delete_task(task)
     end
 
-    new_assigns = fetch_pagination_attributes(assigns.base_query, assigns.page, assigns.media_state)
+    new_assigns =
+      fetch_pagination_attributes(
+        assigns.base_query,
+        assigns.page,
+        assigns.media_state,
+        assigns.sort_key,
+        assigns.sort_direction
+      )
 
     {:noreply, assign(socket, new_assigns)}
   end
@@ -256,7 +338,15 @@ defmodule Pinchflat.Pages.HistoryTableLive do
   def handle_info(%{topic: "job:state", event: "change", payload: payload}, %{assigns: assigns} = socket)
       when is_map(payload) do
     if refresh_required?(payload) do
-      new_assigns = fetch_pagination_attributes(assigns.base_query, assigns.page, assigns.media_state)
+      new_assigns =
+        fetch_pagination_attributes(
+          assigns.base_query,
+          assigns.page,
+          assigns.media_state,
+          assigns.sort_key,
+          assigns.sort_direction
+        )
+
       {:noreply, assign(socket, new_assigns)}
     else
       {:noreply, socket}
@@ -264,7 +354,14 @@ defmodule Pinchflat.Pages.HistoryTableLive do
   end
 
   def handle_info(%{topic: "job:state", event: "change"}, %{assigns: assigns} = socket) do
-    new_assigns = fetch_pagination_attributes(assigns.base_query, assigns.page, assigns.media_state)
+    new_assigns =
+      fetch_pagination_attributes(
+        assigns.base_query,
+        assigns.page,
+        assigns.media_state,
+        assigns.sort_key,
+        assigns.sort_direction
+      )
 
     {:noreply, assign(socket, new_assigns)}
   end
@@ -280,16 +377,14 @@ defmodule Pinchflat.Pages.HistoryTableLive do
     {:noreply, socket}
   end
 
-  defp fetch_pagination_attributes(base_query, page, media_state) do
+  defp fetch_pagination_attributes(base_query, page, media_state, sort_key, sort_direction) do
     total_record_count = Repo.aggregate(base_query, :count, :id)
     total_pages = max(ceil(total_record_count / @limit), 1)
     page = NumberUtils.clamp(page, 1, total_pages)
+    sorted_query = order_records(base_query, media_state, sort_key, sort_direction)
 
     if media_state == "pending" do
-      records =
-        base_query
-        |> order_pending_media()
-        |> fetch_records(page)
+      records = fetch_records(sorted_query, page)
 
       tasks_by_media_item_id = fetch_download_tasks(records)
 
@@ -301,7 +396,7 @@ defmodule Pinchflat.Pages.HistoryTableLive do
         tasks_by_media_item_id: tasks_by_media_item_id
       }
     else
-      records = fetch_records(base_query, page)
+      records = fetch_records(sorted_query, page)
 
       %{
         page: page,
@@ -340,7 +435,6 @@ defmodule Pinchflat.Pages.HistoryTableLive do
         :media_size_bytes
       ])
     )
-    |> order_by(desc: :id)
   end
 
   defp generate_base_query("failed") do
@@ -360,7 +454,6 @@ defmodule Pinchflat.Pages.HistoryTableLive do
         :media_size_bytes
       ])
     )
-    |> order_by(desc: :id)
   end
 
   defp generate_base_query("downloaded") do
@@ -380,7 +473,22 @@ defmodule Pinchflat.Pages.HistoryTableLive do
         :media_size_bytes
       ])
     )
-    |> order_by(desc: :id)
+  end
+
+  defp order_records(base_query, "pending", nil, _sort_direction), do: order_pending_media(base_query)
+  defp order_records(base_query, _media_state, nil, _sort_direction), do: order_by(base_query, desc: :id)
+
+  defp order_records(base_query, _media_state, sort_key, sort_direction) do
+    sort_field = Map.fetch!(@sort_fields, Atom.to_string(sort_key))
+
+    sort_expression = dynamic([media_item], field(media_item, ^sort_field))
+
+    nulls_last_expression =
+      dynamic([media_item], fragment("CASE WHEN ? IS NULL THEN 1 ELSE 0 END", ^sort_expression))
+
+    from(media_item in base_query,
+      order_by: ^[{:asc, nulls_last_expression}, {sort_direction, sort_expression}, asc: :id]
+    )
   end
 
   defp format_datetime(nil), do: ""

--- a/test/pinchflat_web/controllers/pages/history_table_live_test.exs
+++ b/test/pinchflat_web/controllers/pages/history_table_live_test.exs
@@ -8,6 +8,8 @@ defmodule PinchflatWeb.Pages.HistoryTableLiveTest do
 
   alias Pinchflat.Pages.HistoryTableLive
   alias Pinchflat.Downloading.MediaDownloadWorker
+  alias Pinchflat.Media.MediaItem
+  alias Pinchflat.Repo
 
   describe "pending ordering" do
     test "shows executing downloads before later queued pending items across pages", %{conn: conn} do
@@ -58,5 +60,151 @@ defmodule PinchflatWeb.Pages.HistoryTableLiveTest do
 
       assert_enqueued(worker: MediaDownloadWorker, args: %{"id" => failed.id})
     end
+  end
+
+  describe "sorting" do
+    test "sorts by upload date and toggles the direction", %{conn: conn} do
+      source = source_fixture()
+      older = media_item_fixture(%{source_id: source.id, title: "Older", uploaded_at: ~U[2024-01-01 00:00:00Z]})
+      newer = media_item_fixture(%{source_id: source.id, title: "Newer", uploaded_at: ~U[2024-01-02 00:00:00Z]})
+
+      {:ok, view, _html} = live_isolated(conn, HistoryTableLive, session: %{"media_state" => "downloaded"})
+
+      view |> element("th button", "Upload Date") |> render_click()
+      assert render_element(view, "tbody tr:first-child") =~ older.title
+      assert render_element(view, "tbody tr:last-child") =~ newer.title
+      assert render(view) =~ ~s(aria-sort="ascending")
+
+      view |> element("th button", "Upload Date") |> render_click()
+      assert render_element(view, "tbody tr:first-child") =~ newer.title
+      assert render_element(view, "tbody tr:last-child") =~ older.title
+      assert render(view) =~ ~s(aria-sort="descending")
+    end
+
+    test "sorts pending history by upload date", %{conn: conn} do
+      source = source_fixture()
+
+      older =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          title: "Older",
+          uploaded_at: ~U[2024-01-01 00:00:00Z]
+        })
+
+      newer =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          title: "Newer",
+          uploaded_at: ~U[2024-01-02 00:00:00Z]
+        })
+
+      {:ok, view, _html} = live_isolated(conn, HistoryTableLive, session: %{"media_state" => "pending"})
+
+      view |> element("th button", "Upload Date") |> render_click()
+      assert render_element(view, "tbody tr:first-child") =~ older.title
+      assert render_element(view, "tbody tr:last-child") =~ newer.title
+    end
+
+    test "sorts failed history by upload date", %{conn: conn} do
+      source = source_fixture()
+
+      older =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          last_error: "Older failure",
+          title: "Older",
+          uploaded_at: ~U[2024-01-01 00:00:00Z]
+        })
+
+      newer =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          last_error: "Newer failure",
+          title: "Newer",
+          uploaded_at: ~U[2024-01-02 00:00:00Z]
+        })
+
+      {:ok, view, _html} = live_isolated(conn, HistoryTableLive, session: %{"media_state" => "failed"})
+
+      view |> element("th button", "Upload Date") |> render_click()
+      assert render_element(view, "tbody tr:first-child") =~ older.title
+      assert render_element(view, "tbody tr:last-child") =~ newer.title
+    end
+
+    test "uses ascending IDs to break equal timestamp ties", %{conn: conn} do
+      source = source_fixture()
+      first = media_item_fixture(%{source_id: source.id, title: "First", uploaded_at: ~U[2024-01-01 00:00:00Z]})
+      second = media_item_fixture(%{source_id: source.id, title: "Second", uploaded_at: first.uploaded_at})
+
+      {:ok, view, _html} = live_isolated(conn, HistoryTableLive, session: %{"media_state" => "downloaded"})
+
+      view |> element("th button", "Upload Date") |> render_click()
+      assert render_element(view, "tbody tr:first-child") =~ first.title
+      assert render_element(view, "tbody tr:last-child") =~ second.title
+    end
+
+    test "sorts indexed and downloaded dates with deterministic null handling", %{conn: conn} do
+      source = source_fixture()
+      older = media_item_fixture(%{source_id: source.id, title: "Older", media_downloaded_at: nil})
+      newer = media_item_fixture(%{source_id: source.id, title: "Newer", media_downloaded_at: ~U[2024-01-02 00:00:00Z]})
+
+      Repo.update_all(
+        from(media_item in MediaItem, where: media_item.id == ^older.id),
+        set: [inserted_at: ~U[2024-01-01 00:00:00Z]]
+      )
+
+      Repo.update_all(
+        from(media_item in MediaItem, where: media_item.id == ^newer.id),
+        set: [inserted_at: ~U[2024-01-02 00:00:00Z]]
+      )
+
+      {:ok, view, _html} = live_isolated(conn, HistoryTableLive, session: %{"media_state" => "downloaded"})
+
+      view |> element("th button", "Indexed At") |> render_click()
+      assert render_element(view, "tbody tr:first-child") =~ older.title
+      assert render_element(view, "tbody tr:last-child") =~ newer.title
+
+      view |> element("th button", "Downloaded At") |> render_click()
+      assert render_element(view, "tbody tr:first-child") =~ newer.title
+      assert render_element(view, "tbody tr:last-child") =~ older.title
+    end
+
+    test "resets to the first page and ignores unknown sort keys", %{conn: conn} do
+      source = source_fixture()
+
+      for index <- 1..11 do
+        media_item_fixture(%{source_id: source.id, title: "Item #{index}", uploaded_at: ~U[2024-01-01 00:00:00Z]})
+      end
+
+      {:ok, view, _html} = live_isolated(conn, HistoryTableLive, session: %{"media_state" => "downloaded"})
+
+      view |> element("span.pagination-next") |> render_click()
+      assert pagination_text(view) == "Page 2 of 2"
+
+      socket = %{assigns: %{sort_key: nil, sort_direction: :desc}}
+      assert {:noreply, ^socket} = HistoryTableLive.handle_event("sort_update", %{"sort_key" => "not_a_field"}, socket)
+
+      view |> element("th button", "Upload Date") |> render_click()
+      assert pagination_text(view) == "Page 1 of 2"
+    end
+  end
+
+  defp render_element(view, selector) do
+    view
+    |> element(selector)
+    |> render()
+  end
+
+  defp pagination_text(view) do
+    view
+    |> element("nav span.mx-2")
+    |> render()
+    |> String.replace(~r/<[^>]*>/, "")
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
   end
 end

--- a/test/pinchflat_web/controllers/sources/index_table_live_test.exs
+++ b/test/pinchflat_web/controllers/sources/index_table_live_test.exs
@@ -85,7 +85,7 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
       {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: create_session())
 
       # Click the row to change the sort direction
-      click_element(view, "th", "Name")
+      click_element(view, "th button", "Name")
 
       assert render_element(view, "tbody tr:first-child") =~ source1.custom_name
       assert render_element(view, "tbody tr:last-child") =~ source2.custom_name
@@ -98,13 +98,13 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
       {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: create_session())
 
       # Click the row to change the sort field
-      click_element(view, "th", "Enabled?")
+      click_element(view, "th button", "Enabled?")
 
       assert render_element(view, "tbody tr:first-child") =~ source2.custom_name
       assert render_element(view, "tbody tr:last-child") =~ source1.custom_name
 
       # Click the row to again change the sort direcation
-      click_element(view, "th", "Enabled?")
+      click_element(view, "th button", "Enabled?")
       assert render_element(view, "tbody tr:first-child") =~ source1.custom_name
       assert render_element(view, "tbody tr:last-child") =~ source2.custom_name
     end
@@ -128,7 +128,7 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
 
       {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: create_session())
 
-      click_element(view, "th", "Pending")
+      click_element(view, "th button", "Pending")
 
       assert render_element(view, "tbody tr:first-child") =~ source2.custom_name
       assert render_element(view, "tbody tr:last-child") =~ source1.custom_name
@@ -141,7 +141,7 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
 
       {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: create_session())
 
-      click_element(view, "th", "Downloaded")
+      click_element(view, "th button", "Downloaded")
 
       assert render_element(view, "tbody tr:first-child") =~ source2.custom_name
       assert render_element(view, "tbody tr:last-child") =~ source1.custom_name
@@ -158,10 +158,10 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
       # media_item_fixture creates stray zero-size sources, so only the biggest
       # source has a deterministic position: last when ascending, first when
       # descending
-      click_element(view, "th", "Size")
+      click_element(view, "th button", "Size")
       assert render_element(view, "tbody tr:last-child") =~ source1.custom_name
 
-      click_element(view, "th", "Size")
+      click_element(view, "th button", "Size")
       assert render_element(view, "tbody tr:first-child") =~ source1.custom_name
     end
 
@@ -171,12 +171,12 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
 
       {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: create_session())
 
-      click_element(view, "th", "Type")
+      click_element(view, "th button", "Type")
 
       assert render_element(view, "tbody tr:first-child") =~ source1.custom_name
       assert render_element(view, "tbody tr:last-child") =~ source2.custom_name
 
-      click_element(view, "th", "Type")
+      click_element(view, "th button", "Type")
 
       assert render_element(view, "tbody tr:first-child") =~ source2.custom_name
       assert render_element(view, "tbody tr:last-child") =~ source1.custom_name
@@ -190,7 +190,7 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
 
       {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: create_session())
 
-      click_element(view, "th", "Media Profile")
+      click_element(view, "th button", "Media Profile")
 
       assert render_element(view, "tbody tr:first-child") =~ source2.custom_name
       assert render_element(view, "tbody tr:last-child") =~ source1.custom_name


### PR DESCRIPTION
## Summary
- Adds sortable Upload Date, Indexed At, and Downloaded At columns to Home history.
- Preserves the default queue/ID ordering, active history tab, filters, and pagination behavior.
- Adds accessible sort buttons, direction indicators, NULL handling, stable ID tie-breaking, and focused LiveView coverage.

## User-visible behavior
Home history now exposes keyboard-accessible sort buttons for Upload Date, Indexed At, and Downloaded At. A first activation sorts ascending, a second activation reverses the direction, and changing sort resets to page 1. Pending history keeps its existing queue order until an explicit sort is selected.

## Compatibility and migration notes
No migration or persisted preference was added. The default ordering remains unchanged. Sort keys are restricted to the three allowlisted client-facing fields; unknown keys are ignored without creating atoms or crashing the LiveView. NULL date values sort last and every explicit ordering ends with media-item ID for deterministic pagination.

## Tests actually run
- `docker compose run --rm phx mix format` on the four PR1 files: passed.
- `docker compose run --rm phx mix test test/pinchflat_web/controllers/pages/history_table_live_test.exs test/pinchflat_web/controllers/sources/index_table_live_test.exs`: 25 tests, 0 failures.
- `docker compose run --rm phx yarn run ui:check-theme`: passed.
- `docker compose run --rm phx mix check`: compile, Credo, Sobelow, and 1,553 ExUnit tests passed; overall command exited 1 because Prettier received Windows `EPERM` while traversing the host-mounted `.agents/skills` junction at `/app/.agents/skills`.
- Docker app healthcheck: `http://localhost:4000/healthcheck` returned `{"status":"ok"}`.

## DevTools MCP verification
Using the existing browser tab at `http://localhost:4000/`:
- Pending tab: captured the initial rows; clicked Upload Date twice and verified ascending/descending `aria-sort`, accessible labels, changed row order where timestamps differed, Indexed At, and Downloaded At.
- Failed tab: activated Upload Date, Indexed At, and Downloaded At; the Failed tab remained selected.
- Downloaded tab: captured two rows; clicked Upload Date twice, Indexed At, and Downloaded At; the Downloaded tab remained selected, direction indicators updated, and no duplicate rows appeared.
- Final DOM assertion on `http://localhost:4000/?tab=downloaded`: 2 rows, 0 duplicate rows, Downloaded At `aria-sort="ascending"` with the expected accessible label.
- Console inspection found no new error-level messages; only existing DevTools issues and LiveView debug logs were present.
- A viewport screenshot was captured after the final Downloaded At sort.

## Tests not run / limitations
- No separate selfhosted-image build was run; the Dockerfile changes in `docker/dev.Dockerfile` and `docker/selfhosted.Dockerfile` are preserved as unstaged user changes and are intentionally outside this PR1 commit.
- `priv/repo/erd.png` was generated by the Docker checks/app startup and restored to `HEAD`; it is not part of this PR.

## Non-goals
- No new filters or history columns.
- No global sort-preference persistence.
- No source-list changes.
- No Docker-file changes in this PR.
