### PR TITLE
Persist media availability from yt-dlp

### DIFF
--- a/lib/pinchflat/media/media.ex
+++ b/lib/pinchflat/media/media.ex
@@ -187,7 +187,10 @@ defmodule Pinchflat.Media do
   Returns {:ok, %MediaItem{}} | {:error, %Ecto.Changeset{}}
   """
   def update_media_item(%MediaItem{} = media_item, attrs) do
-    update_attrs = Map.drop(attrs, @fields_to_drop_on_update)
+    update_attrs =
+      attrs
+      |> Map.drop(@fields_to_drop_on_update)
+      |> preserve_known_availability(media_item)
 
     media_item
     |> MediaItem.changeset(update_attrs)
@@ -331,10 +334,23 @@ defmodule Pinchflat.Media do
   end
 
   defp update_media_item_from_backend_attrs(media_item, attrs) do
+    attrs =
+      attrs
+      |> Map.drop(@fields_to_drop_on_update)
+      |> preserve_known_availability(media_item)
+
     media_item
-    |> MediaItem.changeset(Map.drop(attrs, @fields_to_drop_on_update))
+    |> MediaItem.changeset(attrs)
     |> Repo.update()
   end
+
+  # A later backend response can omit availability while yt-dlp is unable to determine it.
+  # Keep a value already captured instead of replacing it with nil.
+  defp preserve_known_availability(attrs, %{availability: availability}) when not is_nil(availability) do
+    if Map.get(attrs, :availability) == nil, do: Map.delete(attrs, :availability), else: attrs
+  end
+
+  defp preserve_known_availability(attrs, _media_item), do: attrs
 
   defp maybe_prevent_download_by_default(attrs, %Source{collection_type: :playlist, selection_mode: :manual}) do
     Map.put_new(attrs, :prevent_download, true)

--- a/lib/pinchflat/media/media_item.ex
+++ b/lib/pinchflat/media/media_item.ex
@@ -17,6 +17,8 @@ defmodule Pinchflat.Media.MediaItem do
   alias Pinchflat.Metadata.MediaMetadata
   alias Pinchflat.Media.MediaItemsSearchIndex
 
+  @availability_values ~w(public unlisted subscriber_only premium_only needs_auth private)a
+
   @allowed_fields [
     # these fields are only captured on index
     :playlist_index,
@@ -28,6 +30,7 @@ defmodule Pinchflat.Media.MediaItem do
     :livestream,
     :source_id,
     :short_form_content,
+    :availability,
     :uploaded_at,
     :upload_date_index,
     :duration_seconds,
@@ -73,6 +76,7 @@ defmodule Pinchflat.Media.MediaItem do
     field :original_url, :string
     field :livestream, :boolean, default: false
     field :short_form_content, :boolean, default: false
+    field :availability, Ecto.Enum, values: @availability_values
     field :media_downloaded_at, :utc_datetime
     field :media_redownloaded_at, :utc_datetime
     field :uploaded_at, :utc_datetime

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -3,6 +3,9 @@ defmodule Pinchflat.YtDlp.Media do
   Contains utilities for working with singular pieces of media
   """
 
+  @availability_values ~w(public unlisted subscriber_only premium_only needs_auth private)a
+  @availability_aliases %{"members-only" => :subscriber_only, "members_only" => :subscriber_only}
+
   @enforce_keys [
     :media_id,
     :title,
@@ -25,6 +28,7 @@ defmodule Pinchflat.YtDlp.Media do
     :uploaded_at,
     :duration_seconds,
     :playlist_index,
+    :availability,
     :predicted_media_filepath
   ]
 
