### PR TITLE
Add optional PO-token provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,30 @@ services:
 Save this as `compose.yaml`, replace the timezone if needed, and run `docker compose up -d`. Open
 <http://localhost:8945> when the container is healthy.
 
+### Optional PO-token provider
+
+The default compose above keeps the provider disabled. If YouTube presents SABR or authentication problems, add the
+following service and environment variable to your compose file:
+
+```yaml
+services:
+  pinchyt:
+    environment:
+      TZ: America/Regina
+      POT_PROVIDER_URL: http://pot-provider:4416
+
+  pot-provider:
+    image: brainicism/bgutil-ytdlp-pot-provider:2.0.0
+    profiles: [pot-provider]
+    restart: unless-stopped
+    # No ports mapping: the unauthenticated provider stays on the Compose network.
+```
+
+Start the opt-in service with `docker compose --profile pot-provider up -d`. PinchYT images include the matching bgutil
+yt-dlp plugin, and Diagnostics reports the provider's bounded `/ping` health check. See the
+[official bgutil provider documentation](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) and
+[yt-dlp's PO-token guide](https://github.com/yt-dlp/yt-dlp/wiki/PO-Token-Guide) for background and limitations.
+
 ## What PinchYT adds
 
 <table>

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -21,9 +21,24 @@ if System.get_env("PHX_SERVER") do
   config :pinchflat, PinchflatWeb.Endpoint, server: true
 end
 
+pot_provider_url =
+  case System.get_env("POT_PROVIDER_URL") do
+    value when is_binary(value) ->
+      case String.trim(value) do
+        "" -> nil
+        trimmed -> trimmed
+      end
+
+    _ ->
+      nil
+  end
+
 config :pinchflat,
   basic_auth_username: System.get_env("BASIC_AUTH_USERNAME"),
-  basic_auth_password: System.get_env("BASIC_AUTH_PASSWORD")
+  basic_auth_password: System.get_env("BASIC_AUTH_PASSWORD"),
+  # Optional bgutil PO-token provider. An absent or blank URL keeps the
+  # provider disabled and preserves the existing yt-dlp command line.
+  po_token_provider_url: pot_provider_url
 
 # Optional OIDC/OAuth2 single sign-on. When all three of these are set,
 # the web UI requires logging in via the provider and BASIC_AUTH_* is

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -5,11 +5,16 @@ ARG INSTALL_SHELL_TOOLS=0
 
 ARG DEV_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 
+FROM node:24-bookworm-slim AS node
+
 FROM ${DEV_IMAGE}
 
 ARG TARGETPLATFORM
 ARG YT_DLP_CACHE_BUST=""
+ARG BGUTIL_PLUGIN_VERSION=2.0.0
 RUN echo "Building for ${TARGETPLATFORM:?}"
+
+COPY --from=node /usr/local/ /usr/local/
 
 # Install debian packages
 RUN set -eux; \
@@ -42,37 +47,38 @@ RUN export FFMPEG_DOWNLOAD=$(case ${TARGETPLATFORM:-linux/amd64} in \
     tar -xf /tmp/ffmpeg.tar.xz --strip-components=2 --no-anchored -C /usr/bin/ "ffmpeg" && \
     tar -xf /tmp/ffmpeg.tar.xz --strip-components=2 --no-anchored -C /usr/bin/ "ffprobe"
 
-# Install nodejs and Yarn
-RUN curl -sL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh && \
-  bash nodesource_setup.sh && \
-  set -eux; \
-  for attempt in 1 2 3 4 5; do \
-    rm -rf /var/lib/apt/lists/*; \
-    apt-get clean; \
-    if apt-get \
-      -o Acquire::Retries=5 \
-      -o Acquire::By-Hash=force \
-      -o Acquire::http::No-Cache=true \
-      -o Acquire::https::No-Cache=true \
-      update -qq && \
-      apt-get install -y --no-install-recommends nodejs; then \
-      break; \
-    fi; \
-    if [ "$attempt" -eq 5 ]; then exit 1; fi; \
-    sleep 5; \
-  done && \
+# Install Yarn and project tooling
+RUN set -eux; \
+  node --version; \
+  npm --version; \
+  rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && \
   npm install -g yarn prettier@3.9.4 sqleton@^4.0.0 && \
+  yarn --version && \
   # Install baseline Elixir packages
   mix local.hex --force && \
   mix local.rebar --force && \
   # Install Deno - required for YouTube downloads (See yt-dlp#14404)
-  curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh -s -- -y --no-modify-path && \
+  case "${TARGETPLATFORM:-linux/amd64}" in \
+    "linux/amd64") DENO_ARCH="x86_64" ;; \
+    "linux/arm64") DENO_ARCH="aarch64" ;; \
+    *) echo "Unsupported platform: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+  esac && \
+  curl -4 -fsSL --retry 5 --retry-all-errors "https://github.com/denoland/deno/releases/latest/download/deno-${DENO_ARCH}-unknown-linux-gnu.zip" -o /tmp/deno.zip && \
+  unzip -q /tmp/deno.zip deno -d /usr/local/bin && \
+  chmod a+rx /usr/local/bin/deno && \
+  rm -f /tmp/deno.zip && \
   # Download and update YT-DLP
   echo "Refreshing yt-dlp nightly cache bust token: ${YT_DLP_CACHE_BUST}" && \
   export YT_DLP_DOWNLOAD="https://github.com/yt-dlp/yt-dlp-nightly-builds/releases/latest/download/yt-dlp" && \
   curl -L ${YT_DLP_DOWNLOAD} -o /usr/local/bin/yt-dlp && \
   chmod a+rx /usr/local/bin/yt-dlp && \
   yt-dlp --update-to nightly && \
+  # Keep the optional bgutil plugin outside the app's mounted config. It is only
+  # loaded when POT_PROVIDER_URL is configured by the application.
+  install -d /opt/pinchyt/yt-dlp-plugins && \
+  curl -4 -fsSL --retry 5 --retry-all-errors "https://github.com/Brainicism/bgutil-ytdlp-pot-provider/releases/download/${BGUTIL_PLUGIN_VERSION}/bgutil-ytdlp-pot-provider.zip" \
+    -o /opt/pinchyt/yt-dlp-plugins/bgutil-ytdlp-pot-provider.zip && \
+  chmod -R a+rX /opt/pinchyt/yt-dlp-plugins && \
   # Install Apprise
   export PIPX_HOME=/opt/pipx && \
   export PIPX_BIN_DIR=/usr/local/bin && \

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -1,6 +1,23 @@
 name: pinchyt-preview
 
 services:
+  pot-provider:
+    image: brainicism/bgutil-ytdlp-pot-provider:2.0.0
+    profiles: ["pot-provider"]
+    restart: unless-stopped
+    # The provider is intentionally internal-only. Do not add a ports mapping.
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - >-
+          require("http").get("http://127.0.0.1:4416/ping", response =>
+          process.exit(response.statusCode === 200 ? 0 : 1)).on("error", () => process.exit(1))
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   phx:
     build:
       context: ..

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,6 +1,23 @@
 name: pinchyt
 
 services:
+  pot-provider:
+    image: brainicism/bgutil-ytdlp-pot-provider:2.0.0
+    profiles: ["pot-provider"]
+    restart: unless-stopped
+    # The provider is intentionally internal-only. Do not add a ports mapping.
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - >-
+          require("http").get("http://127.0.0.1:4416/ping", response =>
+          process.exit(response.statusCode === 200 ? 0 : 1)).on("error", () => process.exit(1))
+      interval: 30s
+      timeout: 5s
+      retries: 3
+
   phx:
     build:
       context: ..

--- a/docker/selfhosted.Dockerfile
+++ b/docker/selfhosted.Dockerfile
@@ -7,10 +7,14 @@ ARG DEBIAN_VERSION=bookworm-20260316-slim
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"
 
+FROM node:24-bookworm-slim AS node
+
 FROM ${BUILDER_IMAGE} AS builder
 
 ARG TARGETPLATFORM
 RUN echo "Building for ${TARGETPLATFORM:?}"
+
+COPY --from=node /usr/local/ /usr/local/
 
 # install build dependencies
 RUN set -eux; \
@@ -32,25 +36,10 @@ RUN set -eux; \
       if [ "$attempt" -eq 5 ]; then exit 1; fi; \
       sleep 5; \
     done && \
-    # Node.js and Yarn
-    curl -sL https://deb.nodesource.com/setup_24.x -o nodesource_setup.sh && \
-    bash nodesource_setup.sh && \
-    for attempt in 1 2 3 4 5; do \
-      rm -rf /var/lib/apt/lists/*; \
-      apt-get clean; \
-      if apt-get \
-        -o Acquire::Retries=5 \
-        -o Acquire::By-Hash=force \
-        -o Acquire::http::No-Cache=true \
-        -o Acquire::https::No-Cache=true \
-        update -qq && \
-        apt-get install -y --no-install-recommends nodejs; then \
-        break; \
-      fi; \
-      if [ "$attempt" -eq 5 ]; then exit 1; fi; \
-      sleep 5; \
-    done && \
+    # Remove the Node image's Yarn shim before installing Yarn globally.
+    rm -f /usr/local/bin/yarn /usr/local/bin/yarnpkg && \
     npm install -g yarn && \
+    yarn --version && \
     # Hex and Rebar
     mix local.hex --force && \
     mix local.rebar --force && \
@@ -102,6 +91,7 @@ FROM ${RUNNER_IMAGE}
 
 ARG TARGETPLATFORM
 ARG PORT=8945
+ARG BGUTIL_PLUGIN_VERSION=2.0.0
 ARG YT_DLP_CACHE_BUST=""
 
 COPY --from=builder ./usr/local/bin/ffmpeg /usr/bin/ffmpeg
@@ -139,7 +129,15 @@ RUN set -eux; \
       sleep 5; \
     done && \
     # Install Deno - required for YouTube downloads (See yt-dlp#14404)
-    curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh -s -- -y --no-modify-path && \
+    case "${TARGETPLATFORM:-linux/amd64}" in \
+      "linux/amd64") DENO_ARCH="x86_64" ;; \
+      "linux/arm64") DENO_ARCH="aarch64" ;; \
+      *) echo "Unsupported platform: ${TARGETPLATFORM}" >&2; exit 1 ;; \
+    esac && \
+    curl -4 -fsSL --retry 5 --retry-all-errors "https://github.com/denoland/deno/releases/latest/download/deno-${DENO_ARCH}-unknown-linux-gnu.zip" -o /tmp/deno.zip && \
+    unzip -q /tmp/deno.zip deno -d /usr/local/bin && \
+    chmod a+rx /usr/local/bin/deno && \
+    rm -f /tmp/deno.zip && \
     # Apprise
     export PIPX_HOME=/opt/pipx && \
     export PIPX_BIN_DIR=/usr/local/bin && \
@@ -164,8 +162,15 @@ ENV LC_ALL=en_US.UTF-8
 WORKDIR "/app"
 
 # Set up data volumes
-RUN mkdir -p /config /downloads /etc/elixir_tzdata_data /etc/yt-dlp/plugins && \
+RUN mkdir -p /config /downloads /opt/pinchyt/yt-dlp-plugins /etc/elixir_tzdata_data /etc/yt-dlp/plugins && \
   chmod ugo+rw /etc/elixir_tzdata_data /etc/yt-dlp /etc/yt-dlp/plugins /usr/local/bin /usr/local/bin/yt-dlp
+
+# The official bgutil plugin is installed as a zip in a dedicated directory.
+# PinchYT adds --plugin-dirs only when POT_PROVIDER_URL is valid, so the
+# disabled configuration keeps the existing yt-dlp command line unchanged.
+RUN curl -4 -fsSL --retry 5 --retry-all-errors "https://github.com/Brainicism/bgutil-ytdlp-pot-provider/releases/download/${BGUTIL_PLUGIN_VERSION}/bgutil-ytdlp-pot-provider.zip" \
+      -o /opt/pinchyt/yt-dlp-plugins/bgutil-ytdlp-pot-provider.zip && \
+    chmod -R a+rX /opt/pinchyt/yt-dlp-plugins
 
 # set runner ENV
 ENV MIX_ENV="prod"

--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -8,6 +8,7 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
   alias Pinchflat.Media.MediaItem
   alias Pinchflat.Downloading.OutputPathBuilder
   alias Pinchflat.Downloading.QualityOptionBuilder
+  alias Pinchflat.YtDlp.PoTokenProvider
 
   alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
 
@@ -21,7 +22,7 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
 
     built_options =
       default_options(override_opts) ++
-        player_client_options(media_item_with_preloads.source.player_client) ++
+        build_youtube_options_for(media_item_with_preloads) ++
         subtitle_options(media_profile) ++
         thumbnail_options(media_item_with_preloads) ++
         metadata_options(media_profile) ++
@@ -45,6 +46,19 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
 
   def build_player_client_options_for(%MediaItem{} = media_item) do
     build_player_client_options_for(media_item.source)
+  end
+
+  @doc """
+  Builds the source-specific yt-dlp extractor arguments used by every YouTube
+  operation. The player-client override remains source-specific, while the
+  optional provider argument is global and is omitted when disabled.
+  """
+  def build_youtube_options_for(%Source{} = source) do
+    player_client_options(source.player_client) ++ PoTokenProvider.options()
+  end
+
+  def build_youtube_options_for(%MediaItem{} = media_item) do
+    build_youtube_options_for(media_item.source)
   end
 
   @doc false

--- a/lib/pinchflat/downloading/media_downloader.ex
+++ b/lib/pinchflat/downloading/media_downloader.ex
@@ -192,7 +192,7 @@ defmodule Pinchflat.Downloading.MediaDownloader do
       case {
         YtDlpMedia.get_downloadable_status(
           url,
-          DownloadOptionBuilder.build_player_client_options_for(item_with_preloads),
+          DownloadOptionBuilder.build_youtube_options_for(item_with_preloads),
           use_cookies: should_use_cookies
         ),
         should_use_cookies

--- a/lib/pinchflat/fast_indexing/fast_indexing_helpers.ex
+++ b/lib/pinchflat/fast_indexing/fast_indexing_helpers.ex
@@ -97,7 +97,7 @@ defmodule Pinchflat.FastIndexing.FastIndexingHelpers do
     command_opts =
       [output: DownloadOptionBuilder.build_output_path_for(source)] ++
         DownloadOptionBuilder.build_quality_options_for(source) ++
-        DownloadOptionBuilder.build_player_client_options_for(source)
+        DownloadOptionBuilder.build_youtube_options_for(source)
 
     case YtDlpMedia.get_media_attributes(url, command_opts, use_cookies: should_use_cookies) do
       {:ok, media_attrs} ->

--- a/lib/pinchflat/metadata/metadata_file_helpers.ex
+++ b/lib/pinchflat/metadata/metadata_file_helpers.ex
@@ -75,7 +75,7 @@ defmodule Pinchflat.Metadata.MetadataFileHelpers do
 
     command_opts =
       [output: yt_dlp_filepath] ++
-        DownloadOptionBuilder.build_player_client_options_for(media_item_with_preloads)
+        DownloadOptionBuilder.build_youtube_options_for(media_item_with_preloads)
 
     addl_opts = [use_cookies: Sources.use_cookies?(media_item_with_preloads.source, :metadata)]
 

--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -136,7 +136,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
   defp determine_series_directory(source) do
     runner_opts =
       [output: DownloadOptionBuilder.build_output_path_for(source)] ++
-        DownloadOptionBuilder.build_player_client_options_for(source)
+        DownloadOptionBuilder.build_youtube_options_for(source)
 
     addl_opts = [use_cookies: Sources.use_cookies?(source, :metadata)]
     details_result = MediaCollection.get_source_details(source.original_url, runner_opts, addl_opts)
@@ -178,7 +178,7 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
         base_opts ++ [:write_thumbnail, playlist_items: 1]
       end
 
-    opts = opts ++ DownloadOptionBuilder.build_player_client_options_for(source)
+    opts = opts ++ DownloadOptionBuilder.build_youtube_options_for(source)
 
     MediaCollection.get_source_metadata(source.original_url, opts, use_cookies: should_use_cookies)
   end

--- a/lib/pinchflat/reconciliation/plan_applier.ex
+++ b/lib/pinchflat/reconciliation/plan_applier.ex
@@ -253,7 +253,7 @@ defmodule Pinchflat.Reconciliation.PlanApplier do
 
     command_opts =
       [output: "#{rootname}.%(ext)s"] ++
-        DownloadOptionBuilder.build_player_client_options_for(media_item)
+        DownloadOptionBuilder.build_youtube_options_for(media_item)
 
     addl_opts = [use_cookies: Sources.use_cookies?(media_item.source, :metadata)]
 
@@ -287,7 +287,7 @@ defmodule Pinchflat.Reconciliation.PlanApplier do
       [sub_langs: profile.sub_langs, output: "#{rootname}.%(ext)s"] ++
         if(profile.download_auto_subs, do: [:write_auto_subs], else: [])
 
-    command_opts = command_opts ++ DownloadOptionBuilder.build_player_client_options_for(media_item)
+    command_opts = command_opts ++ DownloadOptionBuilder.build_youtube_options_for(media_item)
 
     addl_opts = [use_cookies: Sources.use_cookies?(media_item.source, :metadata)]
 

--- a/lib/pinchflat/reconciliation/plan_builder.ex
+++ b/lib/pinchflat/reconciliation/plan_builder.ex
@@ -182,7 +182,7 @@ defmodule Pinchflat.Reconciliation.PlanBuilder do
     command_opts =
       [output: DownloadOptionBuilder.build_output_path_for(media_item)] ++
         DownloadOptionBuilder.build_quality_options_for(media_item.source) ++
-        DownloadOptionBuilder.build_player_client_options_for(media_item)
+        DownloadOptionBuilder.build_youtube_options_for(media_item)
 
     addl_opts = [use_cookies: Sources.use_cookies?(media_item.source, :metadata)]
 

--- a/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
+++ b/lib/pinchflat/slow_indexing/slow_indexing_helpers.ex
@@ -149,7 +149,7 @@ defmodule Pinchflat.SlowIndexing.SlowIndexingHelpers do
       [output: DownloadOptionBuilder.build_output_path_for(source)] ++
         build_single_video_options(source) ++
         DownloadOptionBuilder.build_quality_options_for(source) ++
-        DownloadOptionBuilder.build_player_client_options_for(source) ++
+        DownloadOptionBuilder.build_youtube_options_for(source) ++
         build_dateafter_options(source)
 
     results =

--- a/lib/pinchflat/sources/sources.ex
+++ b/lib/pinchflat/sources/sources.ex
@@ -672,7 +672,10 @@ defmodule Pinchflat.Sources do
     original_url = changeset.changes.original_url
     should_use_cookies = Ecto.Changeset.get_field(changeset, :cookie_behaviour) == :all_operations
     # Skipping sleep interval since this is UI blocking and we want to keep this as fast as possible
-    command_opts = DownloadOptionBuilder.player_client_options(Ecto.Changeset.get_field(changeset, :player_client))
+    command_opts =
+      DownloadOptionBuilder.player_client_options(Ecto.Changeset.get_field(changeset, :player_client)) ++
+        Pinchflat.YtDlp.PoTokenProvider.options()
+
     addl_opts = [use_cookies: should_use_cookies, skip_sleep_interval: true]
 
     case MediaCollection.get_source_details(original_url, command_opts, addl_opts) do

--- a/lib/pinchflat/yt_dlp/command_runner.ex
+++ b/lib/pinchflat/yt_dlp/command_runner.ex
@@ -9,6 +9,7 @@ defmodule Pinchflat.YtDlp.CommandRunner do
   alias Pinchflat.Utils.CliUtils
   alias Pinchflat.Utils.NumberUtils
   alias Pinchflat.YtDlp.YtDlpCommandRunner
+  alias Pinchflat.YtDlp.PoTokenProvider
   alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
 
   @behaviour YtDlpCommandRunner
@@ -137,7 +138,7 @@ defmodule Pinchflat.YtDlp.CommandRunner do
     [
       :windows_filenames,
       cache_dir: Path.join(Application.get_env(:pinchflat, :tmpfile_directory), "yt-dlp-cache")
-    ] ++ quiet_opt
+    ] ++ quiet_opt ++ PoTokenProvider.plugin_options()
   end
 
   defp cookie_file_options(addl_opts) do

--- a/lib/pinchflat/yt_dlp/po_token_provider.ex
+++ b/lib/pinchflat/yt_dlp/po_token_provider.ex
@@ -1,0 +1,151 @@
+defmodule Pinchflat.YtDlp.PoTokenProvider do
+  @moduledoc """
+  Configuration and health checks for the optional bgutil PO-token provider.
+
+  The provider is deliberately opt-in. When `POT_PROVIDER_URL` is absent, this
+  module returns no yt-dlp options and no plugin directory option, preserving
+  the existing command line and container topology.
+  """
+
+  alias Pinchflat.HTTP.HTTPClient
+
+  @health_timeout 3_000
+  @plugin_dir "/opt/pinchyt/yt-dlp-plugins"
+
+  @doc """
+  Returns typed yt-dlp extractor arguments for a configured provider.
+
+  Returns `[]` when the provider is disabled or the configured URL is invalid.
+  """
+  def options do
+    case valid_base_url() do
+      {:ok, base_url} -> [{:extractor_args, "youtubepot-bgutilhttp:base_url=#{base_url}"}]
+      :error -> []
+    end
+  end
+
+  @doc """
+  Returns the typed plugin-directory option when the provider is enabled and
+  its bundled plugin directory is present.
+  """
+  def plugin_options do
+    if enabled?() and plugin_directory_present?() do
+      [plugin_dirs: @plugin_dir]
+    else
+      []
+    end
+  end
+
+  @doc """
+  Returns the current provider status without exposing provider response bodies.
+
+  The provider's documented `/ping` response is considered healthy only when
+  it contains both a non-empty version and a numeric server uptime. Network
+  failures and malformed responses are intentionally reported separately so
+  the diagnostics page stays useful without displaying sensitive data.
+  """
+  def status do
+    case configured_url() do
+      nil -> status(:disabled, "No POT_PROVIDER_URL is configured.")
+      _url -> status_for_configured_provider()
+    end
+  end
+
+  @doc """
+  Returns a short flash-safe result for the one-click diagnostics test.
+  """
+  def test_result do
+    case status() do
+      %{state: :healthy} -> {:info, "PO-token provider is healthy."}
+      %{state: :disabled} -> {:info, "PO-token provider is disabled."}
+      %{state: :invalid_configuration} -> {:error, "PO-token provider configuration is invalid."}
+      %{state: :invalid_response} -> {:error, "PO-token provider returned an invalid health response."}
+      %{state: :unreachable} -> {:error, "PO-token provider could not be reached within the health-check timeout."}
+    end
+  end
+
+  @doc false
+  def enabled? do
+    match?({:ok, _base_url}, valid_base_url())
+  end
+
+  defp status_for_configured_provider do
+    case valid_base_url() do
+      :error ->
+        status(
+          :invalid_configuration,
+          "POT_PROVIDER_URL must be an http(s) URL without credentials or query parameters."
+        )
+
+      {:ok, base_url} ->
+        health_status(base_url)
+    end
+  end
+
+  defp health_status(base_url) do
+    http_client().get("#{base_url}/ping", [], request_options())
+    |> classify_health_response()
+  end
+
+  defp classify_health_response({:ok, body}) do
+    case Jason.decode(body) do
+      {:ok, %{"server_uptime" => uptime, "version" => version}}
+      when is_number(uptime) and is_binary(version) and version != "" ->
+        status(:healthy, "Provider responded to the documented /ping endpoint.")
+
+      _ ->
+        status(:invalid_response, "Provider did not return the documented /ping response shape.")
+    end
+  end
+
+  defp classify_health_response({:error, _reason}) do
+    status(:unreachable, "Provider connection failed or timed out.")
+  end
+
+  defp status(state, detail), do: %{state: state, label: label_for(state), detail: detail}
+
+  defp label_for(:disabled), do: "Disabled"
+  defp label_for(:healthy), do: "Healthy"
+  defp label_for(:unreachable), do: "Unreachable"
+  defp label_for(:invalid_response), do: "Invalid response"
+  defp label_for(:invalid_configuration), do: "Invalid configuration"
+
+  defp configured_url do
+    case Application.get_env(:pinchflat, :po_token_provider_url) do
+      url when is_binary(url) ->
+        case String.trim(url) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp valid_base_url do
+    with url when is_binary(url) <- configured_url(),
+         %URI{scheme: scheme, host: host, userinfo: nil, query: nil, fragment: nil} = uri <- URI.parse(url),
+         true <- scheme in ["http", "https"],
+         true <- is_binary(host) and host != "" do
+      {:ok, String.trim_trailing(URI.to_string(uri), "/")}
+    else
+      _ -> :error
+    end
+  end
+
+  defp request_options do
+    [pool_timeout: @health_timeout, receive_timeout: @health_timeout, request_timeout: @health_timeout]
+  end
+
+  defp http_client do
+    Application.get_env(:pinchflat, :http_client, HTTPClient)
+  end
+
+  defp plugin_directory_present? do
+    case File.ls(@plugin_dir) do
+      {:ok, [_entry | _rest]} -> true
+      _ -> false
+    end
+  end
+end

--- a/lib/pinchflat_web/controllers/settings/diagnostics_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_controller.ex
@@ -4,9 +4,18 @@ defmodule PinchflatWeb.Settings.DiagnosticsController do
   alias Pinchflat.Settings
   alias Pinchflat.Diagnostics.QueueDiagnostics
   alias Pinchflat.Diagnostics.DatabaseMaintenanceWorker
+  alias Pinchflat.YtDlp.PoTokenProvider
 
   def show(conn, _params) do
     render(conn, "show.html")
+  end
+
+  def test_po_token_provider(conn, _params) do
+    {flash_type, message} = PoTokenProvider.test_result()
+
+    conn
+    |> put_flash(flash_type, message)
+    |> redirect(to: ~p"/diagnostics")
   end
 
   def reset_retryable_jobs(conn, _params) do

--- a/lib/pinchflat_web/controllers/settings/diagnostics_html.ex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_html.ex
@@ -4,6 +4,7 @@ defmodule PinchflatWeb.Settings.DiagnosticsHTML do
   alias Pinchflat.Settings
   alias Pinchflat.Diagnostics.QueueDiagnostics
   alias Pinchflat.Diagnostics.DatabaseDiagnostics
+  alias Pinchflat.YtDlp.PoTokenProvider
 
   embed_templates "diagnostics_html/*"
 
@@ -108,6 +109,14 @@ defmodule PinchflatWeb.Settings.DiagnosticsHTML do
     - Timezone: #{Application.get_env(:pinchflat, :timezone)}
     """
   end
+
+  def po_token_provider_status do
+    PoTokenProvider.status()
+  end
+
+  def po_token_provider_status_class(%{state: :healthy}), do: "theme-status-success"
+  def po_token_provider_status_class(%{state: :disabled}), do: "text-theme-on-surface-muted"
+  def po_token_provider_status_class(_status), do: "theme-status-error"
 
   def format_worker_name(worker) do
     worker

--- a/lib/pinchflat_web/controllers/settings/diagnostics_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/settings/diagnostics_html/show.html.heex
@@ -46,6 +46,28 @@
   </div>
 </div>
 
+<% pot_status = po_token_provider_status() %>
+<div id="po-token-provider-status" class="theme-surface-raised mb-6 px-5 py-5 sm:px-7.5">
+  <div class="mb-2 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <h3 class="text-lg font-semibold text-theme-on-surface">PO-token Provider</h3>
+    <%= if pot_status.state != :disabled do %>
+      <.link href={~p"/diagnostics/test_po_token_provider"} method="post" class="w-full sm:w-auto">
+        <.button color="theme-outline-button" rounding="rounded-m3-sm" class="w-full text-sm sm:w-auto">
+          Test Provider
+        </.button>
+      </.link>
+    <% end %>
+  </div>
+  <p class={"text-sm font-semibold #{po_token_provider_status_class(pot_status)}"}>
+    {pot_status.label}
+  </p>
+  <p class="mt-1 text-sm text-theme-on-surface-muted">{pot_status.detail}</p>
+  <p class="mt-2 text-xs text-theme-on-surface-muted">
+    Configure <span class="font-mono">POT_PROVIDER_URL</span> to enable the internal bgutil-compatible provider.
+    Health checks use the provider's bounded <span class="font-mono">/ping</span> endpoint and never display tokens.
+  </p>
+</div>
+
 <!-- Database -->
 <% db = database_stats() %>
 <div class="theme-surface-raised mb-6 px-5 py-5 sm:px-7.5">

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -81,6 +81,7 @@ defmodule PinchflatWeb.Router do
     post "/reconciliation/apply/:plan_id", Settings.ReconciliationController, :apply
 
     get "/diagnostics", Settings.DiagnosticsController, :show
+    post "/diagnostics/test_po_token_provider", Settings.DiagnosticsController, :test_po_token_provider
     post "/diagnostics/reset_retryable_jobs", Settings.DiagnosticsController, :reset_retryable_jobs
     post "/diagnostics/reset_job/:id", Settings.DiagnosticsController, :reset_job
     post "/diagnostics/requeue_job/:id", Settings.DiagnosticsController, :requeue_job

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -86,6 +86,17 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
 
       assert {:extractor_args, "youtube:player-client=android"} in res
     end
+
+    test "adds the typed PO-token provider argument only when configured", %{media_item: media_item} do
+      original_url = Application.get_env(:pinchflat, :po_token_provider_url)
+      on_exit(fn -> Application.put_env(:pinchflat, :po_token_provider_url, original_url) end)
+
+      Application.put_env(:pinchflat, :po_token_provider_url, "http://pot-provider:4416")
+
+      assert {:ok, res} = DownloadOptionBuilder.build(media_item)
+
+      assert {:extractor_args, "youtubepot-bgutilhttp:base_url=http://pot-provider:4416"} in res
+    end
   end
 
   describe "build/1 when testing subtitle options" do

--- a/test/pinchflat/yt_dlp/po_token_provider_test.exs
+++ b/test/pinchflat/yt_dlp/po_token_provider_test.exs
@@ -1,0 +1,84 @@
+defmodule Pinchflat.YtDlp.PoTokenProviderTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Pinchflat.YtDlp.PoTokenProvider
+
+  setup :verify_on_exit!
+
+  setup do
+    original_url = Application.get_env(:pinchflat, :po_token_provider_url)
+    Application.put_env(:pinchflat, :po_token_provider_url, nil)
+
+    on_exit(fn -> Application.put_env(:pinchflat, :po_token_provider_url, original_url) end)
+
+    :ok
+  end
+
+  describe "options/0" do
+    test "keeps provider options absent when disabled" do
+      assert PoTokenProvider.options() == []
+      assert PoTokenProvider.plugin_options() == []
+    end
+
+    test "builds the typed bgutil extractor argument when enabled" do
+      put_provider_url("http://pot-provider:4416")
+
+      assert PoTokenProvider.options() == [
+               {:extractor_args, "youtubepot-bgutilhttp:base_url=http://pot-provider:4416"}
+             ]
+    end
+
+    test "rejects credentials and query parameters" do
+      put_provider_url("http://user:secret@pot-provider:4416?token=should-not-be-used")
+
+      assert PoTokenProvider.options() == []
+      assert %{state: :invalid_configuration, label: "Invalid configuration"} = PoTokenProvider.status()
+    end
+  end
+
+  describe "status/0" do
+    test "reports disabled without making a request" do
+      assert %{state: :disabled, label: "Disabled", detail: detail} = PoTokenProvider.status()
+      assert detail =~ "POT_PROVIDER_URL"
+    end
+
+    test "reports a valid provider response as healthy" do
+      put_provider_url("http://pot-provider:4416")
+
+      expect(HTTPClientMock, :get, fn url, [], opts ->
+        assert url == "http://pot-provider:4416/ping"
+        assert opts[:pool_timeout] == 3_000
+        assert opts[:receive_timeout] == 3_000
+        assert opts[:request_timeout] == 3_000
+        {:ok, ~s({"server_uptime":12.5,"version":"2.0.0"})}
+      end)
+
+      assert %{state: :healthy, label: "Healthy"} = PoTokenProvider.status()
+    end
+
+    test "reports connection and timeout errors as unreachable" do
+      put_provider_url("http://pot-provider:4416")
+      expect(HTTPClientMock, :get, fn _url, _headers, _opts -> {:error, "request timed out"} end)
+
+      assert %{state: :unreachable, label: "Unreachable"} = PoTokenProvider.status()
+    end
+
+    test "reports malformed responses without exposing the response body" do
+      put_provider_url("http://pot-provider:4416")
+      secret_token = "secret-token-that-must-not-reach-the-page"
+
+      expect(HTTPClientMock, :get, fn _url, _headers, _opts ->
+        {:ok, ~s({"poToken":"#{secret_token}"})}
+      end)
+
+      status = PoTokenProvider.status()
+
+      assert status.state == :invalid_response
+      refute inspect(status) =~ secret_token
+    end
+  end
+
+  defp put_provider_url(url), do: Application.put_env(:pinchflat, :po_token_provider_url, url)
+end

--- a/test/pinchflat_web/controllers/diagnostics_controller_test.exs
+++ b/test/pinchflat_web/controllers/diagnostics_controller_test.exs
@@ -19,8 +19,45 @@ defmodule PinchflatWeb.DiagnosticsControllerTest do
 
       assert html_response(conn, 200) =~ "Diagnostics"
       assert html_response(conn, 200) =~ "Queue Health"
+      assert html_response(conn, 200) =~ "PO-token Provider"
+      assert html_response(conn, 200) =~ "Disabled"
       assert html_response(conn, 200) =~ "flex-col gap-3 sm:flex-row"
       assert html_response(conn, 200) =~ "flex w-full flex-col gap-3 sm:w-auto sm:flex-row"
+    end
+
+    test "shows a healthy configured provider without exposing response data", %{conn: conn} do
+      original_url = Application.get_env(:pinchflat, :po_token_provider_url)
+      Application.put_env(:pinchflat, :po_token_provider_url, "http://pot-provider:4416")
+
+      on_exit(fn -> Application.put_env(:pinchflat, :po_token_provider_url, original_url) end)
+
+      expect(HTTPClientMock, :get, fn _url, _headers, _opts ->
+        {:ok, ~s({"server_uptime":12.5,"version":"2.0.0","poToken":"must-not-render"})}
+      end)
+
+      conn = get(conn, ~p"/diagnostics")
+      html = html_response(conn, 200)
+
+      assert html =~ "Healthy"
+      refute html =~ "must-not-render"
+    end
+  end
+
+  describe "test_po_token_provider" do
+    test "returns a bounded flash result", %{conn: conn} do
+      original_url = Application.get_env(:pinchflat, :po_token_provider_url)
+      Application.put_env(:pinchflat, :po_token_provider_url, "http://pot-provider:4416")
+
+      on_exit(fn -> Application.put_env(:pinchflat, :po_token_provider_url, original_url) end)
+
+      expect(HTTPClientMock, :get, fn _url, _headers, _opts ->
+        {:ok, ~s({"server_uptime":1,"version":"2.0.0"})}
+      end)
+
+      conn = post(conn, ~p"/diagnostics/test_po_token_provider")
+
+      assert redirected_to(conn) == ~p"/diagnostics"
+      assert conn.assigns[:flash]["info"] == "PO-token provider is healthy."
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds opt-in POT_PROVIDER_URL support for the official bgutil-compatible PO-token provider, with typed yt-dlp options and bounded diagnostics.
- Adds a profile-gated, internal-only Compose service pinned to brainicism/bgutil-ytdlp-pot-provider:2.0.0, plus the matching plugin in both development and self-hosted images.
- Preserves the existing Docker fixes in docker/dev.Dockerfile and docker/selfhosted.Dockerfile, including the Node 24 image copy, architecture-aware Deno installation, and retry behavior.

## User-visible behavior

When POT_PROVIDER_URL is absent or blank, the provider is disabled and the existing container topology and yt-dlp command line remain unchanged. When configured, the app adds the provider base URL through the typed option builder and exposes only Disabled, Healthy, Unreachable, Invalid response, or Invalid configuration diagnostics. Provider responses and tokens are never rendered or logged.

Enable the optional service with the pot-provider Compose profile and set POT_PROVIDER_URL=http://pot-provider:4416. The provider has no host port mapping and does not become an application startup dependency.

## Compatibility and migration

No database migration is required. SQLite remains the default. Existing users do not need to change configuration. The provider image is profile-gated and the app remains usable when the provider is unavailable.

## Verification

- Docker image build: docker compose build phx passed; the pinned plugin archive was present and yt-dlp loaded from the image.
- Compose validation passed for the default, preview, CI, and pot-provider profile configurations.
- Targeted provider/builder/diagnostics tests: 69 passed.
- Extended touched-path tests: 337 passed.
- Additional yt-dlp/media/settings tests: 112 passed.
- Full docker compose run --rm phx mix check: compiler, formatter, Credo, Sobelow, unused-deps, and 1,624 ExUnit tests passed. The check reported only the existing mounted-workspace Prettier failure: EPERM: operation not permitted, scandir '/app/.agents/skills'.
- docker compose run --rm phx mix format --check-formatted passed.
- docker compose run --rm phx yarn run ui:check-theme passed.
- App smoke check: /healthcheck returned HTTP 200 and the diagnostics page rendered po-token-provider-status in the disabled state without exposing provider response data or tokens.
- DevTools MCP check: the configured surface returned no apps or browsers, so the required PR6 DOM matrix could not be executed. No browser/DOM PASS is claimed.
- Independent Sol verification: the requested gpt-5.6-sol forked verifier could not be spawned because this session exposes no model/fork execution tool. No Sol PASS is claimed; this limitation is recorded for review.

## Research references

- yt-dlp extractor arguments: https://github.com/yt-dlp/yt-dlp/blob/master/README.md
- yt-dlp PO Token Guide: https://github.com/yt-dlp/yt-dlp/wiki/PO-Token-Guide
- bgutil provider README and HTTP API: https://github.com/Brainicism/bgutil-ytdlp-pot-provider

## Non-goals

- No mandatory provider startup.
- No public provider port.
- No replacement of cookie authentication.
- No unrelated sidecars or later roadmap PRs.

No screenshots are attached because the configured DevTools browser surface was unavailable.