### PR TITLE
Add source metadata field locks

### DIFF
--- a/lib/pinchflat/metadata/source_metadata_storage_worker.ex
+++ b/lib/pinchflat/metadata/source_metadata_storage_worker.ex
@@ -56,19 +56,21 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
            fetch_source_metadata_and_images(series_directory, source) do
       source_metadata_filepath = MetadataFileHelpers.compress_and_store_metadata_for(source, source_metadata)
 
+      metadata_attrs =
+        %{
+          series_directory: series_directory,
+          nfo_filepath: store_source_nfo(source, series_directory, source_metadata),
+          metadata: Map.merge(%{metadata_filepath: source_metadata_filepath}, metadata_image_attrs)
+        }
+        |> put_if_binary(:custom_name, source_name_from_metadata(source, source_metadata))
+        |> put_if_binary(:description, source_metadata["description"])
+
       Sources.update_source(
         source,
-        Map.merge(
-          %{
-            series_directory: series_directory,
-            nfo_filepath: store_source_nfo(source, series_directory, source_metadata),
-            description: source_metadata["description"],
-            metadata: Map.merge(%{metadata_filepath: source_metadata_filepath}, metadata_image_attrs)
-          },
-          source_image_attrs
-        ),
+        Map.merge(metadata_attrs, source_image_attrs),
         # `run_post_commit_tasks: false` prevents this from running in an infinite loop
-        run_post_commit_tasks: false
+        run_post_commit_tasks: false,
+        automated_metadata_refresh: true
       )
 
       :ok
@@ -182,6 +184,26 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorker do
 
     MediaCollection.get_source_metadata(source.original_url, opts, use_cookies: should_use_cookies)
   end
+
+  defp source_name_from_metadata(source, metadata) do
+    name_keys =
+      case source.collection_type do
+        :channel -> ["channel", "uploader", "title"]
+        :playlist -> ["playlist_title", "playlist", "title"]
+        :video -> ["title"]
+        _ -> ["title", "channel", "uploader"]
+      end
+
+    Enum.find_value(name_keys, fn key ->
+      case metadata[key] do
+        value when is_binary(value) and value != "" -> value
+        _ -> nil
+      end
+    end)
+  end
+
+  defp put_if_binary(attrs, key, value) when is_binary(value), do: Map.put(attrs, key, value)
+  defp put_if_binary(attrs, _key, _value), do: attrs
 
   defp tmp_directory do
     Application.get_env(:pinchflat, :tmpfile_directory)

--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -39,7 +39,9 @@ defmodule Pinchflat.Sources.Source do
     collection_id
     collection_type
     custom_name
+    custom_name_locked
     description
+    description_locked
     nfo_filepath
     poster_filepath
     fanart_filepath
@@ -97,7 +99,9 @@ defmodule Pinchflat.Sources.Source do
     field :uuid, Ecto.UUID
 
     field :custom_name, :string
+    field :custom_name_locked, :boolean, default: false
     field :description, :string
+    field :description_locked, :boolean, default: false
     field :collection_name, :string
     field :collection_id, :string
     field :collection_type, Ecto.Enum, values: [:channel, :playlist, :video]

--- a/lib/pinchflat/sources/sources.ex
+++ b/lib/pinchflat/sources/sources.ex
@@ -24,6 +24,11 @@ defmodule Pinchflat.Sources do
   alias Pinchflat.FastIndexing.FastIndexingHelpers
   alias Pinchflat.Metadata.SourceMetadataStorageWorker
 
+  @automated_metadata_lock_fields %{
+    custom_name: :custom_name_locked,
+    description: :description_locked
+  }
+
   @doc """
   Returns the configured path to the shared cookie file.
 
@@ -509,6 +514,8 @@ defmodule Pinchflat.Sources do
   Returns {:ok, %Source{}} | {:error, %Ecto.Changeset{}}
   """
   def update_source(%Source{} = source, attrs, opts \\ []) do
+    attrs = maybe_apply_automated_metadata_locks(source, attrs, opts)
+
     case change_source(source, attrs, :initial) do
       %Ecto.Changeset{valid?: true} ->
         source