@@ -141,8 +145,28 @@ defmodule Pinchflat.YtDlp.Media do
         if something is a short via the URL again
   """
   def indexing_output_template do
-    "%(.{id,title,live_status,original_url,description,aspect_ratio,duration,upload_date,timestamp,playlist_index,filename})j"
+    "%(.{id,title,live_status,original_url,description,aspect_ratio,duration,upload_date,timestamp,playlist_index,filename,availability})j"
   end
+
+  @doc """
+  Normalizes yt-dlp availability values to the values stored by PinchYT.
+
+  Unknown, blank, and missing values return `nil`.
+
+  Returns `:public | :unlisted | :subscriber_only | :premium_only | :needs_auth | :private | nil`.
+  """
+  def normalize_availability(value) when is_atom(value) do
+    if value in @availability_values, do: value
+  end
+
+  def normalize_availability(value) when is_binary(value) do
+    value = String.trim(value)
+
+    Map.get(@availability_aliases, value) ||
+      Enum.find(@availability_values, fn known_value -> Atom.to_string(known_value) == value end)
+  end
+
+  def normalize_availability(_value), do: nil
 
   @doc """
   Transforms a response from yt-dlp into a struct. Interprets the response to
@@ -161,6 +185,7 @@ defmodule Pinchflat.YtDlp.Media do
       short_form_content: response["original_url"] && short_form_content?(response),
       uploaded_at: response["upload_date"] && parse_uploaded_at(response),
       playlist_index: response["playlist_index"] || 0,
+      availability: normalize_availability(response["availability"]),
       predicted_media_filepath: response["filename"]
     }
   end

--- a/lib/pinchflat_web/controllers/api/media_controller.ex
+++ b/lib/pinchflat_web/controllers/api/media_controller.ex
@@ -173,6 +173,7 @@ defmodule PinchflatWeb.Api.MediaController do
           uuid: mi.uuid,
           title: mi.title,
           media_id: mi.media_id,
+          availability: mi.availability,
           source_id: mi.source_id,
           uploaded_at: mi.uploaded_at,
           media_downloaded_at: mi.media_downloaded_at,

--- a/lib/pinchflat_web/schemas.ex
+++ b/lib/pinchflat_web/schemas.ex
@@ -216,6 +216,12 @@ defmodule PinchflatWeb.Schemas do
         title: %Schema{type: :string, description: "Media title", example: "My Video Title"},
         media_id: %Schema{type: :string, description: "External media ID", example: "youtube_video_id"},
         source_id: %Schema{type: :integer, description: "ID of the source this media belongs to", example: 1},
+        availability: %Schema{
+          type: :string,
+          nullable: true,
+          enum: ~w(public unlisted subscriber_only premium_only needs_auth private),
+          description: "Availability reported by yt-dlp"
+        },
         source: %Schema{
           allOf: [Source],
           description: "The source this media belongs to"

--- a/priv/repo/migrations/20260910120000_add_availability_to_media_items.exs
+++ b/priv/repo/migrations/20260910120000_add_availability_to_media_items.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddAvailabilityToMediaItems do
+  use Ecto.Migration
+
+  def change do
+    alter table(:media_items) do
+      add :availability, :string
+    end
+  end
+end

--- a/test/pinchflat/downloading/media_downloader_test.exs
+++ b/test/pinchflat/downloading/media_downloader_test.exs
@@ -38,7 +38,8 @@ defmodule Pinchflat.Downloading.MediaDownloaderTest do
           {:ok, render_metadata(:media_metadata)}
       end)
 
-      assert {:ok, _} = MediaDownloader.download_for_media_item(media_item)
+      assert {:ok, updated_media_item} = MediaDownloader.download_for_media_item(media_item)
+      assert updated_media_item.availability == :public
     end
 
     test "saves the metadata filepath to the database", %{media_item: media_item} do

--- a/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
+++ b/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
@@ -75,6 +75,16 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
       assert [%MediaItem{}] = FastIndexingHelpers.index_and_kickoff_downloads(source)
     end
 
+    test "persists availability returned during fast indexing", %{source: source} do
+      expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl_opts ->
+        {:ok, media_attributes_return_fixture(%{availability: "subscriber_only"})}
+      end)
+
+      assert [%MediaItem{availability: :subscriber_only}] = FastIndexingHelpers.index_and_kickoff_downloads(source)
+    end
+
     test "does not enqueue a download job if the source does not allow it" do
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
       source = source_fixture(%{download_media: false})

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -32,6 +32,13 @@ defmodule Pinchflat.MediaTest do
 
       assert {:ok, _} = Phoenix.json_library().encode(media_item)
     end
