### PR TITLE
Add per-source yt-dlp player-client override

### DIFF
--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -21,6 +21,7 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
 
     built_options =
       default_options(override_opts) ++
+        player_client_options(media_item_with_preloads.source.player_client) ++
         subtitle_options(media_profile) ++
         thumbnail_options(media_item_with_preloads) ++
         metadata_options(media_profile) ++
@@ -30,6 +31,31 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
         config_file_options(media_item_with_preloads)
 
     {:ok, built_options}
+  end
+
+  @doc """
+  Builds the yt-dlp extractor arguments for a source's optional YouTube
+  player-client override.
+
+  Returns [] when the source uses the default client selection.
+  """
+  def build_player_client_options_for(%Source{} = source) do
+    player_client_options(source.player_client)
+  end
+
+  def build_player_client_options_for(%MediaItem{} = media_item) do
+    build_player_client_options_for(media_item.source)
+  end
+
+  @doc false
+  def player_client_options(nil), do: []
+
+  def player_client_options(player_client) do
+    if player_client in Source.player_client_values() do
+      [{:extractor_args, "youtube:player-client=#{player_client}"}]
+    else
+      []
+    end
   end
 
   @doc """

--- a/lib/pinchflat/downloading/media_downloader.ex
+++ b/lib/pinchflat/downloading/media_downloader.ex
@@ -189,7 +189,14 @@ defmodule Pinchflat.Downloading.MediaDownloader do
     else
       maybe_report_progress(override_opts, %{progress_percent: 0.0, progress_status: "Prechecking media"})
 
-      case {YtDlpMedia.get_downloadable_status(url, use_cookies: should_use_cookies), should_use_cookies} do
+      case {
+        YtDlpMedia.get_downloadable_status(
+          url,
+          DownloadOptionBuilder.build_player_client_options_for(item_with_preloads),
+          use_cookies: should_use_cookies
+        ),
+        should_use_cookies
+      } do
         {{:ok, :downloadable}, _} ->
           maybe_report_progress(override_opts, %{
             progress_percent: 0.0,

--- a/lib/pinchflat/fast_indexing/fast_indexing_helpers.ex
+++ b/lib/pinchflat/fast_indexing/fast_indexing_helpers.ex
@@ -96,7 +96,8 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpers do
 
     command_opts =
       [output: DownloadOptionBuilder.build_output_path_for(source)] ++
-        DownloadOptionBuilder.build_quality_options_for(source)
+        DownloadOptionBuilder.build_quality_options_for(source) ++
+        DownloadOptionBuilder.build_player_client_options_for(source)
 
     case YtDlpMedia.get_media_attributes(url, command_opts, use_cookies: should_use_cookies) do
       {:ok, media_attrs} ->

--- a/lib/pinchflat/metadata/metadata_file_helpers.ex
+++ b/lib/pinchflat/metadata/metadata_file_helpers.ex
@@ -10,6 +10,7 @@ defmodule Pinchflat.Metadata.MetadataFileHelpers do
   """
 
   alias Pinchflat.Sources
+  alias Pinchflat.Downloading.DownloadOptionBuilder
   alias Pinchflat.Utils.FilesystemUtils
 
   alias Pinchflat.YtDlp.Media, as: YtDlpMedia
@@ -71,7 +72,11 @@ defmodule Pinchflat.Metadata.MetadataFileHelpers do
   def download_and_store_thumbnail_for(media_item_with_preloads) do
     yt_dlp_filepath = generate_filepath_for(media_item_with_preloads, "thumbnail.%(ext)s")
     real_filepath = generate_filepath_for(media_item_with_preloads, "thumbnail.jpg")
-    command_opts = [output: yt_dlp_filepath]
+
+    command_opts =
+      [output: yt_dlp_filepath] ++
+        DownloadOptionBuilder.build_player_client_options_for(media_item_with_preloads)
+
     addl_opts = [use_cookies: Sources.use_cookies?(media_item_with_preloads.source, :metadata)]
 
     case YtDlpMedia.download_thumbnail(media_item_with_preloads.original_url, command_opts, addl_opts) do