@@ -568,6 +575,27 @@ defmodule Pinchflat.Sources do
   """
   def change_source(%Source{} = source, attrs \\ %{}, validation_stage \\ :pre_insert) do
     Source.changeset(source, attrs, validation_stage)
+  end
+
+  @doc """
+  Removes source metadata fields protected by their lock flags when an
+  automated metadata refresh is being applied.
+
+  User-initiated changes are not filtered by this function unless the caller
+  explicitly opts into the automated refresh contract in `update_source/3`.
+
+  Returns a map with locked automated fields removed.
+  """
+  def apply_automated_metadata_locks(%Source{} = source, attrs) when is_map(attrs) do
+    Enum.reduce(@automated_metadata_lock_fields, attrs, fn {field, lock_field}, filtered_attrs ->
+      if Map.get(source, lock_field, false) do
+        filtered_attrs
+        |> Map.delete(field)
+        |> Map.delete(Atom.to_string(field))
+      else
+        filtered_attrs
+      end
+    end)
   end
 
   @doc """
@@ -1079,6 +1107,14 @@ defmodule Pinchflat.Sources do
     end
 
     :ok
+  end
+
+  defp maybe_apply_automated_metadata_locks(source, attrs, opts) do
+    if Keyword.get(opts, :automated_metadata_refresh, false) do
+      apply_automated_metadata_locks(source, attrs)
+    else
+      attrs
+    end
   end
 
   defp availability_policy_changed?(changes) do

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -59,11 +59,34 @@
       x-init="$el.focus()"
       x-model.fill="sourceUrl"
     />
+    <h3 class="mt-8 text-2xl text-theme-on-surface">Source Metadata</h3>
+    <p class="mt-2 max-w-prose text-sm text-theme-on-surface-muted">
+      Name and description are refreshed from source metadata unless you lock the individual field. Locked fields
+      can still be edited and saved here; the lock only affects automated refreshes.
+    </p>
     <.input
       field={f[:custom_name]}
       type="text"
-      label="Custom Name"
-      help="Does not impact indexing or downloading. Will be inferred from the source if left blank"
+      label="Source Name"
+      help="The name shown throughout PinchYT. It will be refreshed from source metadata unless locked."
+    />
+    <.input
+      field={f[:custom_name_locked]}
+      type="toggle"
+      label="Lock Source Name"
+      help="Keep the current name when automated metadata refreshes run."
+    />
+    <.input
+      field={f[:description]}
+      type="textarea"
+      label="Description"
+      help="The source description shown in PinchYT. It will be refreshed from source metadata unless locked."
+    />
+    <.input
+      field={f[:description_locked]}
+      type="toggle"
+      label="Lock Description"
+      help="Keep the current description when automated metadata refreshes run."
     />
     <.input
       field={f[:media_profile_id]}

--- a/lib/pinchflat_web/schemas.ex
+++ b/lib/pinchflat_web/schemas.ex
@@ -118,11 +118,21 @@ defmodule PinchflatWeb.Schemas do
         },
         enabled: %Schema{type: :boolean, description: "Whether the source is active", example: true},
         custom_name: %Schema{type: :string, description: "Display name for the source", example: "My Channel"},
