### PR TITLE
Add per-source availability policies

### DIFF
--- a/lib/pinchflat/downloading/downloading_helpers.ex
+++ b/lib/pinchflat/downloading/downloading_helpers.ex
@@ -13,6 +13,7 @@ defmodule Pinchflat.Downloading.DownloadingHelpers do
   alias Pinchflat.Media
   alias Pinchflat.Tasks
   alias Pinchflat.Sources.Source
+  alias Pinchflat.Sources.AvailabilityPolicy
   alias Pinchflat.Media.MediaItem
   alias Pinchflat.Downloading.MediaDownloadWorker
 
@@ -47,6 +48,30 @@ defmodule Pinchflat.Downloading.DownloadingHelpers do
   def enqueue_pending_download_tasks(%Source{download_media: false} = source, _job_opts) do
     Logger.info("pending_download_enqueue_skipped source_id=#{source.id} reason=source_downloads_disabled")
     0
+  end
+
+  @doc """
+  Reconciles queued download work after a source availability policy changes.
+
+  Policy blocks are kept separate from `prevent_download`, so manually
+  prevented items are never re-enabled by this operation.
+
+  Returns integer() | :ok.
+  """
+  def reconcile_availability_policy(%Source{} = source) do
+    source
+    |> list_media_items_for_policy()
+    |> Enum.each(fn media_item ->
+      unless AvailabilityPolicy.allowed?(source, media_item.availability) do
+        Tasks.delete_pending_tasks_for(media_item)
+      end
+    end)
+
+    if source.enabled && source.download_media do
+      enqueue_pending_download_tasks(source)
+    else
+      dequeue_pending_download_tasks(source)
+    end
   end
 
   @doc """
@@ -115,14 +140,28 @@ defmodule Pinchflat.Downloading.DownloadingHelpers do
   def kickoff_download_if_pending(%MediaItem{} = media_item, job_opts \\ []) do
     media_item = Repo.preload(media_item, :source)
 
-    if media_item.source.download_media && Media.pending_download?(media_item) do
-      Logger.info("Kicking off download for media item ##{media_item.id} (#{media_item.media_id})")
+    case AvailabilityPolicy.evaluate(media_item.source, media_item.availability) do
+      {:block, reason} ->
+        Logger.info("download_enqueue_skipped media_item_id=#{media_item.id} reason=availability_policy_#{reason}")
 
-      MediaDownloadWorker.kickoff_with_task(media_item, %{}, job_opts)
-    else
-      Logger.info("download_enqueue_skipped media_item_id=#{media_item.id} reason=should_not_download")
-      {:error, :should_not_download}
+        {:error, :should_not_download}
+
+      :allow ->
+        if media_item.source.download_media && Media.pending_download?(media_item) do
+          Logger.info("Kicking off download for media item ##{media_item.id} (#{media_item.media_id})")
+
+          MediaDownloadWorker.kickoff_with_task(media_item, %{}, job_opts)
+        else
+          Logger.info("download_enqueue_skipped media_item_id=#{media_item.id} reason=should_not_download")
+          {:error, :should_not_download}
+        end
     end
+  end
+
+  defp list_media_items_for_policy(source) do
+    MediaQuery.new()
+    |> where(^MediaQuery.for_source(source))
+    |> Repo.all()
   end
 
   @doc """

--- a/lib/pinchflat/media/media.ex
+++ b/lib/pinchflat/media/media.ex
@@ -9,6 +9,7 @@ defmodule Pinchflat.Media do
   alias Pinchflat.Repo
   alias Pinchflat.Tasks
   alias Pinchflat.Sources.Source
+  alias Pinchflat.Sources.AvailabilityPolicy
   alias Pinchflat.Media.MediaItem
   alias Pinchflat.Utils.FilesystemUtils
   alias Pinchflat.Metadata.MediaMetadata
@@ -166,20 +167,38 @@ defmodule Pinchflat.Media do
   def create_media_item_from_backend_attrs(source, media_attrs_struct) do
     attrs = Map.merge(%{source_id: source.id}, Map.from_struct(media_attrs_struct))
 