+
+    test "serializes availability as a nullable API field" do
+      media_item = media_item_fixture(%{availability: :public})
+      encoded_media_item = media_item |> Phoenix.json_library().encode!() |> Phoenix.json_library().decode!()
+
+      assert encoded_media_item["availability"] == "public"
+    end
   end
 
   describe "list_media_items/0" do
@@ -684,6 +691,78 @@ defmodule Pinchflat.MediaTest do
       assert media_item.media_id == media_attrs.media_id
       assert media_item.original_url == media_attrs.original_url
       assert media_item.description == media_attrs.description
+    end
+
+    test "persists every known availability value" do
+      source = source_fixture()
+
+      Enum.each(
+        [
+          {"public", :public},
+          {"unlisted", :unlisted},
+          {"subscriber_only", :subscriber_only},
+          {"premium_only", :premium_only},
+          {"needs_auth", :needs_auth},
+          {"private", :private}
+        ],
+        fn {raw_value, expected_value} ->
+          media_attrs =
+            media_attributes_return_fixture(%{"id" => "video-#{raw_value}", availability: raw_value})
+            |> Phoenix.json_library().decode!()
+            |> YtDlpMedia.response_to_struct()
+
+          assert {:ok, media_item} = Media.create_media_item_from_backend_attrs(source, media_attrs)
+          assert media_item.availability == expected_value
+        end
+      )
+    end
+
+    test "does not erase a known availability when a later response is missing or unknown" do
+      source = source_fixture()
+
+      known_attrs =
+        media_attributes_return_fixture(%{availability: "public"})
+        |> Phoenix.json_library().decode!()
+        |> YtDlpMedia.response_to_struct()
+
+      assert {:ok, %MediaItem{availability: :public}} =
+               Media.create_media_item_from_backend_attrs(source, known_attrs)
+
+      missing_attrs =
+        media_attributes_return_fixture()
+        |> Phoenix.json_library().decode!()
+        |> YtDlpMedia.response_to_struct()
+
+      assert missing_attrs.availability == nil
+
+      assert {:ok, %MediaItem{availability: :public}} =
+               Media.create_media_item_from_backend_attrs(source, missing_attrs)
+
+      unknown_attrs =
+        media_attributes_return_fixture(%{availability: "future_visibility"})
+        |> Phoenix.json_library().decode!()
+        |> YtDlpMedia.response_to_struct()
+
+      assert unknown_attrs.availability == nil
+
+      assert {:ok, %MediaItem{availability: :public}} =
+               Media.create_media_item_from_backend_attrs(source, unknown_attrs)
+    end
+
+    test "updates a changed known availability value when re-indexed" do
+      source = source_fixture()
+
+      known_attrs =
+        media_attributes_return_fixture(%{"availability" => "public"})
+        |> Phoenix.json_library().decode!()
+        |> YtDlpMedia.response_to_struct()
+
+      changed_attrs = %YtDlpMedia{known_attrs | availability: :unlisted}
+
+      assert {:ok, media_item} = Media.create_media_item_from_backend_attrs(source, known_attrs)
+      assert {:ok, updated_media_item} = Media.create_media_item_from_backend_attrs(source, changed_attrs)
+      assert updated_media_item.id == media_item.id
+      assert Repo.reload!(updated_media_item).availability == :unlisted
     end
 
     test "updates the media item if it already exists" do

--- a/test/pinchflat/metadata/metadata_parser_test.exs
+++ b/test/pinchflat/metadata/metadata_parser_test.exs
@@ -60,6 +60,13 @@ defmodule Pinchflat.Metadata.MetadataParserTest do
 
       assert result.duration_seconds == round(metadata["duration"])
     end
