### PR TITLE
Add optional local download staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,39 @@ yt-dlp plugin, and Diagnostics reports the provider's bounded `/ping` health che
 [official bgutil provider documentation](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) and
 [yt-dlp's PO-token guide](https://github.com/yt-dlp/yt-dlp/wiki/PO-Token-Guide) for background and limitations.
 
+### Optional local download staging
+
+Set `DOWNLOAD_STAGING_PATH` to an absolute path inside the container when downloads should complete on a local disk
+before their finished artifacts are transferred to `/downloads`. The default is disabled, so existing deployments keep
+their current direct-to-library behavior. Each download receives its own directory, and the database is updated only
+after the complete artifact set reaches the media root.
+
+For a local staging disk, add a bind mount such as:
+
+```yaml
+services:
+  pinchyt:
+    environment:
+      DOWNLOAD_STAGING_PATH: /staging
+    volumes:
+      - ./download-staging:/staging
+```
+
+For a NAS library with local temporary storage, mount the local staging disk separately from the NAS destination:
+
+```yaml
+services:
+  pinchyt:
+    environment:
+      DOWNLOAD_STAGING_PATH: /staging
+    volumes:
+      - /fast-local-disk/pinchyt-staging:/staging
+      - /mnt/nas/media:/downloads
+```
+
+Staging and the media directory may be on different filesystems. PinchYT uses a temporary destination name and an
+atomic rename after copying in that case. Staging paths must be absolute, writable, and different from the media root.
+
 ## What PinchYT adds
 
 <table>

--- a/config/config.exs
+++ b/config/config.exs
@@ -18,6 +18,9 @@ config :pinchflat,
   apprise_runner: Pinchflat.Lifecycle.Notifications.CommandRunner,
   disk_space_checker: Pinchflat.Diagnostics.DiskSpaceChecker,
   media_directory: "/downloads",
+  # Optional local staging root for completed downloads. Nil preserves direct
+  # writes to media_directory.
+  download_staging_directory: nil,
   # The user may or may not store metadata for their needs, but the app will always store its copy
   metadata_directory: "/config/metadata",
   extras_directory: "/config/extras",

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -33,12 +33,27 @@ pot_provider_url =
       nil
   end
 
+download_staging_directory =
+  case System.get_env("DOWNLOAD_STAGING_PATH") do
+    value when is_binary(value) ->
+      case String.trim(value) do
+        "" -> nil
+        trimmed -> trimmed
+      end
+
+    _ ->
+      nil
+  end
+
 config :pinchflat,
   basic_auth_username: System.get_env("BASIC_AUTH_USERNAME"),
   basic_auth_password: System.get_env("BASIC_AUTH_PASSWORD"),
   # Optional bgutil PO-token provider. An absent or blank URL keeps the
   # provider disabled and preserves the existing yt-dlp command line.
-  po_token_provider_url: pot_provider_url
+  po_token_provider_url: pot_provider_url,
+  # Optional local download staging. An absent or blank path preserves direct
+  # writes to the configured media directory.
+  download_staging_directory: download_staging_directory
 
 # Optional OIDC/OAuth2 single sign-on. When all three of these are set,
 # the web UI requires logging in via the provider and BASIC_AUTH_* is

--- a/lib/pinchflat/boot/pre_job_startup_tasks.ex
+++ b/lib/pinchflat/boot/pre_job_startup_tasks.ex
@@ -15,6 +15,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
   alias Pinchflat.Repo
   alias Pinchflat.Settings
   alias Pinchflat.Utils.FilesystemUtils
+  alias Pinchflat.Downloading.DownloadStaging
 
   alias Pinchflat.Lifecycle.UserScripts.CommandRunner, as: UserScriptRunner
 
@@ -41,6 +42,7 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
 
   def init(state) do
     ensure_tmpfile_directory()
+    cleanup_stale_download_staging()
     reset_executing_jobs()
     revive_stalled_reconcile_jobs()
     create_blank_yt_dlp_files()
@@ -57,6 +59,20 @@ defmodule Pinchflat.Boot.PreJobStartupTasks do
     if !File.exists?(tmpfile_dir) do
       File.mkdir_p!(tmpfile_dir)
     end
+  end
+
+  defp cleanup_stale_download_staging do
+    active_media_item_ids =
+      Oban.Job
+      |> where(worker: "Pinchflat.Downloading.MediaDownloadWorker", state: "executing")
+      |> select([job], job.args)
+      |> Repo.all()
+      |> Enum.flat_map(fn
+        %{"id" => id} when is_integer(id) -> [id]
+        _ -> []
+      end)
+
+    DownloadStaging.cleanup_stale(active_media_item_ids)
   end
 
   # If a node cannot gracefully shut down, the currently executing jobs get stuck

--- a/lib/pinchflat/downloading/download_option_builder.ex
+++ b/lib/pinchflat/downloading/download_option_builder.ex
@@ -8,6 +8,7 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
   alias Pinchflat.Media.MediaItem
   alias Pinchflat.Downloading.OutputPathBuilder
   alias Pinchflat.Downloading.QualityOptionBuilder
+  alias Pinchflat.Downloading.DownloadStaging
   alias Pinchflat.YtDlp.PoTokenProvider
 
   alias Pinchflat.Utils.FilesystemUtils, as: FSUtils
@@ -20,18 +21,21 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
   def build(%MediaItem{} = media_item_with_preloads, override_opts \\ []) do
     media_profile = media_item_with_preloads.source.media_profile
 
-    built_options =
-      default_options(override_opts) ++
-        build_youtube_options_for(media_item_with_preloads) ++
-        subtitle_options(media_profile) ++
-        thumbnail_options(media_item_with_preloads) ++
-        metadata_options(media_profile) ++
-        quality_options(media_profile) ++
-        sponsorblock_options(media_profile) ++
-        output_options(media_item_with_preloads) ++
-        config_file_options(media_item_with_preloads)
+    with {:ok, output_options} <- output_options(media_item_with_preloads, override_opts),
+         {:ok, thumbnail_options} <- thumbnail_options(media_item_with_preloads, override_opts) do
+      built_options =
+        default_options(override_opts) ++
+          build_youtube_options_for(media_item_with_preloads) ++
+          subtitle_options(media_profile) ++
+          thumbnail_options ++
+          metadata_options(media_profile) ++
+          quality_options(media_profile) ++
+          sponsorblock_options(media_profile) ++
+          output_options ++
+          config_file_options(media_item_with_preloads)
 
-    {:ok, built_options}
+      {:ok, built_options}
+    end
   end
 
   @doc """
@@ -154,24 +158,27 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
     end)
   end
 
-  defp thumbnail_options(media_item_with_preloads) do
+  defp thumbnail_options(media_item_with_preloads, override_opts) do
     media_profile = media_item_with_preloads.source.media_profile
     mapped_struct = Map.from_struct(media_profile)
 
-    Enum.reduce(mapped_struct, [], fn attr, acc ->
-      case attr do
-        {:download_thumbnail, true} ->
-          thumbnail_save_location = determine_thumbnail_location(media_item_with_preloads)
+    with {:ok, thumbnail_save_location} <- determine_thumbnail_location(media_item_with_preloads, override_opts) do
+      options =
+        Enum.reduce(mapped_struct, [], fn attr, acc ->
+          case attr do
+            {:download_thumbnail, true} ->
+              acc ++ [:write_thumbnail, convert_thumbnail: "jpg", output: "thumbnail:#{thumbnail_save_location}"]
 
-          acc ++ [:write_thumbnail, convert_thumbnail: "jpg", output: "thumbnail:#{thumbnail_save_location}"]
+            {:embed_thumbnail, true} ->
+              acc ++ [:embed_thumbnail, convert_thumbnail: "jpg"]
 
-        {:embed_thumbnail, true} ->
-          acc ++ [:embed_thumbnail, convert_thumbnail: "jpg"]
+            _ ->
+              acc
+          end
+        end)
 
-        _ ->
-          acc
-      end
-    end)
+      {:ok, options}
+    end
   end
 
   defp metadata_options(media_profile) do
@@ -227,19 +234,36 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
     Enum.map(config_filepaths, fn filepath -> {:config_locations, filepath} end)
   end
 
-  defp output_options(media_item_with_preloads) do
-    [
-      output: build_output_path_for(media_item_with_preloads)
-    ]
+  defp output_options(media_item_with_preloads, override_opts) do
+    relative_output_path = build_relative_output_path(media_item_with_preloads)
+
+    case Keyword.get(override_opts, :staging_directory) do
+      nil ->
+        {:ok, [output: Path.join(base_directory(), relative_output_path)]}
+
+      staging_directory ->
+        with {:ok, output_path} <- DownloadStaging.output_path(staging_directory, relative_output_path) do
+          {:ok, [output: output_path]}
+        end
+    end
   end
 
   defp build_output_path(string, media_item_with_preloads, template_options) do
+    Path.join(base_directory(), build_relative_output_path(string, media_item_with_preloads, template_options))
+  end
+
+  defp build_relative_output_path(media_item_with_preloads) do
+    output_path_template = Sources.output_path_template(media_item_with_preloads.source)
+    build_relative_output_path(output_path_template, media_item_with_preloads, %{})
+  end
+
+  defp build_relative_output_path(string, media_item_with_preloads, template_options) do
     additional_options_map = Map.merge(output_options_map(media_item_with_preloads), template_options)
     {:ok, output_path} = OutputPathBuilder.build(string, additional_options_map)
     relative_output_path = output_path |> String.trim_leading("/") |> String.trim_leading("\\")
     source_subdirectory = media_item_with_preloads.source.download_subdirectory
 
-    [base_directory(), source_subdirectory, relative_output_path]
+    [source_subdirectory, relative_output_path]
     |> Enum.reject(&is_nil/1)
     |> Path.join()
   end
@@ -263,8 +287,18 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilder do
   # The thumbnail must share the media file's basename (differing only in
   # extension) for media center apps to pick it up as the episode thumbnail -
   # Plex in particular only matches an exactly-named sidecar image
-  defp determine_thumbnail_location(media_item_with_preloads) do
-    build_output_path_for(media_item_with_preloads)
+  defp determine_thumbnail_location(media_item_with_preloads, override_opts) do
+    if media_item_with_preloads.source.media_profile.download_thumbnail do
+      case Keyword.get(override_opts, :staging_directory) do
+        nil ->
+          {:ok, build_output_path_for(media_item_with_preloads)}
+
+        staging_directory ->
+          DownloadStaging.output_path(staging_directory, build_relative_output_path(media_item_with_preloads))
+      end
+    else
+      {:ok, nil}
+    end
   end
 
   defp pad_int(integer, count \\ 2, padding \\ "0") do

--- a/lib/pinchflat/downloading/download_staging.ex
+++ b/lib/pinchflat/downloading/download_staging.ex
@@ -1,0 +1,451 @@
+defmodule Pinchflat.Downloading.DownloadStaging do
+  @moduledoc """
+  Provides optional local staging for yt-dlp download artifacts.
+
+  A staging directory is created per download. Artifacts are kept there until
+  yt-dlp has completed, then moved or copied into the configured media root.
+  The database only receives paths after that transfer succeeds.
+  """
+
+  require Logger
+
+  alias Pinchflat.Diagnostics.DiskSpaceChecker
+
+  @directory_prefix "media-"
+  @stale_after_seconds 24 * 60 * 60
+  @minimum_free_bytes 1
+
+  @doc """
+  Returns the configured staging root, or nil when staging is disabled.
+
+  Returns binary() | nil.
+  """
+  def configured_directory do
+    case Application.get_env(:pinchflat, :download_staging_directory) do
+      value when is_binary(value) ->
+        case String.trim(value) do
+          "" -> nil
+          trimmed -> trimmed
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  @doc """
+  Validates the configured staging root without creating a download directory.
+
+  Returns :disabled | {:ok, binary()} | {:error, atom()}.
+  """
+  def validate_configuration do
+    case configured_directory() do
+      nil ->
+        :disabled
+
+      root ->
+        case validate_root(root) do
+          {:ok, validated_root} -> {:ok, validated_root}
+          {:error, reason} -> {:error, reason}
+        end
+    end
+  end
+
+  @doc """
+  Creates a unique staging directory for a media item.
+
+  Returns {:ok, binary() | nil} | {:error, atom()}.
+  """
+  def prepare(media_item_id) do
+    case validate_configuration() do
+      :disabled ->
+        {:ok, nil}
+
+      {:ok, root} ->
+        with :ok <- validate_media_item_id(media_item_id),
+             :ok <- check_disk_space(root),
+             directory = Path.join(root, "#{@directory_prefix}#{media_item_id}-#{Ecto.UUID.generate()}"),
+             :ok <- File.mkdir_p(directory) do
+          {:ok, directory}
+        else
+          {:error, reason} -> {:error, reason}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @doc """
+  Resolves a relative yt-dlp output path under a staging directory.
+
+  Returns {:ok, binary()} | {:error, :path_escape}.
+  """
+  def output_path(staging_directory, relative_path)
+      when is_binary(staging_directory) and is_binary(relative_path) do
+    root = Path.expand(staging_directory)
+    path = Path.expand(Path.join(staging_directory, relative_path))
+
+    if Path.type(relative_path) == :relative and path_under_directory?(path, root) and path != root do
+      {:ok, path}
+    else
+      {:error, :path_escape}
+    end
+  end
+
+  @doc """
+  Transfers all files referenced by a successful yt-dlp response into the
+  configured media directory and rewrites the response with final paths.
+
+  Missing optional sidecars are nulled so the database cannot retain a path
+  into the temporary directory. The main media file is required.
+
+  Returns {:ok, map()} | {:error, atom()}.
+  """
+  def transfer(parsed_json, staging_directory, opts \\ [])
+
+  def transfer(parsed_json, nil, _opts) when is_map(parsed_json), do: {:ok, parsed_json}
+
+  def transfer(parsed_json, staging_directory, opts) when is_map(parsed_json) and is_binary(staging_directory) do
+    with :ok <- validate_staging_directory(staging_directory),
+         {:ok, paths} <- artifact_paths(parsed_json),
+         {:ok, path_map} <- transfer_paths(paths, staging_directory, opts) do
+      {:ok, rewrite_paths(parsed_json, path_map)}
+    end
+  end
+
+  @doc """
+  Removes one download's staging directory. Invalid paths are ignored rather
+  than recursively deleting outside the configured root.
+
+  Returns :ok.
+  """
+  def cleanup(nil), do: :ok
+
+  def cleanup(staging_directory) when is_binary(staging_directory) do
+    case configured_directory() do
+      nil ->
+        :ok
+
+      root ->
+        expanded_root = Path.expand(root)
+        expanded_directory = Path.expand(staging_directory)
+
+        if expanded_directory != expanded_root and path_under_directory?(expanded_directory, expanded_root) do
+          _ = File.rm_rf(expanded_directory)
+        else
+          Logger.warning("Refusing to clean invalid download staging path")
+        end
+
+        :ok
+    end
+  end
+
+  @doc """
+  Removes old, unowned per-item staging directories.
+
+  Active media item IDs are preserved. The default age threshold is one day;
+  tests and maintenance callers may provide `stale_after_seconds`.
+
+  Returns :ok.
+  """
+  def cleanup_stale(active_media_item_ids \\ MapSet.new(), opts \\ []) do
+    case validate_configuration() do
+      :disabled ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Download staging cleanup skipped: #{inspect(reason)}")
+        :ok
+
+      {:ok, root} ->
+        active_ids = MapSet.new(active_media_item_ids)
+        stale_after_seconds = Keyword.get(opts, :stale_after_seconds, @stale_after_seconds)
+
+        case File.ls(root) do
+          {:ok, entries} ->
+            Enum.each(entries, fn entry ->
+              directory = Path.join(root, entry)
+
+              if stale_directory?(directory, entry, active_ids, stale_after_seconds) do
+                cleanup(directory)
+              end
+            end)
+
+          {:error, reason} ->
+            Logger.warning("Download staging cleanup could not list root: #{inspect(reason)}")
+        end
+
+        :ok
+    end
+  end
+
+  defp validate_root(root) do
+    if Path.type(root) != :absolute do
+      {:error, :staging_root_must_be_absolute}
+    else
+      validate_absolute_root(root)
+    end
+  end
+
+  defp validate_absolute_root(root) do
+    expanded_root = Path.expand(root)
+    media_root = Application.get_env(:pinchflat, :media_directory) |> Path.expand()
+
+    cond do
+      expanded_root == media_root ->
+        {:error, :staging_root_matches_media_root}
+
+      not ensure_directory(expanded_root) ->
+        {:error, :staging_root_unavailable}
+
+      not writable_directory?(expanded_root) ->
+        {:error, :staging_root_not_writable}
+
+      true ->
+        {:ok, expanded_root}
+    end
+  end
+
+  defp ensure_directory(directory) do
+    with :ok <- File.mkdir_p(directory),
+         {:ok, %{type: :directory}} <- File.stat(directory) do
+      true
+    else
+      _ -> false
+    end
+  end
+
+  defp writable_directory?(directory) do
+    probe = Path.join(directory, ".pinchyt-write-test-#{Ecto.UUID.generate()}")
+
+    case File.write(probe, "") do
+      :ok ->
+        _ = File.rm(probe)
+        true
+
+      {:error, _reason} ->
+        false
+    end
+  end
+
+  defp validate_media_item_id(media_item_id) when is_integer(media_item_id) and media_item_id > 0, do: :ok
+  defp validate_media_item_id(_media_item_id), do: {:error, :invalid_media_item_id}
+
+  defp check_disk_space(root) do
+    checker = Application.get_env(:pinchflat, :disk_space_checker, DiskSpaceChecker)
+
+    case checker.available_bytes(root) do
+      {:ok, available_bytes} when available_bytes >= @minimum_free_bytes ->
+        :ok
+
+      {:ok, _available_bytes} ->
+        {:error, :insufficient_staging_space}
+
+      :error ->
+        # A missing df utility should not make the optional feature unusable.
+        :ok
+    end
+  end
+
+  defp validate_staging_directory(staging_directory) do
+    case configured_directory() do
+      nil ->
+        {:error, :staging_disabled}
+
+      root ->
+        expanded_root = Path.expand(root)
+        expanded_directory = Path.expand(staging_directory)
+
+        cond do
+          expanded_directory == expanded_root -> {:error, :invalid_staging_directory}
+          not path_under_directory?(expanded_directory, expanded_root) -> {:error, :invalid_staging_directory}
+          not File.dir?(expanded_directory) -> {:error, :invalid_staging_directory}
+          true -> :ok
+        end
+    end
+  end
+
+  defp artifact_paths(parsed_json) do
+    case parsed_json["filepath"] do
+      filepath when is_binary(filepath) ->
+        sidecars =
+          [parsed_json["infojson_filename"]] ++
+            Enum.map(parsed_json["thumbnails"] || [], &Map.get(&1, "filepath")) ++
+            Enum.map(Map.values(parsed_json["requested_subtitles"] || %{}), &Map.get(&1, "filepath"))
+
+        optional_paths =
+          sidecars
+          |> Enum.filter(&is_binary/1)
+          |> Enum.uniq()
+          |> Enum.map(&{&1, false})
+
+        {:ok, [{filepath, true} | optional_paths]}
+
+      _ ->
+        {:error, :missing_media_filepath}
+    end
+  end
+
+  defp transfer_paths(paths, staging_directory, opts) do
+    Enum.reduce_while(paths, {:ok, %{}, []}, fn {source, required?}, {:ok, path_map, transferred} ->
+      case transfer_path(source, required?, staging_directory, opts) do
+        {:ok, destination, existed?} ->
+          {:cont, {:ok, Map.put(path_map, source, destination), [{destination, existed?} | transferred]}}
+
+        {:missing_optional, _destination} ->
+          {:cont, {:ok, Map.put(path_map, source, nil), transferred}}
+
+        {:error, reason} ->
+          rollback_transfers(transferred)
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, path_map, _transferred} -> {:ok, path_map}
+      error -> error
+    end
+  end
+
+  defp transfer_path(source, required?, staging_directory, opts) do
+    with {:ok, destination} <- destination_for(source, staging_directory),
+         {:ok, source_stat} <- File.stat(source) do
+      if source_stat.type == :regular do
+        destination_existed? = File.exists?(destination)
+
+        case move_file(source, destination, opts) do
+          :ok -> {:ok, destination, destination_existed?}
+          {:error, reason} -> {:error, reason}
+        end
+      else
+        {:error, :invalid_media_artifact}
+      end
+    else
+      {:error, :enoent} ->
+        if required? do
+          {:error, :missing_media_artifact}
+        else
+          case destination_for(source, staging_directory) do
+            {:ok, destination} -> {:missing_optional, destination}
+            {:error, reason} -> {:error, reason}
+          end
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp destination_for(source, staging_directory) do
+    expanded_source = Path.expand(source)
+    expanded_staging_directory = Path.expand(staging_directory)
+
+    cond do
+      not path_under_directory?(expanded_source, expanded_staging_directory) ->
+        {:error, :path_escape}
+
+      expanded_source == expanded_staging_directory ->
+        {:error, :invalid_media_artifact}
+
+      true ->
+        relative_path = Path.relative_to(expanded_source, expanded_staging_directory)
+        media_root = Application.get_env(:pinchflat, :media_directory) |> Path.expand()
+        {:ok, Path.expand(Path.join(media_root, relative_path))}
+    end
+  end
+
+  defp move_file(source, destination, opts) do
+    :ok = File.mkdir_p(Path.dirname(destination))
+
+    if Keyword.get(opts, :transfer_mode) == :copy do
+      copy_then_rename(source, destination)
+    else
+      case File.rename(source, destination) do
+        :ok ->
+          :ok
+
+        {:error, :exdev} ->
+          copy_then_rename(source, destination)
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp copy_then_rename(source, destination) do
+    temporary_destination = destination <> ".pinchyt-copy-#{Ecto.UUID.generate()}"
+
+    case File.cp(source, temporary_destination) do
+      :ok ->
+        case File.rename(temporary_destination, destination) do
+          :ok ->
+            File.rm(source)
+
+          {:error, reason} ->
+            _ = File.rm(temporary_destination)
+            {:error, reason}
+        end
+
+      {:error, reason} ->
+        _ = File.rm(temporary_destination)
+        {:error, reason}
+    end
+  end
+
+  defp rollback_transfers(transferred) do
+    Enum.each(transferred, fn {destination, existed?} ->
+      unless existed?, do: File.rm(destination)
+    end)
+  end
+
+  defp rewrite_paths(parsed_json, path_map) do
+    parsed_json
+    |> Map.update("filepath", nil, &Map.get(path_map, &1, &1))
+    |> Map.update("infojson_filename", nil, &rewrite_optional_path(&1, path_map))
+    |> Map.update("thumbnails", [], fn thumbnails ->
+      Enum.map(
+        thumbnails,
+        &Map.update(&1, "filepath", nil, fn filepath -> rewrite_optional_path(filepath, path_map) end)
+      )
+    end)
+    |> Map.update("requested_subtitles", %{}, fn requested_subtitles ->
+      Map.new(requested_subtitles, fn {language, attrs} ->
+        {language, Map.update(attrs, "filepath", nil, fn filepath -> rewrite_optional_path(filepath, path_map) end)}
+      end)
+    end)
+  end
+
+  defp rewrite_optional_path(nil, _path_map), do: nil
+  defp rewrite_optional_path(filepath, path_map), do: Map.get(path_map, filepath, filepath)
+
+  defp stale_directory?(directory, entry, active_ids, stale_after_seconds) do
+    with true <- String.starts_with?(entry, @directory_prefix),
+         {:ok, media_item_id} <- media_item_id_from_entry(entry),
+         false <- MapSet.member?(active_ids, media_item_id),
+         {:ok, %{type: :directory, mtime: mtime}} <- File.stat(directory, time: :posix) do
+      System.system_time(:second) - mtime >= stale_after_seconds
+    else
+      _ -> false
+    end
+  end
+
+  defp media_item_id_from_entry(entry) do
+    case Regex.run(~r/^media-(\d+)-/, entry, capture: :all_but_first) do
+      [id] -> {:ok, String.to_integer(id)}
+      _ -> {:error, :not_a_staging_directory}
+    end
+  end
+
+  defp path_under_directory?(path, directory) do
+    expanded_path = Path.expand(path)
+    expanded_directory = Path.expand(directory)
+
+    expanded_path == expanded_directory ||
+      String.starts_with?(expanded_path, expanded_directory <> directory_separator(expanded_directory))
+  end
+
+  defp directory_separator(path) do
+    if String.contains?(path, "\\"), do: "\\", else: "/"
+  end
+end

--- a/lib/pinchflat/downloading/media_download_worker.ex
+++ b/lib/pinchflat/downloading/media_download_worker.ex
@@ -149,6 +149,11 @@ defmodule Pinchflat.Downloading.MediaDownloadWorker do
         persist_download_failure(media_item, :transient, should_force)
         {:ok, :non_retry}
 
+      {:error, :staging_unavailable, message} ->
+        persist_download_failure(media_item, :permanent, should_force)
+        maybe_update_progress(job_id, %{progress_status: message})
+        {:ok, :non_retry}
+
       {:error, _error_atom, message} ->
         maybe_ignore_unavailable_media(media_item, job_id, message, should_force)
     end

--- a/lib/pinchflat/downloading/media_downloader.ex
+++ b/lib/pinchflat/downloading/media_downloader.ex
@@ -18,6 +18,7 @@ defmodule Pinchflat.Downloading.MediaDownloader do
   alias Pinchflat.Metadata.MetadataFileHelpers
   alias Pinchflat.Utils.FilesystemUtils
   alias Pinchflat.Downloading.DownloadOptionBuilder
+  alias Pinchflat.Downloading.DownloadStaging
 
   alias Pinchflat.YtDlp.Media, as: YtDlpMedia
 
@@ -82,31 +83,57 @@ defmodule Pinchflat.Downloading.MediaDownloader do
     output_filepath = FilesystemUtils.generate_metadata_tmpfile(:json)
     media_with_preloads = Repo.preload(media_item, [:metadata, source: :media_profile])
 
-    case download_with_options(media_item.original_url, media_with_preloads, output_filepath, override_opts) do
-      {:ok, parsed_json} ->
-        update_media_item_from_parsed_json(media_with_preloads, parsed_json)
+    case DownloadStaging.prepare(media_with_preloads.id) do
+      {:ok, staging_directory} ->
+        try do
+          download_override_opts = maybe_add_staging_directory(override_opts, staging_directory)
 
-      {:error, :unsuitable_for_download} ->
-        message =
-          "Media item ##{media_with_preloads.id} isn't suitable for download yet. May be an active or processing live stream"
+          case download_with_options(
+                 media_item.original_url,
+                 media_with_preloads,
+                 output_filepath,
+                 download_override_opts
+               ) do
+            {:ok, parsed_json} ->
+              case DownloadStaging.transfer(parsed_json, staging_directory) do
+                {:ok, transferred_json} ->
+                  update_media_item_from_parsed_json(media_with_preloads, transferred_json)
 
-        Logger.warning(message)
+                {:error, reason} ->
+                  {:error, :staging_unavailable, staging_error_message(reason)}
+              end
 
-        {:error, :unsuitable_for_download, message}
+            {:error, :unsuitable_for_download} ->
+              message =
+                "Media item ##{media_with_preloads.id} isn't suitable for download yet. May be an active or processing live stream"
 
-      {:error, message, _exit_code} ->
-        Logger.error("yt-dlp download error for media item ##{media_with_preloads.id}: #{inspect(message)}")
+              Logger.warning(message)
 
-        if String.contains?(to_string(message), recoverable_errors()) do
-          attempt_recovery_from_error(media_with_preloads, output_filepath, message)
-        else
-          {:error, :download_failed, message}
+              {:error, :unsuitable_for_download, message}
+
+            {:error, :staging_unavailable, message} ->
+              {:error, :staging_unavailable, message}
+
+            {:error, message, _exit_code} ->
+              Logger.error("yt-dlp download error for media item ##{media_with_preloads.id}: #{inspect(message)}")
+
+              if String.contains?(to_string(message), recoverable_errors()) && is_nil(staging_directory) do
+                attempt_recovery_from_error(media_with_preloads, output_filepath, message)
+              else
+                {:error, :download_failed, message}
+              end
+
+            err ->
+              Logger.error("Unknown error downloading media item ##{media_with_preloads.id}: #{inspect(err)}")
+
+              {:error, :unknown, "Unknown error: #{inspect(err)}"}
+          end
+        after
+          DownloadStaging.cleanup(staging_directory)
         end
 
-      err ->
-        Logger.error("Unknown error downloading media item ##{media_with_preloads.id}: #{inspect(err)}")
-
-        {:error, :unknown, "Unknown error: #{inspect(err)}"}
+      {:error, reason} ->
+        {:error, :staging_unavailable, staging_error_message(reason)}
     end
   end
 
@@ -163,7 +190,17 @@ defmodule Pinchflat.Downloading.MediaDownloader do
   defp download_with_options(url, item_with_preloads, output_filepath, override_opts) do
     emit_progress = Keyword.has_key?(override_opts, :progress_handler)
     build_opts = Keyword.put(override_opts, :emit_progress, emit_progress)
-    {:ok, options} = DownloadOptionBuilder.build(item_with_preloads, build_opts)
+
+    case DownloadOptionBuilder.build(item_with_preloads, build_opts) do
+      {:ok, options} ->
+        do_download_with_options(url, item_with_preloads, output_filepath, override_opts, options, emit_progress)
+
+      {:error, reason} ->
+        {:error, :staging_unavailable, staging_error_message(reason)}
+    end
+  end
+
+  defp do_download_with_options(url, item_with_preloads, output_filepath, override_opts, options, emit_progress) do
     force_use_cookies = Keyword.get(override_opts, :force_use_cookies, false)
     source_uses_cookies = Sources.use_cookies?(item_with_preloads.source, :downloading)
     should_use_cookies = force_use_cookies || source_uses_cookies
@@ -288,6 +325,16 @@ defmodule Pinchflat.Downloading.MediaDownloader do
       nil -> :ok
       progress_handler -> progress_handler.(attrs)
     end
+  end
+
+  defp maybe_add_staging_directory(override_opts, nil), do: override_opts
+
+  defp maybe_add_staging_directory(override_opts, staging_directory) do
+    Keyword.put(override_opts, :staging_directory, staging_directory)
+  end
+
+  defp staging_error_message(reason) do
+    "Download staging is unavailable: #{inspect(reason)}"
   end
 
   defp persisted_last_error(media_item, message) do

--- a/test/pinchflat/downloading/download_option_builder_test.exs
+++ b/test/pinchflat/downloading/download_option_builder_test.exs
@@ -33,6 +33,14 @@ defmodule Pinchflat.Downloading.DownloadOptionBuilderTest do
       assert {:output, "/tmp/test/media/#{media_item.source.custom_name}.%(ext)s"} in res
     end
 
+    test "routes yt-dlp output under the per-item staging directory when requested", %{media_item: media_item} do
+      staging_directory = "/tmp/test/staging/media-#{media_item.id}-unique"
+
+      assert {:ok, res} = DownloadOptionBuilder.build(media_item, staging_directory: staging_directory)
+
+      assert {:output, "#{staging_directory}/%(title)S.%(ext)s"} in res
+    end
+
     test "respects custom media_item-related output path options", %{media_item: media_item} do
       media_item =
         update_media_profile_attribute(media_item, %{output_path_template: "{{ media_upload_date_index }}.%(ext)s"})

--- a/test/pinchflat/downloading/download_staging_test.exs
+++ b/test/pinchflat/downloading/download_staging_test.exs
@@ -1,0 +1,166 @@
+defmodule Pinchflat.Downloading.DownloadStagingTest do
+  use ExUnit.Case, async: false
+
+  import Mox
+
+  alias Pinchflat.Downloading.DownloadStaging
+
+  setup do
+    media_root = Path.join(System.tmp_dir!(), "pinchyt-staging-media-#{System.unique_integer([:positive])}")
+    staging_root = Path.join(System.tmp_dir!(), "pinchyt-staging-root-#{System.unique_integer([:positive])}")
+    original_media_root = Application.get_env(:pinchflat, :media_directory)
+    original_staging_root = Application.get_env(:pinchflat, :download_staging_directory)
+    original_disk_checker = Application.get_env(:pinchflat, :disk_space_checker)
+
+    File.mkdir_p!(media_root)
+    File.mkdir_p!(staging_root)
+    Application.put_env(:pinchflat, :media_directory, media_root)
+    Application.put_env(:pinchflat, :download_staging_directory, staging_root)
+    stub(DiskSpaceCheckerMock, :available_bytes, fn _path -> {:ok, 1_000_000} end)
+
+    on_exit(fn ->
+      Application.put_env(:pinchflat, :media_directory, original_media_root)
+      Application.put_env(:pinchflat, :download_staging_directory, original_staging_root)
+      Application.put_env(:pinchflat, :disk_space_checker, original_disk_checker)
+      File.rm_rf!(media_root)
+      File.rm_rf!(staging_root)
+    end)
+
+    {:ok, media_root: media_root, staging_root: staging_root}
+  end
+
+  test "disabled configuration keeps the direct-download path unchanged" do
+    Application.put_env(:pinchflat, :download_staging_directory, nil)
+
+    assert DownloadStaging.configured_directory() == nil
+    assert DownloadStaging.validate_configuration() == :disabled
+    assert {:ok, nil} = DownloadStaging.prepare(1)
+    assert {:ok, parsed} = DownloadStaging.transfer(%{"filepath" => "/downloads/video.mp4"}, nil)
+    assert parsed["filepath"] == "/downloads/video.mp4"
+  end
+
+  test "validates an absolute writable root and rejects the media root", %{media_root: media_root} do
+    Application.put_env(:pinchflat, :download_staging_directory, "relative/staging")
+    assert DownloadStaging.validate_configuration() == {:error, :staging_root_must_be_absolute}
+
+    Application.put_env(:pinchflat, :download_staging_directory, media_root)
+    assert DownloadStaging.validate_configuration() == {:error, :staging_root_matches_media_root}
+  end
+
+  test "creates unique per-item directories inside the configured root", %{staging_root: staging_root} do
+    assert {:ok, first} = DownloadStaging.prepare(10)
+    assert {:ok, second} = DownloadStaging.prepare(10)
+    assert first != second
+    assert Path.dirname(first) == staging_root
+    assert Path.dirname(second) == staging_root
+    assert File.dir?(first)
+    assert File.dir?(second)
+
+    DownloadStaging.cleanup(first)
+    DownloadStaging.cleanup(second)
+    refute File.exists?(first)
+    refute File.exists?(second)
+  end
+
+  test "moves the complete artifact set and rewrites final paths", %{media_root: media_root} do
+    assert {:ok, staging_directory} = DownloadStaging.prepare(20)
+    paths = create_artifacts(staging_directory)
+
+    assert {:ok, transferred} = DownloadStaging.transfer(paths.metadata, staging_directory)
+    assert transferred["filepath"] == Path.join(media_root, "Shows/Example/video.mp4")
+    assert transferred["infojson_filename"] == Path.join(media_root, "Shows/Example/video.info.json")
+    assert transferred["requested_subtitles"]["en"]["filepath"] == Path.join(media_root, "Shows/Example/video.en.srt")
+    assert transferred["thumbnails"] == [%{"filepath" => Path.join(media_root, "Shows/Example/video.jpg")}]
+
+    Enum.each(paths.destination_files, fn filepath -> assert File.exists?(filepath) end)
+    Enum.each(paths.source_files, fn filepath -> refute File.exists?(filepath) end)
+    DownloadStaging.cleanup(staging_directory)
+    refute File.exists?(staging_directory)
+  end
+
+  test "uses copy to a destination temporary name before the final rename", %{media_root: media_root} do
+    assert {:ok, staging_directory} = DownloadStaging.prepare(21)
+    paths = create_artifacts(staging_directory)
+
+    assert {:ok, transferred} = DownloadStaging.transfer(paths.metadata, staging_directory, transfer_mode: :copy)
+    assert File.exists?(transferred["filepath"])
+    assert File.read!(transferred["filepath"]) == "video"
+    refute Enum.any?(Path.wildcard(Path.join(media_root, "**/*.pinchyt-copy-*")))
+    refute File.exists?(paths.metadata["filepath"])
+  end
+
+  test "rejects traversal and invalid identifiers without leaving files", %{staging_root: staging_root} do
+    assert {:ok, staging_directory} = DownloadStaging.prepare(22)
+    assert {:error, :path_escape} = DownloadStaging.output_path(staging_directory, "../outside/video.mp4")
+    assert {:error, :invalid_media_item_id} = DownloadStaging.prepare("../22")
+
+    outside_path = Path.join(staging_root, "../outside-video.mp4") |> Path.expand()
+    assert {:error, :path_escape} = DownloadStaging.transfer(%{"filepath" => outside_path}, staging_directory)
+    refute File.exists?(outside_path)
+    DownloadStaging.cleanup(staging_directory)
+  end
+
+  test "requires the media artifact and cleans a failed attempt", %{staging_root: staging_root} do
+    assert {:ok, staging_directory} = DownloadStaging.prepare(23)
+    missing_media = Path.join(staging_directory, "missing/video.mp4")
+
+    assert {:error, :missing_media_artifact} =
+             DownloadStaging.transfer(%{"filepath" => missing_media}, staging_directory)
+
+    DownloadStaging.cleanup(staging_directory)
+    assert File.ls!(staging_root) == []
+  end
+
+  test "stale cleanup skips an active media item", %{staging_root: staging_root} do
+    assert {:ok, active_directory} = DownloadStaging.prepare(24)
+    assert {:ok, stale_directory} = DownloadStaging.prepare(25)
+    unrelated_directory = Path.join(staging_root, "keep-me")
+    File.mkdir_p!(unrelated_directory)
+
+    assert :ok = DownloadStaging.cleanup_stale([24], stale_after_seconds: 0)
+    assert File.dir?(active_directory)
+    refute File.exists?(stale_directory)
+    assert File.dir?(unrelated_directory)
+  end
+
+  test "returns a useful error when staging has no free space" do
+    stub(DiskSpaceCheckerMock, :available_bytes, fn _path -> {:ok, 0} end)
+
+    assert {:error, :insufficient_staging_space} = DownloadStaging.prepare(26)
+  end
+
+  defp create_artifacts(staging_directory) do
+    source_files =
+      Enum.map(
+        [
+          "Shows/Example/video.mp4",
+          "Shows/Example/video.info.json",
+          "Shows/Example/video.en.srt",
+          "Shows/Example/video.jpg"
+        ],
+        &Path.join(staging_directory, &1)
+      )
+
+    Enum.zip(source_files, ["video", "{}", "subtitles", "thumbnail"])
+    |> Enum.each(fn {filepath, contents} ->
+      File.mkdir_p!(Path.dirname(filepath))
+      File.write!(filepath, contents)
+    end)
+
+    metadata = %{
+      "filepath" => Enum.at(source_files, 0),
+      "infojson_filename" => Enum.at(source_files, 1),
+      "requested_subtitles" => %{"en" => %{"filepath" => Enum.at(source_files, 2)}},
+      "thumbnails" => [%{"filepath" => Enum.at(source_files, 3)}]
+    }
+
+    destination_files =
+      Enum.map(source_files, fn filepath ->
+        filepath
+        |> Path.relative_to(staging_directory)
+        |> then(&Path.join(Application.get_env(:pinchflat, :media_directory), &1))
+      end)
+
+    %{metadata: metadata, source_files: source_files, destination_files: destination_files}
+  end
+end

--- a/test/pinchflat/downloading/media_downloader_staging_test.exs
+++ b/test/pinchflat/downloading/media_downloader_staging_test.exs
@@ -1,0 +1,102 @@
+defmodule Pinchflat.Downloading.MediaDownloaderStagingTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.MediaFixtures
+
+  alias Pinchflat.Downloading.MediaDownloader
+
+  setup do
+    media_root = Path.join(System.tmp_dir!(), "pinchyt-downloader-media-#{System.unique_integer([:positive])}")
+    staging_root = Path.join(System.tmp_dir!(), "pinchyt-downloader-staging-#{System.unique_integer([:positive])}")
+    original_media_root = Application.get_env(:pinchflat, :media_directory)
+    original_staging_root = Application.get_env(:pinchflat, :download_staging_directory)
+    original_disk_checker = Application.get_env(:pinchflat, :disk_space_checker)
+
+    File.mkdir_p!(media_root)
+    File.mkdir_p!(staging_root)
+    Application.put_env(:pinchflat, :media_directory, media_root)
+    Application.put_env(:pinchflat, :download_staging_directory, staging_root)
+    stub(DiskSpaceCheckerMock, :available_bytes, fn _path -> {:ok, 1_000_000} end)
+
+    on_exit(fn ->
+      Application.put_env(:pinchflat, :media_directory, original_media_root)
+      Application.put_env(:pinchflat, :download_staging_directory, original_staging_root)
+      Application.put_env(:pinchflat, :disk_space_checker, original_disk_checker)
+      File.rm_rf!(media_root)
+      File.rm_rf!(staging_root)
+    end)
+
+    media_item = media_item_fixture(%{title: "Staged download", media_filepath: nil})
+
+    {:ok, media_item: media_item, staging_root: staging_root}
+  end
+
+  test "transfers completed artifacts before persisting final paths", %{
+    media_item: media_item,
+    staging_root: staging_root
+  } do
+    expect(YtDlpRunnerMock, :run, 3, fn
+      _url, :get_downloadable_status, _opts, _output_template, _addl_opts ->
+        {:ok, "{}"}
+
+      _url, :download, opts, _output_template, _addl_opts ->
+        output_template = Keyword.fetch!(opts, :output)
+        artifact_directory = Path.dirname(output_template)
+        media_filepath = Path.join(artifact_directory, "video.mp4")
+        infojson_filepath = Path.join(artifact_directory, "video.info.json")
+        subtitle_filepath = Path.join(artifact_directory, "video.en.srt")
+        thumbnail_filepath = Path.join(artifact_directory, "video.jpg")
+
+        Enum.each(
+          [
+            {media_filepath, "video"},
+            {infojson_filepath, "{}"},
+            {subtitle_filepath, "subtitles"},
+            {thumbnail_filepath, "thumbnail"}
+          ],
+          fn {filepath, contents} ->
+            File.mkdir_p!(Path.dirname(filepath))
+            File.write!(filepath, contents)
+          end
+        )
+
+        metadata =
+          render_parsed_metadata(:media_metadata)
+          |> Map.merge(%{
+            "filepath" => media_filepath,
+            "infojson_filename" => infojson_filepath,
+            "requested_subtitles" => %{"en" => %{"filepath" => subtitle_filepath}},
+            "thumbnails" => [%{"filepath" => thumbnail_filepath}]
+          })
+
+        {:ok, Phoenix.json_library().encode!(metadata)}
+
+      _url, :download_thumbnail, _opts, _output_template, _addl_opts ->
+        {:ok, ""}
+    end)
+
+    assert {:ok, updated_media_item} = MediaDownloader.download_for_media_item(media_item)
+    assert File.exists?(updated_media_item.media_filepath)
+    assert String.starts_with?(updated_media_item.media_filepath, Application.get_env(:pinchflat, :media_directory))
+    assert File.ls!(staging_root) == []
+  end
+
+  test "cleans an item staging directory after yt-dlp failure without updating the database", %{
+    media_item: media_item,
+    staging_root: staging_root
+  } do
+    expect(YtDlpRunnerMock, :run, 2, fn
+      _url, :get_downloadable_status, _opts, _output_template, _addl_opts ->
+        {:ok, "{}"}
+
+      _url, :download, _opts, _output_template, _addl_opts ->
+        {:error, "temporary transfer failure", 1}
+    end)
+
+    assert {:error, :download_failed, "temporary transfer failure"} =
+             MediaDownloader.download_for_media_item(media_item)
+
+    assert Repo.reload!(media_item).media_filepath == nil
+    assert File.ls!(staging_root) == []
+  end
+end


### PR DESCRIPTION
## Summary

- Add an opt-in DOWNLOAD_STAGING_PATH local staging root with per-media-item directories.
- Keep yt-dlp artifacts out of the media library until the complete artifact set transfers successfully.
- Support same-filesystem moves and cross-filesystem copy-to-temporary-then-rename transfers, with cleanup, stale-job protection, traversal validation, and disk-space checks.

## Behavior

- Staging is disabled by default; deployments without DOWNLOAD_STAGING_PATH retain direct-to-library behavior.
- The configured staging root must be absolute, writable, and different from the media root.
- The database is updated only after final paths are in the media directory.
- Failed downloads and stale directories are cleaned safely; active executing jobs are preserved.
- README documents local-disk and NAS-library bind-mount examples.

## Verification

- Targeted staging/download-option/media-downloader tests: 99 passed.
- Downloading and startup-task tests: 225 passed.
- Full Docker ExUnit suite: 1,636 passed, 0 failures.
- Docker compiler, formatter, Credo, Sobelow, and unused-deps stages passed.
- docker compose config -q, mix format --check-formatted, and git diff --check passed.
- PinchYT restarted successfully; /healthcheck returned HTTP 200.
- mix check still reports the known container Prettier permission failure while scanning /app/.agents/skills; no PR7 formatting failure was reported.
- The required DevTools DOM matrix could not run because the connected CUA reported no browser/apps.
- The requested independent Sol verifier is unavailable in this execution environment; no Sol PASS is claimed.

## Scope notes

- priv/repo/erd.png was restored and is not included.
- plans/ remains untracked and was not included.
- docker/dev.Dockerfile and docker/selfhosted.Dockerfile were preserved unchanged; their prior Docker fixes remain on master.
- No later roadmap PR is included.