-    case attrs.media_id do
-      nil ->
-        insert_media_item_from_backend_attrs(source, attrs)
+    result =
+      case attrs.media_id do
+        nil ->
+          insert_media_item_from_backend_attrs(source, attrs)
 
-      media_id ->
-        case Repo.get_by(MediaItem, source_id: source.id, media_id: media_id) do
-          %MediaItem{} = media_item ->
-            update_media_item_from_backend_attrs(media_item, attrs)
+        media_id ->
+          case Repo.get_by(MediaItem, source_id: source.id, media_id: media_id) do
+            %MediaItem{} = media_item ->
+              update_media_item_from_backend_attrs(media_item, attrs)
 
-          nil ->
-            insert_media_item_from_backend_attrs(source, attrs)
-        end
+            nil ->
+              insert_media_item_from_backend_attrs(source, attrs)
+          end
+      end
+
+    reconcile_availability_policy(source, result)
+  end
+
+  @doc """
+  Cancels queued work when a newly indexed availability value is blocked by the
+  source policy. Manual `prevent_download` state is left untouched.
+  """
+  def reconcile_availability_policy(%Source{} = source, {:ok, %MediaItem{} = media_item} = result) do
+    if AvailabilityPolicy.allowed?(source, media_item.availability) do
+      result
+    else
+      Tasks.delete_pending_tasks_for(media_item)
+      result
     end
   end