+
+    test "it extracts and normalizes availability", %{metadata: metadata} do
+      result = Parser.parse_for_media_item(metadata)
+
+      assert metadata["availability"] == "public"
+      assert result.availability == :public
+    end
   end
 
   describe "parse_for_media_item/1 when testing subtitle metadata" do

--- a/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
+++ b/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
@@ -193,6 +193,15 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
       assert Enum.all?(media_items, fn %MediaItem{} -> true end)
     end
 
+    test "persists availability returned during slow indexing", %{source: source} do
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        {:ok, source_attributes_return_fixture(%{availability: "private"})}
+      end)
+
+      assert media_items = SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+      assert Enum.all?(media_items, &(&1.availability == :private))
+    end
+
     test "attaches all media_items to the given source", %{source: source} do
       source_id = source.id
       assert media_items = SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)

--- a/test/pinchflat/yt_dlp/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/media_collection_test.exs
@@ -19,6 +19,28 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
                MediaCollection.get_media_attributes_for_collection(@channel_url)
     end
 
+    test "normalizes availability for collection indexing" do
+      output =
+        Phoenix.json_library().encode!(%{
+          id: "video1",
+          title: "Video 1",
+          original_url: "https://example.com/video1",
+          live_status: "not_live",
+          description: "desc1",
+          aspect_ratio: 1.67,
+          duration: 12.34,
+          upload_date: "20210101",
+          availability: "subscriber_only"
+        })
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        {:ok, output}
+      end)
+
+      assert {:ok, [%Media{availability: :subscriber_only}]} =
+               MediaCollection.get_media_attributes_for_collection(@channel_url)
+    end
+
     test "passes the expected default args" do
       expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes_for_collection, opts, ot, _addl_opts ->
         assert opts == [:simulate, :skip_download, :ignore_no_formats_error, :no_warnings]

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -266,6 +266,14 @@ defmodule Pinchflat.YtDlp.MediaTest do
       assert {:ok, _} = Media.get_media_attributes(@media_url, [], addl_arg: true)
     end
 
+    test "normalizes availability from yt-dlp output" do
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl ->
+        {:ok, media_attributes_return_fixture(%{availability: "unlisted"})}
+      end)
+
+      assert {:ok, %{availability: :unlisted}} = Media.get_media_attributes(@media_url)
+    end
+
     test "returns the error straight through when the command fails" do
       expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl -> {:error, "Big issue", 1} end)
 
@@ -282,11 +290,33 @@ defmodule Pinchflat.YtDlp.MediaTest do
   describe "indexing_output_template/0" do
     test "contains all the greatest hits" do
       attrs =
-        ~w(id title live_status original_url description aspect_ratio duration upload_date timestamp playlist_index filename)a
+        ~w(id title live_status original_url description aspect_ratio duration upload_date timestamp playlist_index filename availability)a
 
       formatted_attrs = "%(.{#{Enum.join(attrs, ",")}})j"
 
       assert formatted_attrs == Media.indexing_output_template()
+    end
+  end
+
+  describe "normalize_availability/1" do
+    for {raw_value, normalized_value} <- [
+          {"public", :public},
+          {"unlisted", :unlisted},
+          {"subscriber_only", :subscriber_only},
+          {"members-only", :subscriber_only},
+          {"premium_only", :premium_only},
+          {"needs_auth", :needs_auth},
+          {"private", :private}
+        ] do
+      test "normalizes #{raw_value}" do
+        assert Media.normalize_availability(unquote(raw_value)) == unquote(normalized_value)
+      end
+    end
+
+    test "returns nil for missing and unknown values" do
+      assert Media.normalize_availability(nil) == nil
+      assert Media.normalize_availability("") == nil
+      assert Media.normalize_availability("future_visibility") == nil
     end
   end
 
@@ -316,6 +346,7 @@ defmodule Pinchflat.YtDlp.MediaTest do
                uploaded_at: ~U[2020-09-13 12:26:40Z],
                duration_seconds: 60,
                playlist_index: 1,