--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -134,8 +134,10 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   defp maybe_ignore_unavailable_source_metadata(_source, result), do: result
 
   defp determine_series_directory(source) do
-    output_path = DownloadOptionBuilder.build_output_path_for(source)
-    runner_opts = [output: output_path]
+    runner_opts =
+      [output: DownloadOptionBuilder.build_output_path_for(source)] ++
+        DownloadOptionBuilder.build_player_client_options_for(source)
+
     addl_opts = [use_cookies: Sources.use_cookies?(source, :metadata)]
     details_result = MediaCollection.get_source_details(source.original_url, runner_opts, addl_opts)
 
@@ -175,6 +177,8 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
       else
         base_opts ++ [:write_thumbnail, playlist_items: 1]
       end
+
+    opts = opts ++ DownloadOptionBuilder.build_player_client_options_for(source)
 
     MediaCollection.get_source_metadata(source.original_url, opts, use_cookies: should_use_cookies)
   end

--- a/lib/pinchflat/reconciliation/plan_applier.ex
+++ b/lib/pinchflat/reconciliation/plan_applier.ex
@@ -23,6 +23,7 @@ defmodule Pinchflat.Reconciliation.PlanApplier do
   alias Pinchflat.Reconciliation.ReconcilePlan
   alias Pinchflat.Reconciliation.ReconcilePlanItem
   alias Pinchflat.Metadata.MetadataFileHelpers
+  alias Pinchflat.Downloading.DownloadOptionBuilder
   alias Pinchflat.Downloading.MediaDownloadWorker
   alias Pinchflat.YtDlp.Media, as: YtDlpMedia
   alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
@@ -249,7 +250,11 @@ defmodule Pinchflat.Reconciliation.PlanApplier do
 
   defp backfill_media_item_attribute(media_item, %{attribute: "thumbnail"} = row) do
     rootname = Path.rootname(row.to_path)
-    command_opts = [output: "#{rootname}.%(ext)s"]
+
+    command_opts =
+      [output: "#{rootname}.%(ext)s"] ++
+        DownloadOptionBuilder.build_player_client_options_for(media_item)
+
     addl_opts = [use_cookies: Sources.use_cookies?(media_item.source, :metadata)]
 
     case YtDlpMedia.download_thumbnail(media_item.original_url, command_opts, addl_opts) do
@@ -281,6 +286,8 @@ defmodule Pinchflat.Reconciliation.PlanApplier do
     command_opts =
       [sub_langs: profile.sub_langs, output: "#{rootname}.%(ext)s"] ++
         if(profile.download_auto_subs, do: [:write_auto_subs], else: [])
+
+    command_opts = command_opts ++ DownloadOptionBuilder.build_player_client_options_for(media_item)
 
     addl_opts = [use_cookies: Sources.use_cookies?(media_item.source, :metadata)]
 

--- a/lib/pinchflat/reconciliation/plan_builder.ex
+++ b/lib/pinchflat/reconciliation/plan_builder.ex
@@ -181,7 +181,8 @@ defmodule Pinchflat.Reconciliation.PlanBuilder do
   defp network_predict_media_filepath(media_item) do
     command_opts =
       [output: DownloadOptionBuilder.build_output_path_for(media_item)] ++
-        DownloadOptionBuilder.build_quality_options_for(media_item.source)
+        DownloadOptionBuilder.build_quality_options_for(media_item.source) ++
+        DownloadOptionBuilder.build_player_client_options_for(media_item)
 
     addl_opts = [use_cookies: Sources.use_cookies?(media_item.source, :metadata)]
 