+
+  def reconcile_availability_policy(_source, result), do: result
 
   @doc """
   Updates a media_item.

--- a/lib/pinchflat/media/media_query.ex
+++ b/lib/pinchflat/media/media_query.ex
@@ -11,6 +11,7 @@ defmodule Pinchflat.Media.MediaQuery do
   import Ecto.Query, warn: false
 
   alias Pinchflat.Media.MediaItem
+  alias Pinchflat.Sources.AvailabilityPolicy
 
   # This allows the module to be aliased and query methods to be used
   # all in one go
@@ -130,6 +131,7 @@ defmodule Pinchflat.Media.MediaQuery do
       [mi],
       not (^downloaded()) and
         not (^download_prevented()) and
+        ^AvailabilityPolicy.query_condition() and
         ^upload_date_after_source_cutoff() and
         ^format_matching_profile_preference() and
         ^matches_source_title_regex() and

--- a/lib/pinchflat/sources/availability_policy.ex
+++ b/lib/pinchflat/sources/availability_policy.ex
@@ -1,0 +1,74 @@
+defmodule Pinchflat.Sources.AvailabilityPolicy do
+  @moduledoc """
+  Decides whether a source's availability policy allows a media item to download.
+
+  Unknown and missing availability remains eligible so that adding this policy
+  does not change the behavior of media whose backend metadata is incomplete.
+  """
+
+  import Ecto.Query
+
+  alias Pinchflat.Sources.Source
+
+  @public_values [:public, :unlisted]
+  @members_only_values [:subscriber_only, :premium_only, :needs_auth]
+  @known_values @public_values ++ @members_only_values ++ [:private]
+
+  @doc """
+  Returns `:allow` or `{:block, reason}` for a source and availability value.
+
+  Unknown values are allowed and never converted into atoms.
+  """
+  def evaluate(%Source{} = source, availability) do
+    case availability do
+      availability when availability in @public_values ->
+        if source.download_public_media != false, do: :allow, else: {:block, :public_media_disabled}
+
+      availability when availability in @members_only_values ->
+        if source.download_members_only_media != false,
+          do: :allow,
+          else: {:block, :members_only_media_disabled}
+
+      :private ->
+        {:block, :private_media}
+
+      value when is_binary(value) ->
+        evaluate(source, normalize(value))
+
+      _unknown_or_missing ->
+        :allow
+    end
+  end
+
+  @doc "Returns whether the source policy allows the media item to download."
+  def allowed?(%Source{} = source, availability), do: evaluate(source, availability) == :allow
+
+  @doc "Returns the known availability values used by the policy matrix."
+  def known_values, do: @known_values
+
+  @doc """
+  Returns the SQL predicate matching `evaluate/2` for a query joined as
+  `[media_item, source]`.
+  """
+  def query_condition do
+    dynamic(
+      [media_item, source],
+      is_nil(media_item.availability) or
+        media_item.availability not in ^@known_values or
+        (media_item.availability in ^@public_values and source.download_public_media == true) or
+        (media_item.availability in ^@members_only_values and source.download_members_only_media == true)
+    )
+  end
+
+  defp normalize(value) do
+    case value do
+      "public" -> :public
+      "unlisted" -> :unlisted
+      "subscriber_only" -> :subscriber_only
+      "premium_only" -> :premium_only
+      "needs_auth" -> :needs_auth
+      "private" -> :private
+      _unknown -> nil
+    end
+  end
+end

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -31,6 +31,8 @@ defmodule Pinchflat.Sources.Source do
     cookie_behaviour
     selection_mode
     download_media
+    download_public_media
+    download_members_only_media
     last_indexed_at
     original_url
     download_cutoff_date
@@ -84,6 +86,10 @@ defmodule Pinchflat.Sources.Source do
     field :cookie_behaviour, Ecto.Enum, values: [:disabled, :when_needed, :all_operations], default: :disabled
     field :selection_mode, Ecto.Enum, values: [:all, :manual], default: :all
     field :download_media, :boolean, default: true
+    # Keep both policies enabled by default so existing sources retain their
+    # current behavior after the policy fields are introduced.
+    field :download_public_media, :boolean, default: true
+    field :download_members_only_media, :boolean, default: true
     field :last_indexed_at, :utc_datetime
     # Only download media items that were published after this date
     field :download_cutoff_date, :date

--- a/lib/pinchflat/sources/sources.ex
+++ b/lib/pinchflat/sources/sources.ex
@@ -1045,29 +1045,37 @@ defmodule Pinchflat.Sources do
     current_changes = changeset.changes
     applied_changes = Ecto.Changeset.apply_changes(changeset)
 
-    # We need both current_changes and applied_changes to determine
-    # the course of action to take. For example, we only care if a source is supposed
-    # to be `enabled` or not - we don't care if that information comes from the
-    # current changes or if that's how it already was in the database.
-    # Rephrased, we're essentially using it in place of `get_field/2`
-    case {current_changes, applied_changes} do
-      {%{download_media: true}, %{enabled: true}} ->
-        DownloadingHelpers.enqueue_pending_download_tasks(source)
+    if availability_policy_changed?(current_changes) do
+      DownloadingHelpers.reconcile_availability_policy(source)
+    else
+      # We need both current_changes and applied_changes to determine
+      # the course of action to take. For example, we only care if a source is supposed
+      # to be `enabled` or not - we don't care if that information comes from the
+      # current changes or if that's how it already was in the database.
+      # Rephrased, we're essentially using it in place of `get_field/2`
+      case {current_changes, applied_changes} do
+        {%{download_media: true}, %{enabled: true}} ->
+          DownloadingHelpers.enqueue_pending_download_tasks(source)
 
-      {%{enabled: true}, %{download_media: true}} ->
-        DownloadingHelpers.enqueue_pending_download_tasks(source)
+        {%{enabled: true}, %{download_media: true}} ->
+          DownloadingHelpers.enqueue_pending_download_tasks(source)
 
-      {%{download_media: false}, _} ->
-        DownloadingHelpers.dequeue_pending_download_tasks(source)
+        {%{download_media: false}, _} ->
+          DownloadingHelpers.dequeue_pending_download_tasks(source)
 
-      {%{enabled: false}, _} ->
-        DownloadingHelpers.dequeue_pending_download_tasks(source)
+        {%{enabled: false}, _} ->
+          DownloadingHelpers.dequeue_pending_download_tasks(source)
 
-      _ ->
-        nil
+        _ ->
+          nil
+      end
     end
 
     :ok
+  end
+
+  defp availability_policy_changed?(changes) do
+    Map.has_key?(changes, :download_public_media) || Map.has_key?(changes, :download_members_only_media)
   end
 
   defp maybe_run_indexing_task(changeset, source) do

--- a/lib/pinchflat_web/controllers/sources/source_html.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html.ex
@@ -520,6 +520,16 @@ defmodule PinchflatWeb.Sources.SourceHTML do
       ),
       field("Download media", yes_no(source.download_media), "Whether newly indexed media is queued for download"),
       field(
+        "Public and unlisted media",
+        yes_no(source.download_public_media),
+        "Whether public and unlisted media is eligible for download"
+      ),
+      field(
+        "Members-only media",
+        yes_no(source.download_members_only_media),
+        "Whether subscriber-only, premium-only, and authentication-required media is eligible for download"
+      ),
+      field(
         "Index frequency",
         index_frequency_label(source.index_frequency_minutes),
         "How often the full channel or playlist is re-read"

--- a/lib/pinchflat_web/controllers/sources/source_html/media_item_table_live.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html/media_item_table_live.ex
@@ -131,6 +131,10 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
               <dd class="text-right text-theme-on-surface">{DateTime.to_date(media_item.uploaded_at)}</dd>
             </div>
             <div class="flex items-start justify-between gap-3">
+              <dt class="text-theme-on-surface-muted">Availability</dt>
+              <dd class="text-right"><.availability_badge availability={media_item.availability} /></dd>
+            </div>
+            <div class="flex items-start justify-between gap-3">
               <dt class="text-theme-on-surface-muted">Size / Progress</dt>
               <dd class="max-w-[65%] text-right text-theme-on-surface">
                 <.progress_details media_item={media_item} task={Map.get(@tasks_by_media_item_id, media_item.id)} />
@@ -191,6 +195,10 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
                 <span>{status.label}</span>
               </span>
             </.tooltip>
+          </:col>
+
+          <:col :let={media_item} label="Availability">
+            <.availability_badge availability={media_item.availability} />
           </:col>
 
           <:col :let={media_item} label="Upload Date">{DateTime.to_date(media_item.uploaded_at)}</:col>
@@ -502,6 +510,7 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
       :duration_seconds,
       :livestream,
       :short_form_content,
+      :availability,
       :media_size_bytes,
       :unavailable_at,
       :unavailable_reason,
@@ -713,6 +722,35 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
     |> min(100.0)
     |> trunc()
   end
+
+  attr :availability, :any, default: nil
+
+  defp availability_badge(assigns) do
+    {label, class} = availability_presentation(assigns.availability)
+    assigns = assign(assigns, label: label, class: class)
+
+    ~H"""
+    <span class={["inline-flex whitespace-nowrap rounded-full px-2.5 py-1 text-xs font-medium", @class]}>
+      {@label}
+    </span>
+    """
+  end
+
+  defp availability_presentation(:public), do: {"Public", "theme-badge-success"}
+  defp availability_presentation("public"), do: availability_presentation(:public)
+  defp availability_presentation(:unlisted), do: {"Unlisted", "theme-badge-success"}
+  defp availability_presentation("unlisted"), do: availability_presentation(:unlisted)
+
+  defp availability_presentation(:subscriber_only), do: {"Members-only", "theme-badge-warning"}
+  defp availability_presentation("subscriber_only"), do: availability_presentation(:subscriber_only)
+  defp availability_presentation(:premium_only), do: {"Premium-only", "theme-badge-warning"}
+  defp availability_presentation("premium_only"), do: availability_presentation(:premium_only)
+  defp availability_presentation(:needs_auth), do: {"Needs authentication", "theme-badge-warning"}
+  defp availability_presentation("needs_auth"), do: availability_presentation(:needs_auth)
+
+  defp availability_presentation(:private), do: {"Private", "theme-danger-panel"}
+  defp availability_presentation("private"), do: availability_presentation(:private)
+  defp availability_presentation(_unknown), do: {"Unknown", "bg-theme-surface-3 text-theme-on-surface-muted"}
 
   defp update_task_progress(tasks_by_media_item_id, records, %{media_item_id: media_item_id} = payload)
        when is_integer(media_item_id) do

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -128,28 +128,62 @@
       Downloading Options
     </h3>
 
-    <.input
-      field={f[:download_media]}
-      type="toggle"
-      label="Download Media"
-      help="Unchecking still indexes media but it won't be downloaded until you enable this option"
-    />
-    <section :if={@show_delay_automatic_download} class="mt-3">
+    <section
+      class="space-y-3"
+      x-data={
+        Phoenix.json_library().encode!(%{
+          downloadMembersOnlyMedia: Ecto.Changeset.get_field(@changeset, :download_members_only_media),
+          cookieBehaviour: to_string(Ecto.Changeset.get_field(@changeset, :cookie_behaviour))
+        })
+      }
+    >
       <.input
-        field={f[:delay_automatic_download]}
+        field={f[:download_media]}
         type="toggle"
-        label="Delay Automatic Download"
-        help="For playlists only. Index first, then send me to a selection screen so I can choose which items to download."
+        label="Download Media"
+        help="Unchecking still indexes media but it won't be downloaded until you enable this option"
       />
+      <.input
+        field={f[:download_public_media]}
+        type="toggle"
+        label="Download Public and Unlisted Media"
+        help="Controls media that yt-dlp reports as public or unlisted"
+      />
+      <.input
+        field={f[:download_members_only_media]}
+        type="toggle"
+        label="Download Members-only Media"
+        help="Includes subscriber-only, premium-only, and media that requires authentication"
+        x-model="downloadMembersOnlyMedia"
+      />
+      <section :if={@show_delay_automatic_download} class="mt-3">
+        <.input
+          field={f[:delay_automatic_download]}
+          type="toggle"
+          label="Delay Automatic Download"
+          help="For playlists only. Index first, then send me to a selection screen so I can choose which items to download."
+        />
+      </section>
+
+      <.input
+        field={f[:cookie_behaviour]}
+        options={friendly_cookie_behaviours()}
+        type="select"
+        label="Cookie Behaviour"
+        help="Uses your YouTube cookies for this source (if configured). 'When Needed' tries to minimize cookie usage except for certain indexing and downloading tasks. See docs"
+        x-model="cookieBehaviour"
+      />
+      <div
+        x-cloak
+        x-show="downloadMembersOnlyMedia && cookieBehaviour === 'disabled'"
+        class="theme-status-card theme-status-card-warning text-sm"
+        role="alert"
+      >
+        Members-only media may fail without cookies. Configure a cookies.txt file and select a cookie behaviour if
+        you want PinchYT to access it; this setting will not enable cookies automatically.
+      </div>
     </section>
 
-    <.input
-      field={f[:cookie_behaviour]}
-      options={friendly_cookie_behaviours()}
-      type="select"
-      label="Cookie Behaviour"
-      help="Uses your YouTube cookies for this source (if configured). 'When Needed' tries to minimize cookie usage except for certain indexing and downloading tasks. See docs"
-    />
     <section class="theme-surface-accent mt-3 px-6 py-5">
       <div class="grid gap-5 lg:grid-cols-[minmax(0,1fr)_max-content] lg:items-start">
         <div class="space-y-3">

--- a/lib/pinchflat_web/schemas.ex
+++ b/lib/pinchflat_web/schemas.ex
@@ -157,6 +157,16 @@ defmodule PinchflatWeb.Schemas do
           example: :all
         },
         download_media: %Schema{type: :boolean, description: "Download media items", example: true},
+        download_public_media: %Schema{
+          type: :boolean,
+          description: "Download public and unlisted media",
+          example: true
+        },
+        download_members_only_media: %Schema{
+          type: :boolean,
+          description: "Download subscriber-only, premium-only, and authentication-required media",
+          example: true
+        },
         last_indexed_at: %Schema{
           type: :string,
           format: :date_time,
@@ -353,6 +363,16 @@ defmodule PinchflatWeb.Schemas do
             description: %Schema{type: :string, description: "Source description"},
             enabled: %Schema{type: :boolean, description: "Whether the source is active", default: true},
             download_media: %Schema{type: :boolean, description: "Download media items", default: true},
+            download_public_media: %Schema{
+              type: :boolean,
+              description: "Download public and unlisted media",
+              default: true
+            },
+            download_members_only_media: %Schema{
+              type: :boolean,
+              description: "Download subscriber-only, premium-only, and authentication-required media",
+              default: true
+            },
             fast_index: %Schema{type: :boolean, description: "Use fast indexing", default: false},
             delay_automatic_download: %Schema{
               type: :boolean,
@@ -411,6 +431,11 @@ defmodule PinchflatWeb.Schemas do
             description: %Schema{type: :string, description: "Source description"},
             enabled: %Schema{type: :boolean, description: "Whether the source is active"},
             download_media: %Schema{type: :boolean, description: "Download media items"},
+            download_public_media: %Schema{type: :boolean, description: "Download public and unlisted media"},
+            download_members_only_media: %Schema{
+              type: :boolean,
+              description: "Download subscriber-only, premium-only, and authentication-required media"
+            },
             fast_index: %Schema{type: :boolean, description: "Use fast indexing"},
             index_frequency_minutes: %Schema{type: :integer, description: "Indexing frequency in minutes"},
             download_cutoff_date: %Schema{

--- a/priv/repo/migrations/20260910130000_add_availability_policies_to_sources.exs
+++ b/priv/repo/migrations/20260910130000_add_availability_policies_to_sources.exs
@@ -1,0 +1,10 @@
+defmodule Pinchflat.Repo.Migrations.AddAvailabilityPoliciesToSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add :download_public_media, :boolean, default: true, null: false
+      add :download_members_only_media, :boolean, default: true, null: false
+    end
+  end
+end

--- a/test/pinchflat/downloading/downloading_helpers_test.exs
+++ b/test/pinchflat/downloading/downloading_helpers_test.exs
@@ -6,6 +6,7 @@ defmodule Pinchflat.Downloading.DownloadingHelpersTest do
   import Pinchflat.ProfilesFixtures
 
   alias Pinchflat.Tasks
+  alias Pinchflat.Sources
   alias Pinchflat.Downloading.DownloadingHelpers
   alias Pinchflat.Downloading.MediaDownloadWorker
 
@@ -109,6 +110,15 @@ defmodule Pinchflat.Downloading.DownloadingHelpersTest do
       refute_enqueued(worker: MediaDownloadWorker)
     end
 
+    test "does not enqueue a download job when the availability policy blocks it" do
+      source = source_fixture(%{download_public_media: false})
+      media_item = media_item_fixture(source_id: source.id, media_filepath: nil, availability: :public)
+
+      assert {:error, :should_not_download} = DownloadingHelpers.kickoff_download_if_pending(media_item)
+
+      refute_enqueued(worker: MediaDownloadWorker)
+    end
+
     test "does not enqueue a download job if the media item does not match the format rules" do
       profile = media_profile_fixture(%{livestream_behaviour: :exclude})
       source = source_fixture(%{media_profile_id: profile.id})
@@ -125,6 +135,25 @@ defmodule Pinchflat.Downloading.DownloadingHelpersTest do
       assert {:ok, _} = DownloadingHelpers.kickoff_download_if_pending(media_item, priority: 1)
 
       assert_enqueued(worker: MediaDownloadWorker, args: %{"id" => media_item.id}, priority: 1)
+    end
+
+    test "re-enables policy-blocked media without clearing manual prevention" do
+      source = source_fixture(%{download_public_media: false})
+      policy_blocked = media_item_fixture(source_id: source.id, media_filepath: nil, availability: :public)
+
+      manually_prevented =
+        media_item_fixture(
+          source_id: source.id,
+          media_filepath: nil,
+          availability: :public,
+          prevent_download: true
+        )
+
+      assert {:ok, _source} = Sources.update_source(source, %{download_public_media: true})
+
+      assert_enqueued(worker: MediaDownloadWorker, args: %{"id" => policy_blocked.id})
+      refute_enqueued(worker: MediaDownloadWorker, args: %{"id" => manually_prevented.id})
+      assert Repo.reload!(manually_prevented).prevent_download
     end
   end
 

--- a/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
+++ b/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
@@ -85,6 +85,21 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
       assert [%MediaItem{availability: :subscriber_only}] = FastIndexingHelpers.index_and_kickoff_downloads(source)
     end
 
+    test "does not enqueue media blocked by the source availability policy" do
+      expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
+
+      source = source_fixture(%{download_members_only_media: false})
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, _opts, _ot, _addl_opts ->
+        {:ok, media_attributes_return_fixture(%{availability: "subscriber_only"})}
+      end)
+
+      assert [%MediaItem{availability: :subscriber_only, prevent_download: false}] =
+               FastIndexingHelpers.index_and_kickoff_downloads(source)
+
+      refute_enqueued(worker: MediaDownloadWorker)
+    end
+
     test "does not enqueue a download job if the source does not allow it" do
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
       source = source_fixture(%{download_media: false})

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -414,6 +414,44 @@ defmodule Pinchflat.MediaTest do
     end
   end
 
+  describe "list_pending_media_items_for/1 when testing availability policies" do
+    test "groups public and unlisted media under the public policy" do
+      source = source_fixture(%{download_public_media: false})
+      _public = media_item_fixture(%{source_id: source.id, media_filepath: nil, availability: :public})
+      _unlisted = media_item_fixture(%{source_id: source.id, media_filepath: nil, availability: :unlisted})
+      unknown = media_item_fixture(%{source_id: source.id, media_filepath: nil, availability: nil})
+
+      assert Media.list_pending_media_items_for(source) == [unknown]
+    end
+
+    test "groups subscriber-only, premium-only, and auth-required media under the members-only policy" do
+      source = source_fixture(%{download_members_only_media: false})
+
+      _subscriber_only =
+        media_item_fixture(%{source_id: source.id, media_filepath: nil, availability: :subscriber_only})
+
+      _premium_only = media_item_fixture(%{source_id: source.id, media_filepath: nil, availability: :premium_only})
+      _needs_auth = media_item_fixture(%{source_id: source.id, media_filepath: nil, availability: :needs_auth})
+      public = media_item_fixture(%{source_id: source.id, media_filepath: nil, availability: :public})
+
+      assert Media.list_pending_media_items_for(source) == [public]
+    end
+
+    test "always blocks private media" do
+      source = source_fixture()
+      _private = media_item_fixture(%{source_id: source.id, media_filepath: nil, availability: :private})
+
+      assert Media.list_pending_media_items_for(source) == []
+    end
+
+    test "does not block unknown or missing availability" do
+      source = source_fixture(%{download_public_media: false, download_members_only_media: false})
+      missing = media_item_fixture(%{source_id: source.id, media_filepath: nil, availability: nil})
+
+      assert Media.list_pending_media_items_for(source) == [missing]
+    end
+  end
+
   describe "list_failed_media_items/0 and list_failed_media_items_for/1" do
     test "returns pending items with a last_error" do
       source = source_fixture()

--- a/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
+++ b/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
@@ -202,6 +202,18 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
       assert Enum.all?(media_items, &(&1.availability == :private))
     end
 
+    test "does not enqueue media blocked by the source availability policy" do
+      source = source_fixture(%{download_public_media: false})
+
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, _opts, _ot, _addl_opts ->
+        {:ok, source_attributes_return_fixture(%{availability: "public"})}
+      end)
+
+      assert media_items = SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+      assert Enum.all?(media_items, fn item -> item.availability == :public and item.prevent_download == false end)
+      refute_enqueued(worker: MediaDownloadWorker)
+    end
+
     test "attaches all media_items to the given source", %{source: source} do
       source_id = source.id
       assert media_items = SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)

--- a/test/pinchflat/sources/availability_policy_test.exs
+++ b/test/pinchflat/sources/availability_policy_test.exs
@@ -1,0 +1,44 @@
+defmodule Pinchflat.Sources.AvailabilityPolicyTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.SourcesFixtures
+
+  alias Pinchflat.Sources.AvailabilityPolicy
+
+  describe "evaluate/2" do
+    for {availability, field, reason} <- [
+          {:public, :download_public_media, :public_media_disabled},
+          {:unlisted, :download_public_media, :public_media_disabled},
+          {:subscriber_only, :download_members_only_media, :members_only_media_disabled},
+          {:premium_only, :download_members_only_media, :members_only_media_disabled},
+          {:needs_auth, :download_members_only_media, :members_only_media_disabled}
+        ] do
+      test "blocks #{availability} when #{field} is disabled" do
+        source = source_fixture(%{unquote(field) => false})
+
+        assert {:block, unquote(reason)} = AvailabilityPolicy.evaluate(source, unquote(availability))
+      end
+    end
+
+    test "private media is always blocked" do
+      source = source_fixture(%{download_public_media: true, download_members_only_media: true})
+
+      assert {:block, :private_media} = AvailabilityPolicy.evaluate(source, :private)
+    end
+
+    test "allows all known values when their policy is enabled" do
+      source = source_fixture()
+
+      for availability <- AvailabilityPolicy.known_values() -- [:private] do
+        assert AvailabilityPolicy.evaluate(source, availability) == :allow
+      end
+    end
+
+    test "allows missing and unknown values" do
+      source = source_fixture(%{download_public_media: false, download_members_only_media: false})
+
+      assert AvailabilityPolicy.evaluate(source, nil) == :allow
+      assert AvailabilityPolicy.evaluate(source, "future_visibility") == :allow
+    end
+  end
+end

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -31,6 +31,13 @@ defmodule Pinchflat.SourcesTest do
   end
 
   describe "schema" do
+    test "defaults availability policies to enabled" do
+      source = source_fixture()
+
+      assert source.download_public_media
+      assert source.download_members_only_media
+    end
+
     test "source_metadata is deleted when the source is deleted" do
       source =
         source_fixture(%{metadata: %{metadata_filepath: "/metadata.json.gz"}})

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -96,6 +96,9 @@ defmodule PinchflatWeb.SourceControllerTest do
       conn = get(conn, ~p"/sources/new")
       assert html_response(conn, 200) =~ "New Source"
       assert html_response(conn, 200) =~ "Delay Automatic Download"
+      assert html_response(conn, 200) =~ "Download Public and Unlisted Media"
+      assert html_response(conn, 200) =~ "Download Members-only Media"
+      assert html_response(conn, 200) =~ "Members-only media may fail without cookies"
       assert html_response(conn, 200) =~ "How source folders work"
       assert html_response(conn, 200) =~ "Insert media profile template"
     end
@@ -354,6 +357,18 @@ defmodule PinchflatWeb.SourceControllerTest do
       put(conn, ~p"/sources/#{source}", source: update_attrs)
 
       assert Pinchflat.Reconciliation.get_plan!(plan.id).status == :stale
+    end
+
+    test "persists availability policy settings", %{conn: conn, source: source} do
+      conn =
+        put(conn, ~p"/sources/#{source}",
+          source: %{download_public_media: "false", download_members_only_media: "false"}
+        )
+
+      assert redirected_to(conn) == ~p"/sources/#{source}"
+      updated_source = Repo.reload!(source)
+      refute updated_source.download_public_media
+      refute updated_source.download_members_only_media
     end
   end
 

--- a/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
+++ b/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
@@ -26,12 +26,14 @@ defmodule PinchflatWeb.Sources.MediaItemTableLiveTest do
     end
 
     test "shows records when present", %{conn: conn, source: source} do
-      media_item = media_item_fixture(source_id: source.id, media_filepath: nil)
+      media_item = media_item_fixture(source_id: source.id, media_filepath: nil, availability: :subscriber_only)
 
       {:ok, _view, html} = live_isolated(conn, MediaItemTableLive, session: create_session(source))
 
       assert html =~ "Showing"
       assert html =~ "Title"
+      assert html =~ "Availability"
+      assert html =~ "Members-only"
       assert html =~ media_item.title
     end
   end


### PR DESCRIPTION
Summary:
- Adds default-enabled public/unlisted and members-only source policies with a pure availability decision matrix.
- Applies policy filtering and queue reconciliation across pending queries, fast/slow indexing, rescans, retries, and source updates without changing manual prevention flags.
- Adds source-form controls and cookie warning, API schema fields, source details, and semantic availability badges.

Verification:
- Docker targeted suite: 489 tests, 0 failures.
- Docker UI theme check: passed.
- Docker full mix check: compile, format, Credo, Sobelow, and 1,588 tests passed; overall command is blocked only by the known Prettier EPERM scanning /app/.agents/skills.
- Live DevTools DOM matrix was not run because no browser provider was exposed in this session.
- Independent Sol fork verification was unavailable in the current tool environment; no Sol PASS is being claimed.

The preserved Docker fixes and untracked plans/ directory are intentionally outside this PR commit.