+               availability: nil,
                predicted_media_filepath: "TiZPUDkDYbk.mp4"
              } == Media.response_to_struct(response)
     end

--- a/test/pinchflat_web/controllers/api/media_controller_test.exs
+++ b/test/pinchflat_web/controllers/api/media_controller_test.exs
@@ -198,7 +198,7 @@ defmodule PinchflatWeb.Api.MediaControllerTest do
     end
 
     test "returns expected fields for each item", %{conn: conn} do
-      media_item_fixture(%{media_downloaded_at: DateTime.utc_now()})
+      media_item_fixture(%{media_downloaded_at: DateTime.utc_now(), availability: :public})
 
       conn = get(conn, "/api/media/recent_downloads")
       response = json_response(conn, 200)
@@ -208,6 +208,7 @@ defmodule PinchflatWeb.Api.MediaControllerTest do
       assert Map.has_key?(item, "uuid")
       assert Map.has_key?(item, "title")
       assert Map.has_key?(item, "media_id")
+      assert item["availability"] == "public"
       assert Map.has_key?(item, "source_id")
       assert Map.has_key?(item, "uploaded_at")
       assert Map.has_key?(item, "media_downloaded_at")

--- a/test/support/fixtures/media_fixtures.ex
+++ b/test/support/fixtures/media_fixtures.ex
@@ -91,7 +91,7 @@ defmodule Pinchflat.MediaFixtures do
     media_item_fixture(merged_attrs)
   end
 
-  def media_attributes_return_fixture do
+  def media_attributes_return_fixture(attrs \\ %{}) do
     media_attributes = %{
       id: "video1",
       title: "Video 1",
@@ -104,7 +104,9 @@ defmodule Pinchflat.MediaFixtures do
       timestamp: 1_600_000_000
     }
 
-    Phoenix.json_library().encode!(media_attributes)
+    media_attributes
+    |> Map.merge(attrs)
+    |> Phoenix.json_library().encode!()
   end
 
   def media_filepath_fixture do

--- a/test/support/fixtures/sources_fixtures.ex
+++ b/test/support/fixtures/sources_fixtures.ex
@@ -76,7 +76,7 @@ defmodule Pinchflat.SourcesFixtures do
     source_fixture(merged_attrs)
   end
 
-  def source_attributes_return_fixture do
+  def source_attributes_return_fixture(attrs \\ %{}) do
     # Use recent dates to ensure media items pass the download_cutoff_date filter
     today = Date.utc_today()
     date1 = Date.add(today, -1) |> Calendar.strftime("%Y%m%d")
@@ -117,6 +117,7 @@ defmodule Pinchflat.SourcesFixtures do
     ]
 
     source_attributes
+    |> Enum.map(&Map.merge(&1, attrs))
     |> Enum.map_join("\n", &Phoenix.json_library().encode!(&1))
   end
 


### PR DESCRIPTION
## Summary

- Persist yt-dlp availability in a nullable string-backed `Ecto.Enum` on `media_items`.
- Normalize known values, including members-only aliases; treat missing and unknown values as `nil` without runtime atom creation.
- Capture availability during scoped indexing, refresh, and download metadata updates; preserve a known value when a later response omits or does not recognize availability.
- Expose availability through the existing media API/OpenAPI schema and recent-download projection.

## Verification

- PR2-focused Docker tests: 354 tests, 0 failures.
- `docker compose run --rm phx mix check`: compile, formatter, Credo, Sobelow, and 1570 tests passed. The command exits non-zero only because Prettier cannot scan the host-mounted `/app/.agents/skills` junction (`EPERM`).
- `docker compose run --rm phx yarn run ui:check-theme`: passed.
- Existing DevTools browser: Home and a source media page rendered with no console errors or availability-related LiveView errors.

## Scope note

The existing Docker fixes in `docker/dev.Dockerfile` and `docker/selfhosted.Dockerfile`, plus the untracked `plans/` directory, are intentionally preserved outside this PR.

Independent Sol fork verification was not available in the current agent environment; the checks above are the local Docker and browser verification performed before handoff.