--- a/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
+++ b/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
@@ -149,6 +149,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
       [output: DownloadOptionBuilder.build_output_path_for(source)] ++
         build_single_video_options(source) ++
         DownloadOptionBuilder.build_quality_options_for(source) ++
+        DownloadOptionBuilder.build_player_client_options_for(source) ++
         build_dateafter_options(source)
 
     results =

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -14,6 +14,25 @@ defmodule Pinchflat.Sources.Source do
   alias Pinchflat.Profiles.MediaProfile
   alias Pinchflat.Metadata.SourceMetadata
 
+  @player_client_options [
+    {"Web", :web},
+    {"Web Safari", :web_safari},
+    {"Web Embedded", :web_embedded},
+    {"Web Music", :web_music},
+    {"Web Creator", :web_creator},
+    {"Mobile Web", :mweb},
+    {"iOS", :ios},
+    {"VisionOS", :visionos},
+    {"Android", :android},
+    {"Android VR", :android_vr},
+    {"TV", :tv},
+    {"TV Downgraded", :tv_downgraded},
+    {"TV Simply", :tv_simply}
+  ]
+
+  @player_client_values Keyword.values(@player_client_options)
+  @cookie_incompatible_player_clients [:android, :ios, :tv_simply]
+
   @allowed_fields ~w(
     enabled
     collection_name
@@ -29,6 +48,7 @@ defmodule Pinchflat.Sources.Source do
     index_frequency_minutes
     fast_index
     cookie_behaviour
+    player_client
     selection_mode
     download_media
     download_public_media
@@ -84,6 +104,7 @@ defmodule Pinchflat.Sources.Source do
     field :index_frequency_minutes, :integer, default: 60 * 24
     field :fast_index, :boolean, default: false
     field :cookie_behaviour, Ecto.Enum, values: [:disabled, :when_needed, :all_operations], default: :disabled
+    field :player_client, Ecto.Enum, values: @player_client_values
     field :selection_mode, Ecto.Enum, values: [:all, :manual], default: :all
     field :download_media, :boolean, default: true
     # Keep both policies enabled by default so existing sources retain their
@@ -146,11 +167,34 @@ defmodule Pinchflat.Sources.Source do
     |> validate_download_subdirectory()
     |> validate_min_and_max_durations()
     |> validate_index_cutoff_date()
+    |> validate_player_client_cookie_compatibility()
     |> validate_number(:retention_period_days, greater_than_or_equal_to: 0)
     # Ensures it ends with `.{{ ext }}` or `.%(ext)s` or similar (with a little wiggle room)
     |> validate_format(:output_path_template_override, MediaProfile.ext_regex(), message: "must end with .{{ ext }}")
     |> cast_assoc(:metadata, with: &SourceMetadata.changeset/2, required: false)
     |> unique_constraint([:collection_id, :media_profile_id, :title_filter_regex], error_key: :original_url)
+  end
+
+  @doc """
+  Returns the finite list of supported YouTube player-client choices.
+
+  The `nil`/Default choice is rendered by the source form and is intentionally
+  not part of this list because it means that yt-dlp should receive no override.
+  """
+  def player_client_options, do: @player_client_options
+
+  @doc """
+  Returns the finite set of player-client atoms accepted by the schema.
+  """
+  def player_client_values, do: @player_client_values
+
+  @doc """
+  Returns the display label for a player-client value.
+  """
+  def player_client_label(nil), do: "Default"
+
+  def player_client_label(player_client) do
+    Keyword.get(@player_client_options, player_client, to_string(player_client))
   end
 
   @doc false
@@ -310,6 +354,22 @@ defmodule Pinchflat.Sources.Source do
       add_error(changeset, :index_cutoff_date, "must be on or before the download cutoff date")
     else
       changeset
+    end
+  end
+
+  defp validate_player_client_cookie_compatibility(changeset) do
+    player_client = get_field(changeset, :player_client)
+    cookie_behaviour = get_field(changeset, :cookie_behaviour)
+
+    cond do
+      player_client == :web_creator and cookie_behaviour == :disabled ->
+        add_error(changeset, :player_client, "requires account cookies; select When Needed or All Operations")
+
+      player_client in @cookie_incompatible_player_clients and cookie_behaviour != :disabled ->
+        add_error(changeset, :player_client, "does not support account cookies; set Cookie Behaviour to Disabled")
+
+      true ->
+        changeset
     end
   end
 

--- a/lib/pinchflat/sources/sources.ex
+++ b/lib/pinchflat/sources/sources.ex
@@ -18,6 +18,7 @@ defmodule Pinchflat.Sources do
   alias Pinchflat.Metadata.SourceMetadata
   alias Pinchflat.Utils.FilesystemUtils
   alias Pinchflat.Downloading.DownloadingHelpers
+  alias Pinchflat.Downloading.DownloadOptionBuilder
   alias Pinchflat.Downloading.MediaDownloadWorker
   alias Pinchflat.SlowIndexing.SlowIndexingHelpers
   alias Pinchflat.FastIndexing.FastIndexingHelpers
@@ -671,9 +672,10 @@ defmodule Pinchflat.Sources do
     original_url = changeset.changes.original_url
     should_use_cookies = Ecto.Changeset.get_field(changeset, :cookie_behaviour) == :all_operations
     # Skipping sleep interval since this is UI blocking and we want to keep this as fast as possible
+    command_opts = DownloadOptionBuilder.player_client_options(Ecto.Changeset.get_field(changeset, :player_client))
     addl_opts = [use_cookies: should_use_cookies, skip_sleep_interval: true]
 
-    case MediaCollection.get_source_details(original_url, [], addl_opts) do
+    case MediaCollection.get_source_details(original_url, command_opts, addl_opts) do
       {:ok, source_details} ->
         add_source_details_by_collection_type(source, changeset, source_details)
 

--- a/lib/pinchflat/yt_dlp/media.ex
+++ b/lib/pinchflat/yt_dlp/media.ex
@@ -57,8 +57,13 @@ defmodule Pinchflat.YtDlp.Media do
   Returns {:ok, :downloadable | :ignorable} | {:error, any}
   """
   def get_downloadable_status(url, addl_opts \\ []) do
+    get_downloadable_status(url, [], addl_opts)
+  end
+
+  @doc false
+  def get_downloadable_status(url, command_opts, addl_opts) do
     action = :get_downloadable_status
-    command_opts = [:simulate, :skip_download]
+    command_opts = [:simulate, :skip_download] ++ command_opts
 
     with {:ok, output} <- backend_runner().run(url, action, command_opts, "%(.{live_status})j", addl_opts),
          {:ok, parsed_json} <- ResponseDecoder.decode(output, action) do

--- a/lib/pinchflat_web/controllers/sources/source_html.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html.ex
@@ -455,6 +455,10 @@ defmodule PinchflatWeb.Sources.SourceHTML do
     ]
   end
 
+  def friendly_player_clients do
+    [{"Default", ""} | Pinchflat.Sources.Source.player_client_options()]
+  end
+
   def cutoff_date_presets do
     [
       {"7 days", compute_date_offset(7)},
@@ -544,6 +548,11 @@ defmodule PinchflatWeb.Sources.SourceHTML do
         "Cookies",
         cookie_behaviour_label(source.cookie_behaviour),
         "When this source's requests use your cookies.txt file"
+      ),
+      field(
+        "Player client",
+        Pinchflat.Sources.Source.player_client_label(source.player_client),
+        "The YouTube player client passed to yt-dlp, or Default when yt-dlp chooses"
       )
     ]
   end

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -133,7 +133,8 @@
       x-data={
         Phoenix.json_library().encode!(%{
           downloadMembersOnlyMedia: Ecto.Changeset.get_field(@changeset, :download_members_only_media),
-          cookieBehaviour: to_string(Ecto.Changeset.get_field(@changeset, :cookie_behaviour))
+          cookieBehaviour: to_string(Ecto.Changeset.get_field(@changeset, :cookie_behaviour)),
+          playerClient: to_string(Ecto.Changeset.get_field(@changeset, :player_client) || "")
         })
       }
     >
@@ -173,6 +174,14 @@
         help="Uses your YouTube cookies for this source (if configured). 'When Needed' tries to minimize cookie usage except for certain indexing and downloading tasks. See docs"
         x-model="cookieBehaviour"
       />
+      <.input
+        field={f[:player_client]}
+        options={friendly_player_clients()}
+        type="select"
+        label="YouTube Player Client"
+        help="Overrides yt-dlp's default YouTube player-client selection for this source. Default is recommended unless you need a specific client."
+        x-model="playerClient"
+      />
       <div
         x-cloak
         x-show="downloadMembersOnlyMedia && cookieBehaviour === 'disabled'"
@@ -181,6 +190,22 @@
       >
         Members-only media may fail without cookies. Configure a cookies.txt file and select a cookie behaviour if
         you want PinchYT to access it; this setting will not enable cookies automatically.
+      </div>
+      <div
+        x-cloak
+        x-show="playerClient === 'web_creator' && cookieBehaviour !== 'all_operations'"
+        class="theme-status-card theme-status-card-warning text-sm"
+        role="alert"
+      >
+        Web Creator requires account cookies. Select All Operations to use this client reliably.
+      </div>
+      <div
+        x-cloak
+        x-show="['android', 'ios', 'tv_simply'].includes(playerClient) && cookieBehaviour !== 'disabled'"
+        class="theme-status-card theme-status-card-warning text-sm"
+        role="alert"
+      >
+        This player client does not support account cookies. Set Cookie Behaviour to Disabled before saving.
       </div>
     </section>
 

--- a/lib/pinchflat_web/schemas.ex
+++ b/lib/pinchflat_web/schemas.ex
@@ -150,6 +150,26 @@ defmodule PinchflatWeb.Schemas do
         },
         index_frequency_minutes: %Schema{type: :integer, description: "Indexing frequency in minutes", example: 1440},
         fast_index: %Schema{type: :boolean, description: "Use fast indexing", example: false},
+        player_client: %Schema{
+          type: :string,
+          nullable: true,
+          enum: [
+            :web,
+            :web_safari,
+            :web_embedded,
+            :web_music,
+            :web_creator,
+            :mweb,
+            :ios,
+            :visionos,
+            :android,
+            :android_vr,
+            :tv,
+            :tv_downgraded,
+            :tv_simply
+          ],
+          description: "Optional yt-dlp YouTube player-client override; null uses yt-dlp defaults"
+        },
         selection_mode: %Schema{
           type: :string,
           enum: [:all, :manual],
@@ -387,6 +407,26 @@ defmodule PinchflatWeb.Schemas do
               default: true
             },
             fast_index: %Schema{type: :boolean, description: "Use fast indexing", default: false},
+            player_client: %Schema{
+              type: :string,
+              nullable: true,
+              enum: [
+                :web,
+                :web_safari,
+                :web_embedded,
+                :web_music,
+                :web_creator,
+                :mweb,
+                :ios,
+                :visionos,
+                :android,
+                :android_vr,
+                :tv,
+                :tv_downgraded,
+                :tv_simply
+              ],
+              description: "Optional yt-dlp YouTube player-client override; null uses yt-dlp defaults"
+            },
             delay_automatic_download: %Schema{
               type: :boolean,
               description: "For playlist sources, index first and wait for a manual item selection before downloading",
@@ -450,6 +490,26 @@ defmodule PinchflatWeb.Schemas do
               description: "Download subscriber-only, premium-only, and authentication-required media"
             },
             fast_index: %Schema{type: :boolean, description: "Use fast indexing"},
+            player_client: %Schema{
+              type: :string,
+              nullable: true,
+              enum: [
+                :web,
+                :web_safari,
+                :web_embedded,
+                :web_music,
+                :web_creator,
+                :mweb,
+                :ios,
+                :visionos,
+                :android,
+                :android_vr,
+                :tv,
+                :tv_downgraded,
+                :tv_simply
+              ],
+              description: "Optional yt-dlp YouTube player-client override; null uses yt-dlp defaults"
+            },
             index_frequency_minutes: %Schema{type: :integer, description: "Indexing frequency in minutes"},
             download_cutoff_date: %Schema{
               type: :string,

--- a/priv/repo/migrations/20260910150000_add_player_client_to_sources.exs
+++ b/priv/repo/migrations/20260910150000_add_player_client_to_sources.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddPlayerClientToSources do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add :player_client, :string
+    end
+  end
+end

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -72,6 +72,20 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
       refute :force_overwrites in res
       assert :no_force_overwrites in res
     end
+
+    test "does not add an extractor argument for the default player client", %{media_item: media_item} do
+      assert {:ok, res} = DownloadOptionBuilder.build(media_item)
+
+      refute Enum.any?(res, &match?({:extractor_args, "youtube:player-client=" <> _}, &1))
+    end
+
+    test "maps a source player client to a typed extractor argument", %{media_item: media_item} do
+      media_item = put_in(media_item.source.player_client, :android)
+
+      assert {:ok, res} = DownloadOptionBuilder.build(media_item)
+
+      assert {:extractor_args, "youtube:player-client=android"} in res
+    end
   end
 
   describe "build/1 when testing subtitle options" do

--- a/test/pinchflat/downloading/media_downloader_test.exs
+++ b/test/pinchflat/downloading/media_downloader_test.exs
@@ -153,6 +153,27 @@ defmodule Pinchflat.Downloading.MediaDownloaderTest do
 
       assert {:ok, _} = MediaDownloader.download_for_media_item(media_item, skip_download_precheck: true)
     end
+
+    test "passes the source player client to precheck and download commands" do
+      expect(YtDlpRunnerMock, :run, 3, fn
+        _url, :get_downloadable_status, opts, _ot, _addl ->
+          assert {:extractor_args, "youtube:player-client=android"} in opts
+          {:ok, "{}"}
+
+        _url, :download, opts, _ot, _addl ->
+          assert {:extractor_args, "youtube:player-client=android"} in opts
+          {:ok, render_metadata(:media_metadata)}
+
+        _url, :download_thumbnail, opts, _ot, _addl ->
+          assert {:extractor_args, "youtube:player-client=android"} in opts
+          {:ok, ""}
+      end)
+
+      source = source_fixture(%{player_client: :android})
+      media_item = media_item_fixture(%{source_id: source.id})
+
+      assert {:ok, _} = MediaDownloader.download_for_media_item(media_item)
+    end
   end
 
   describe "download_for_media_item/3 when testing cookie usage" do

--- a/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
+++ b/test/pinchflat/fast_indexing/fast_indexing_helpers_test.exs
@@ -129,6 +129,19 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpersTest do
       FastIndexingHelpers.index_and_kickoff_downloads(source)
     end
 
+    test "passes the source player client to the yt-dlp runner" do
+      expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
+
+      expect(YtDlpRunnerMock, :run, fn _url, :get_media_attributes, opts, _ot, _addl_opts ->
+        assert {:extractor_args, "youtube:player-client=android"} in opts
+        {:ok, media_attributes_return_fixture()}
+      end)
+
+      source = source_fixture(%{player_client: :android})
+
+      assert [%MediaItem{}] = FastIndexingHelpers.index_and_kickoff_downloads(source)
+    end
+
     test "does not enqueue a download job if the media item does not match the format rules" do
       expect(HTTPClientMock, :get, fn _url -> {:ok, "<yt:videoId>test_1</yt:videoId>"} end)
 

--- a/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
+++ b/test/pinchflat/slow_indexing/slow_indexing_helpers_test.exs
@@ -408,6 +408,17 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpersTest do
 
       SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
     end
+
+    test "passes the source player client to the yt-dlp runner" do
+      expect(YtDlpRunnerMock, :run, 3, fn _url, :get_media_attributes_for_collection, opts, _ot, _addl_opts ->
+        assert {:extractor_args, "youtube:player-client=android"} in opts
+        {:ok, source_attributes_return_fixture()}
+      end)
+
+      source = source_fixture(%{player_client: :android})
+
+      assert [_ | _] = SlowIndexingHelpers.index_and_enqueue_download_for_media_items(source)
+    end
   end
 
   describe "index_and_enqueue_download_for_media_items/2 when testing cookies" do

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -126,6 +126,48 @@ defmodule Pinchflat.SourcesTest do
     end
   end
 
+  describe "player client validation" do
+    test "defaults to yt-dlp's player-client selection" do
+      changeset = Source.changeset(%Source{}, %{}, :initial)
+
+      assert Ecto.Changeset.get_field(changeset, :player_client) == nil
+      refute Map.has_key?(errors_on(changeset), :player_client)
+    end
+
+    test "requires account cookies for the web creator client" do
+      changeset =
+        Source.changeset(
+          %Source{},
+          %{player_client: :web_creator, cookie_behaviour: :disabled},
+          :initial
+        )
+
+      assert "requires account cookies; select When Needed or All Operations" in errors_on(changeset).player_client
+    end
+
+    test "rejects cookie-incompatible clients when cookies are enabled" do
+      changeset =
+        Source.changeset(
+          %Source{},
+          %{player_client: :android, cookie_behaviour: :all_operations},
+          :initial
+        )
+
+      assert "does not support account cookies; set Cookie Behaviour to Disabled" in errors_on(changeset).player_client
+    end
+
+    test "allows android when cookies are disabled" do
+      changeset =
+        Source.changeset(
+          %Source{},
+          %{player_client: :android, cookie_behaviour: :disabled},
+          :initial
+        )
+
+      refute Map.has_key?(errors_on(changeset), :player_client)
+    end
+  end
+
   describe "cookie file helpers" do
     setup do
       extras_directory =
@@ -639,6 +681,22 @@ defmodule Pinchflat.SourcesTest do
       }
 
       assert {:ok, %Source{}} = Sources.create_source(valid_attrs)
+    end
+
+    test "passes a source player-client override to source details" do
+      expect(YtDlpRunnerMock, :run, fn _url, :get_source_details, opts, _ot, _addl ->
+        assert {:extractor_args, "youtube:player-client=android"} in opts
+
+        {:ok, playlist_return()}
+      end)
+
+      valid_attrs = %{
+        media_profile_id: media_profile_fixture().id,
+        original_url: "https://www.youtube.com/channel/abc123",
+        player_client: :android
+      }
+
+      assert {:ok, %Source{player_client: :android}} = Sources.create_source(valid_attrs)
     end
   end
 

--- a/test/pinchflat/yt_dlp/media_test.exs
+++ b/test/pinchflat/yt_dlp/media_test.exs
@@ -133,6 +133,21 @@ defmodule Pinchflat.YtDlp.MediaTest do
       assert {:ok, :downloadable} = Media.get_downloadable_status(@media_url, addl_arg: true)
     end
 
+    test "passes typed command options to the backend runner" do
+      expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, opts, _ot, _addl ->
+        assert [:simulate, :skip_download, {:extractor_args, "youtube:player-client=android"}] == opts
+
+        {:ok, Phoenix.json_library().encode!(%{"live_status" => "was_live"})}
+      end)
+
+      assert {:ok, :downloadable} =
+               Media.get_downloadable_status(
+                 @media_url,
+                 [{:extractor_args, "youtube:player-client=android"}],
+                 use_cookies: false
+               )
+    end
+
     test "returns an error (instead of raising) if the output is not JSON" do
       expect(YtDlpRunnerMock, :run, fn _url, :get_downloadable_status, _opts, _ot, _addl ->
         {:ok, ""}

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -98,6 +98,9 @@ defmodule PinchflatWeb.SourceControllerTest do
       assert html_response(conn, 200) =~ "Delay Automatic Download"
       assert html_response(conn, 200) =~ "Download Public and Unlisted Media"
       assert html_response(conn, 200) =~ "Download Members-only Media"
+      assert html_response(conn, 200) =~ "YouTube Player Client"
+      assert html_response(conn, 200) =~ "Default"
+      assert html_response(conn, 200) =~ "Web Creator"
       assert html_response(conn, 200) =~ "Members-only media may fail without cookies"
       assert html_response(conn, 200) =~ "How source folders work"
       assert html_response(conn, 200) =~ "Insert media profile template"
@@ -176,6 +179,16 @@ defmodule PinchflatWeb.SourceControllerTest do
     test "renders errors when data is invalid", %{conn: conn, invalid_attrs: invalid_attrs} do
       conn = post(conn, ~p"/sources", source: invalid_attrs)
       assert html_response(conn, 200) =~ "New Source"
+    end
+
+    test "renders a cookie compatibility error for the selected player client", %{
+      conn: conn,
+      create_attrs: create_attrs
+    } do
+      conn =
+        post(conn, ~p"/sources", source: Map.merge(create_attrs, %{player_client: "web_creator"}))
+
+      assert html_response(conn, 200) =~ "requires account cookies; select When Needed or All Operations"
     end
 
     test "redirects to onboarding when onboarding", %{conn: conn, create_attrs: create_attrs} do


### PR DESCRIPTION
## Summary
- Add a nullable per-source `player_client` override with a finite allowlist of current yt-dlp YouTube clients.
- Preserve the exact existing command when the source remains on Default (`nil`).
- Pass the typed `youtube:player-client=...` extractor argument through source creation, fast/slow indexing, download prechecks/downloads, metadata, and reconciliation.
- Add source-form selection, cookie compatibility validation/warnings, API schema fields, and focused regression tests.

## yt-dlp contract
The option uses yt-dlp's documented `--extractor-args youtube:player-client=...` syntax and the documented client list:
https://github.com/yt-dlp/yt-dlp#extractor-arguments

The cookie rules follow yt-dlp's current official PO-token guidance: `web_creator` requires account cookies, while `android`, `ios`, and `tv_simply` do not support account cookies. PO-token arguments and provider containers are intentionally out of scope for this PR and remain PR6 work:
https://github.com/yt-dlp/yt-dlp/wiki/PO-Token-Guide#current-po-token-enforcement

## Verification
- Targeted PR5 suite: 518 tests, 0 failures.
- Full Docker `mix check`: 1614 tests, 0 failures; compiler, Credo, formatter, Sobelow, and unused-dependency checks passed.
- UI theme check passed.
- PR5 migration applied to the running dev service; `/healthcheck` returned HTTP 200.
- Generated `priv/repo/erd.png` was restored and is not part of this PR.
- Aggregate `mix check` exit remained 1 because Prettier cannot scan the mounted `/app/.agents/skills` path (`EPERM`); this is an environment permission issue.

## External verification blockers
- The requested DevTools browser DOM scenario could not run because the connected CUA surface reported no browser or app tabs.
- The requested independent Sol verifier could not be spawned because no fork/model execution tool is exposed in this environment. No Sol PASS is being claimed.

Docker changes in `docker/dev.Dockerfile` and `docker/selfhosted.Dockerfile`, plus the untracked `plans/` directory, were intentionally preserved in the worktree and are not part of this PR.