+        custom_name_locked: %Schema{
+          type: :boolean,
+          description: "Whether automated metadata refreshes may change the display name",
+          example: false
+        },
         description: %Schema{
           type: :string,
           nullable: true,
           description: "Source description",
           example: "A collection of videos"
+        },
+        description_locked: %Schema{
+          type: :boolean,
+          description: "Whether automated metadata refreshes may change the description",
+          example: false
         },
         collection_name: %Schema{
           type: :string,
@@ -481,7 +491,15 @@ defmodule PinchflatWeb.Schemas do
           type: :object,
           properties: %{
             custom_name: %Schema{type: :string, description: "Custom display name"},
+            custom_name_locked: %Schema{
+              type: :boolean,
+              description: "Prevent automated metadata refreshes from changing the display name"
+            },
             description: %Schema{type: :string, description: "Source description"},
+            description_locked: %Schema{
+              type: :boolean,
+              description: "Prevent automated metadata refreshes from changing the description"
+            },
             enabled: %Schema{type: :boolean, description: "Whether the source is active"},
             download_media: %Schema{type: :boolean, description: "Download media items"},
             download_public_media: %Schema{type: :boolean, description: "Download public and unlisted media"},

--- a/priv/repo/migrations/20260910160000_add_source_metadata_locks.exs
+++ b/priv/repo/migrations/20260910160000_add_source_metadata_locks.exs
@@ -1,0 +1,10 @@
+defmodule Pinchflat.Repo.Migrations.AddSourceMetadataLocks do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sources) do
+      add :custom_name_locked, :boolean, default: false, null: false
+      add :description_locked, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
+++ b/test/pinchflat/metadata/source_metadata_storage_worker_test.exs
@@ -167,6 +167,104 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
 
       assert source.description == "This is a test file for Pinchflat"
     end
+
+    test "unlocked name and description are refreshed" do
+      stub_metadata_refresh(%{"channel" => "Refreshed Source", "description" => "Refreshed description"})
+      source = source_fixture(%{custom_name: "Old Source", description: "Old description"})
+
+      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+
+      source = Repo.reload!(source)
+      assert source.custom_name == "Refreshed Source"
+      assert source.description == "Refreshed description"
+    end
+
+    test "a locked name remains while an unlocked description refreshes" do
+      stub_metadata_refresh(%{"channel" => "Refreshed Source", "description" => "Refreshed description"})
+      source = source_fixture(%{custom_name: "Pinned Source", custom_name_locked: true, description: "Old description"})
+
+      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+
+      source = Repo.reload!(source)
+      assert source.custom_name == "Pinned Source"
+      assert source.description == "Refreshed description"
+    end
+
+    test "a locked description remains while an unlocked name refreshes" do
+      stub_metadata_refresh(%{"channel" => "Refreshed Source", "description" => "Refreshed description"})
+      source = source_fixture(%{custom_name: "Old Source", description: "Pinned description", description_locked: true})
+
+      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+
+      source = Repo.reload!(source)
+      assert source.custom_name == "Refreshed Source"
+      assert source.description == "Pinned description"
+    end
+
+    test "both locked fields remain unchanged" do
+      stub_metadata_refresh(%{"channel" => "Refreshed Source", "description" => "Refreshed description"})
+
+      source =
+        source_fixture(%{
+          custom_name: "Pinned Source",
+          custom_name_locked: true,
+          description: "Pinned description",
+          description_locked: true
+        })
+
+      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+
+      source = Repo.reload!(source)
+      assert source.custom_name == "Pinned Source"
+      assert source.description == "Pinned description"
+      assert source.custom_name_locked
+      assert source.description_locked
+    end
+
+    test "unlocking a field allows the next refresh to update it" do
+      stub_metadata_refresh(%{"channel" => "Refreshed Source", "description" => "Refreshed description"})
+      source = source_fixture(%{custom_name: "Pinned Source", custom_name_locked: true})
+
+      assert {:ok, source} = Sources.update_source(source, %{custom_name_locked: false})
+      assert :ok = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+
+      source = Repo.reload!(source)
+      assert source.custom_name == "Refreshed Source"
+      refute source.custom_name_locked
+    end
+
+    test "a user can edit a locked field" do
+      source = source_fixture(%{custom_name_locked: true, description_locked: true})
+
+      assert {:ok, source} =
+               Sources.update_source(source, %{
+                 custom_name: "User Name",
+                 description: "User description"
+               })
+
+      assert source.custom_name == "User Name"
+      assert source.description == "User description"
+      assert source.custom_name_locked
+      assert source.description_locked
+    end
+
+    test "a failed refresh preserves metadata values and lock state" do
+      stub(YtDlpRunnerMock, :run, fn
+        _url, :get_source_details, _opts, _ot, _addl -> {:ok, source_details_return_fixture()}
+        _url, :get_source_metadata, _opts, _ot, _addl -> {:error, "metadata unavailable", 1}
+      end)
+
+      source =
+        source_fixture(%{custom_name: "Existing Source", custom_name_locked: true, description: "Existing description"})
+
+      assert {:error, :source_metadata_fetch_failed} = perform_job(SourceMetadataStorageWorker, %{id: source.id})
+
+      source = Repo.reload!(source)
+      assert source.custom_name == "Existing Source"
+      assert source.description == "Existing description"
+      assert source.custom_name_locked
+      refute source.description_locked
+    end
   end
 
   describe "perform/1 when testing metadata storage" do
@@ -540,5 +638,15 @@ defmodule Pinchflat.Metadata.SourceMetadataStorageWorkerTest do
 
       refute source.nfo_filepath
     end
+  end
+
+  defp stub_metadata_refresh(metadata) do
+    stub(YtDlpRunnerMock, :run, fn
+      _url, :get_source_details, _opts, _ot, _addl ->
+        {:ok, source_details_return_fixture()}
+
+      _url, :get_source_metadata, _opts, _ot, _addl ->
+        {:ok, Phoenix.json_library().encode!(metadata)}
+    end)
   end
 end

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -95,6 +95,9 @@ defmodule PinchflatWeb.SourceControllerTest do
     test "renders form", %{conn: conn} do
       conn = get(conn, ~p"/sources/new")
       assert html_response(conn, 200) =~ "New Source"
+      assert html_response(conn, 200) =~ "Source Metadata"
+      assert html_response(conn, 200) =~ "Lock Source Name"
+      assert html_response(conn, 200) =~ "Lock Description"
       assert html_response(conn, 200) =~ "Delay Automatic Download"
       assert html_response(conn, 200) =~ "Download Public and Unlisted Media"
       assert html_response(conn, 200) =~ "Download Members-only Media"
@@ -289,7 +292,11 @@ defmodule PinchflatWeb.SourceControllerTest do
 
     test "renders form for editing chosen source", %{conn: conn, source: source} do
       conn = get(conn, ~p"/sources/#{source}/edit")
-      assert html_response(conn, 200) =~ "Editing \"#{source.custom_name}\""
+      response = html_response(conn, 200)
+      assert response =~ "Editing \"#{source.custom_name}\""
+      assert response =~ "name=\"source[description]\""
+      assert response =~ "name=\"source[custom_name_locked]\""
+      assert response =~ "name=\"source[description_locked]\""
     end
 
     test "renders restore automatic downloads action for manual playlists", %{conn: conn} do

--- a/test/pinchflat_web/controllers/sources/source_controller_api_test.exs
+++ b/test/pinchflat_web/controllers/sources/source_controller_api_test.exs
@@ -32,6 +32,8 @@ defmodule PinchflatWeb.Sources.SourceControllerApiTest do
       assert response["id"] == source.id
       assert response["uuid"] == source.uuid
       assert response["custom_name"] == source.custom_name
+      assert response["custom_name_locked"] == false
+      assert response["description_locked"] == false
     end
 
     test "returns 404 for non-existent source", %{conn: conn} do
@@ -78,7 +80,10 @@ defmodule PinchflatWeb.Sources.SourceControllerApiTest do
 
       attrs = %{
         "source" => %{
-          "custom_name" => "Updated Name"
+          "custom_name" => "Updated Name",
+          "description" => "Updated description",
+          "custom_name_locked" => "true",
+          "description_locked" => "true"
         },
         "_format" => "json"
       }
@@ -91,6 +96,9 @@ defmodule PinchflatWeb.Sources.SourceControllerApiTest do
       # Verify the source was updated
       updated_source = Sources.get_source!(source.id)
       assert updated_source.custom_name == "Updated Name"
+      assert updated_source.description == "Updated description"
+      assert updated_source.custom_name_locked
+      assert updated_source.description_locked
     end
   end
 


### PR DESCRIPTION
## Summary

- Add persisted `custom_name_locked` and `description_locked` source fields with a migration and API schema coverage.
- Centralize automated metadata refresh filtering so each locked field is preserved while user and API saves can still edit it.
- Add a Source Metadata editor with independent lock controls and coverage for refresh, lock/unlock, user-edit, failure-preservation, API, and form behavior.

## Verification

- Targeted PR8 suites: 231 tests, 0 failures.
- Full ExUnit suite in Docker: 1,643 tests, 0 failures.
- `mix format --check-formatted`: passed.
- `git diff --check`: passed.
- Docker `mix check`: compiler, formatter, Credo, Sobelow, unused-deps, and ExUnit stages passed. The only failure is the known environment issue where Prettier cannot scan the mounted `/app/.agents/skills` path (`EPERM`).
- Applied the PR8 migration in the development database and verified `/healthcheck` with HTTP 200.

## Verification limits

- DevTools MCP/CUA reported no visible apps or browsers, so the required browser DOM matrix could not be executed here.
- This session has no independent model-spawn interface, so the requested `gpt-5.6-sol` verifier was unavailable; no Sol PASS is being claimed.

Generated `priv/repo/erd.png` was restored and is not part of this PR. The user-owned untracked `plans/` directory is preserved and unstaged. `docker/dev.Dockerfile` and `docker/selfhosted.Dockerfile` were preserved unchanged.