### PR TITLE
Allow source type selection during creation

### DIFF
--- a/lib/pinchflat/sources/source.ex
+++ b/lib/pinchflat/sources/source.ex
@@ -33,11 +33,19 @@ defmodule Pinchflat.Sources.Source do
   @player_client_values Keyword.values(@player_client_options)
   @cookie_incompatible_player_clients [:android, :ios, :tv_simply]
 
+  @source_type_options [
+    {"Automatic", :automatic},
+    {"Channel", :channel},
+    {"Playlist", :playlist},
+    {"Video", :video}
+  ]
+
   @allowed_fields ~w(
     enabled
     collection_name
     collection_id
     collection_type
+    source_type
     custom_name
     custom_name_locked
     description
@@ -105,6 +113,7 @@ defmodule Pinchflat.Sources.Source do
     field :collection_name, :string
     field :collection_id, :string
     field :collection_type, Ecto.Enum, values: [:channel, :playlist, :video]
+    field :source_type, Ecto.Enum, values: [:automatic, :channel, :playlist, :video], virtual: true, default: :automatic
     field :index_frequency_minutes, :integer, default: 60 * 24
     field :fast_index, :boolean, default: false
     field :cookie_behaviour, Ecto.Enum, values: [:disabled, :when_needed, :all_operations], default: :disabled
@@ -202,6 +211,14 @@ defmodule Pinchflat.Sources.Source do
     Keyword.get(@player_client_options, player_client, to_string(player_client))
   end
 
+  @doc """
+  Returns the source-type choices shown while creating a source.
+
+  The selected value is transient form state. The persisted source type remains
+  collection_type, which is populated from inspected source metadata.
+  """
+  def source_type_options, do: @source_type_options
+
   @doc false
   def index_frequency_when_fast_indexing do
     # 30 days in minutes
@@ -221,7 +238,7 @@ defmodule Pinchflat.Sources.Source do
 
   @doc false
   def json_exluded_fields do
-    ~w(__meta__ __struct__ metadata tasks media_items custom_poster_filename)a
+    ~w(__meta__ __struct__ metadata tasks media_items custom_poster_filename source_type)a
   end
 
   @doc false

--- a/lib/pinchflat/sources/sources.ex
+++ b/lib/pinchflat/sources/sources.ex
@@ -708,6 +708,7 @@ defmodule Pinchflat.Sources do
 
   defp add_source_details_to_changeset(source, changeset) do
     original_url = changeset.changes.original_url
+    source_type = Ecto.Changeset.get_field(changeset, :source_type, :automatic)
     should_use_cookies = Ecto.Changeset.get_field(changeset, :cookie_behaviour) == :all_operations
     # Skipping sleep interval since this is UI blocking and we want to keep this as fast as possible
     command_opts =
@@ -716,54 +717,105 @@ defmodule Pinchflat.Sources do
 
     addl_opts = [use_cookies: should_use_cookies, skip_sleep_interval: true]
 
-    case MediaCollection.get_source_details(original_url, command_opts, addl_opts) do
+    case MediaCollection.get_source_details(
+           original_url,
+           command_opts,
+           Keyword.put(addl_opts, :source_type, source_type)
+         ) do
       {:ok, source_details} ->
         add_source_details_by_collection_type(source, changeset, source_details)
 
       err ->
-        runner_error =
-          case err do
-            {:error, error_msg, _status_code} -> error_msg
-            {:error, error_msg} -> error_msg
-          end
-
         Ecto.Changeset.add_error(
           changeset,
           :original_url,
-          "could not fetch source details from URL",
-          error: runner_error
+          source_details_error_message(source_type),
+          error: source_details_error(err)
         )
     end
   end
 
   defp add_source_details_by_collection_type(source, changeset, source_details) do
     %Ecto.Changeset{changes: changes} = changeset
+    source_type = Ecto.Changeset.get_field(changeset, :source_type, :automatic)
+    detected_type = detected_source_type(source_details)
 
-    collection_changes =
-      if source_details.source_type == :video do
-        %{
-          collection_type: :video,
-          collection_id: source_details.video_id,
-          collection_name: source_details.video_title
-        }
-      else
-        if source_details.playlist_id == source_details.channel_id do
-          %{
-            collection_type: :channel,
-            collection_id: source_details.channel_id,
-            collection_name: source_details.channel_name
-          }
-        else
-          %{
-            collection_type: :playlist,
-            collection_id: source_details.playlist_id,
-            collection_name: source_details.playlist_name
-          }
-        end
-      end
+    cond do
+      detected_type == :unknown ->
+        Ecto.Changeset.add_error(
+          changeset,
+          :original_url,
+          "could not determine whether this URL is a channel, playlist, or video; choose Automatic or check the URL"
+        )
+
+      source_type != :automatic and source_type != detected_type ->
+        Ecto.Changeset.add_error(changeset, :original_url, source_type_mismatch_message(source_type, detected_type))
+
+      true ->
+        add_detected_source_details(source, changeset, source_details, changes, detected_type)
+    end
+  end
+
+  defp add_detected_source_details(source, _changeset, source_details, changes, :video) do
+    collection_changes = %{
+      collection_type: :video,
+      collection_id: source_details.video_id,
+      collection_name: source_details.video_title
+    }
 
     change_source(source, Map.merge(changes, collection_changes))
   end
+
+  defp add_detected_source_details(source, _changeset, source_details, changes, :channel) do
+    collection_changes = %{
+      collection_type: :channel,
+      collection_id: source_details.channel_id,
+      collection_name: source_details.channel_name
+    }
+
+    change_source(source, Map.merge(changes, collection_changes))
+  end
+
+  defp add_detected_source_details(source, _changeset, source_details, changes, :playlist) do
+    collection_changes = %{
+      collection_type: :playlist,
+      collection_id: source_details.playlist_id,
+      collection_name: source_details.playlist_name
+    }
+
+    change_source(source, Map.merge(changes, collection_changes))
+  end
+
+  defp detected_source_type(%{detected_type: detected_type}), do: detected_type
+
+  defp detected_source_type(%{source_type: :video}), do: :video
+
+  defp detected_source_type(%{playlist_id: playlist_id, channel_id: channel_id})
+       when is_binary(channel_id) and channel_id == playlist_id,
+       do: :channel
+
+  defp detected_source_type(%{playlist_id: playlist_id}) when is_binary(playlist_id), do: :playlist
+  defp detected_source_type(_source_details), do: :unknown
+
+  defp source_type_mismatch_message(expected, detected) do
+    "the selected source type is #{source_type_label(expected)}, but this URL resolves to a " <>
+      "#{source_type_label(detected)}; choose #{source_type_label(detected)} or Automatic"
+  end
+
+  defp source_details_error_message(:automatic), do: "could not fetch source details from URL"
+
+  defp source_details_error_message(source_type) do
+    "could not inspect this URL as a #{source_type_label(source_type)}; check the URL or choose Automatic"
+  end
+
+  defp source_details_error({:error, error_msg, _status_code}), do: error_msg
+  defp source_details_error({:error, error_msg}), do: error_msg
+  defp source_details_error(error), do: error
+
+  defp source_type_label(:automatic), do: "Automatic"
+  defp source_type_label(:channel), do: "Channel"
+  defp source_type_label(:playlist), do: "Playlist"
+  defp source_type_label(:video), do: "Video"
 
   defp maybe_change_indexing_frequency(changeset) do
     changeset

--- a/lib/pinchflat/yt_dlp/media_collection.ex
+++ b/lib/pinchflat/yt_dlp/media_collection.ex
@@ -75,13 +75,36 @@ defmodule Pinchflat.YtDlp.MediaCollection do
   we need, so instead we're fetching just the first video (using playlist_end: 1)
   and parsing the source ID and name from _its_ metadata
 
+  The optional source_type runner option accepts automatic, channel, playlist,
+  or video. Automatic preserves URL-based detection. Explicit video inspection
+  uses --no-playlist; explicit channel and playlist inspection use the
+  collection inspection path so the caller can validate the returned metadata.
+
   Returns {:ok, map()} | {:error, any, ...}.
   """
   def get_source_details(source_url, command_opts \\ [], addl_opts \\ []) do
-    if Source.youtube_video_url?(source_url) do
-      get_single_video_source_details(source_url, command_opts, addl_opts)
-    else
-      get_collection_source_details(source_url, command_opts, addl_opts)
+    {source_type, addl_opts} = Keyword.pop(addl_opts, :source_type, :automatic)
+
+    case source_type do
+      :automatic ->
+        if Source.youtube_video_url?(source_url) do
+          get_single_video_source_details(source_url, command_opts, addl_opts)
+        else
+          get_collection_source_details(source_url, command_opts, addl_opts)
+        end
+
+      :video ->
+        if Source.supported_youtube_url?(source_url) and not Source.youtube_video_url?(source_url) do
+          {:error, "URL is not a single video"}
+        else
+          get_single_video_source_details(source_url, command_opts, addl_opts)
+        end
+
+      type when type in [:channel, :playlist] ->
+        get_collection_source_details(source_url, command_opts, addl_opts)
+
+      source_type ->
+        {:error, "unsupported source type: #{inspect(source_type)}"}
     end
   end
 
@@ -119,10 +142,12 @@ defmodule Pinchflat.YtDlp.MediaCollection do
     action = :get_source_details
 
     with {:ok, output} <- backend_runner().run(source_url, action, all_command_opts, output_template, addl_opts),
-         {:ok, parsed_json} <- Phoenix.json_library().decode(output) do
-      {:ok, format_single_video_source_details(parsed_json)}
+         {:ok, parsed_json} <- Phoenix.json_library().decode(output),
+         {:ok, source_details} <- format_single_video_source_details(parsed_json) do
+      {:ok, source_details}
     else
       {:error, %Jason.DecodeError{}} -> {:error, "Error decoding JSON response"}
+      {:error, :not_a_video} -> {:error, "URL did not resolve to a single video"}
       err -> err
     end
   end
@@ -167,6 +192,7 @@ defmodule Pinchflat.YtDlp.MediaCollection do
     # NOTE: I should probably make this a struct some day
     %{
       source_type: :collection,
+      detected_type: detected_collection_type(response),
       channel_id: response["channel_id"],
       channel_name: response["channel"],
       playlist_id: response["playlist_id"],
@@ -179,17 +205,30 @@ defmodule Pinchflat.YtDlp.MediaCollection do
   end
 
   defp format_single_video_source_details(response) do
-    %{
-      source_type: :video,
-      video_id: response["id"],
-      video_title: response["title"],
-      channel_id: response["channel_id"],
-      channel_name: response["channel"],
-      playlist_id: response["playlist_id"],
-      playlist_name: response["playlist_title"],
-      filepath: response["filename"]
-    }
+    if is_binary(response["id"]) and is_binary(response["title"]) do
+      {:ok,
+       %{
+         source_type: :video,
+         detected_type: :video,
+         video_id: response["id"],
+         video_title: response["title"],
+         channel_id: response["channel_id"],
+         channel_name: response["channel"],
+         playlist_id: response["playlist_id"],
+         playlist_name: response["playlist_title"],
+         filepath: response["filename"]
+       }}
+    else
+      {:error, :not_a_video}
+    end
   end
+
+  defp detected_collection_type(%{"channel_id" => channel_id, "playlist_id" => playlist_id})
+       when is_binary(channel_id) and channel_id == playlist_id,
+       do: :channel
+
+  defp detected_collection_type(%{"playlist_id" => playlist_id}) when is_binary(playlist_id), do: :playlist
+  defp detected_collection_type(_response), do: :unknown
 
   defp backend_runner do
     # This approach lets us mock the command for testing

--- a/lib/pinchflat_web/controllers/sources/source_controller.ex
+++ b/lib/pinchflat_web/controllers/sources/source_controller.ex
@@ -141,7 +141,9 @@ defmodule PinchflatWeb.Sources.SourceController do
                   media_profiles: media_profiles(),
                   available_folders: available_media_directories(),
                   current_path: ~p"/sources/new",
-                  layout: get_onboarding_layout()
+                  layout: get_onboarding_layout(),
+                  new_source: true,
+                  show_delay_automatic_download: true
                 ],
                 cookie_file_assigns()
               )

--- a/lib/pinchflat_web/controllers/sources/source_html.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html.ex
@@ -3,6 +3,7 @@ defmodule PinchflatWeb.Sources.SourceHTML do
 
   alias Pinchflat.Sources
   alias Pinchflat.Sources.CustomPoster
+  alias Pinchflat.Sources.Source
 
   embed_templates "source_html/*"
 
@@ -20,6 +21,7 @@ defmodule PinchflatWeb.Sources.SourceHTML do
   attr :cookie_file_contents, :string, default: nil
   attr :available_folders, :list, default: []
   attr :show_delay_automatic_download, :boolean, default: false
+  attr :new_source, :boolean, default: false
 
   def source_form(assigns)
 

--- a/lib/pinchflat_web/controllers/sources/source_html/new.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/new.html.heex
@@ -20,6 +20,7 @@
         cookie_file_configured={@cookie_file_configured}
         cookie_file_contents={@cookie_file_contents}
         show_delay_automatic_download={true}
+        new_source={true}
       />
     </div>
   </div>

--- a/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/source_form.html.heex
@@ -13,9 +13,26 @@
     {
       mediaProfileId: null,
       sourceUrl: '',
+      sourceType: '#{Ecto.Changeset.get_field(@changeset, :source_type, :automatic)}',
       cutoffDate: '#{f[:download_cutoff_date].value}',
       indexCutoffDate: '#{f[:index_cutoff_date].value}',
       isPlaylist: #{Ecto.Changeset.get_field(@changeset, :collection_type) == :playlist},
+      get sourceTypeLabel() {
+        return {
+          automatic: 'Source URL',
+          channel: 'Channel URL',
+          playlist: 'Playlist URL',
+          video: 'Video URL'
+        }[this.sourceType] || 'Source URL'
+      },
+      get sourceTypeHelp() {
+        return {
+          automatic: 'URL of a channel, playlist, or single video (required). Automatic detection preserves existing PinchYT behavior.',
+          channel: 'URL of a YouTube channel (required). PinchYT will reject a URL that resolves to a playlist or video.',
+          playlist: 'URL of a YouTube playlist (required). PinchYT will reject a URL that resolves to a channel or video.',
+          video: 'URL of a single YouTube video (required). Video sources are indexed once and fast indexing is disabled automatically.'
+        }[this.sourceType] || 'URL of a channel, playlist, or single video (required).'
+      },
       get looksLikePlaylist() { return this.isPlaylist || /[?&]list=|\\/playlist/.test(this.sourceUrl) },
       get indexCutoffAfterDownloadCutoff() {
         return !!(this.indexCutoffDate && this.cutoffDate && this.indexCutoffDate > this.cutoffDate)
@@ -51,7 +68,28 @@
       </div>
     </section>
 
+    <section :if={@new_source}>
+      <.input
+        field={f[:source_type]}
+        options={Source.source_type_options()}
+        type="select"
+        label="Source Type"
+        help="Choose Automatic to keep PinchYT's existing URL detection, or select the type you expect before inspection."
+        x-model="sourceType"
+      />
+      <label for={f[:original_url].id} class="mt-5 mb-2 inline-block text-md font-medium text-theme-on-surface">
+        <span x-text="sourceTypeLabel"></span>
+      </label>
+      <.input
+        field={f[:original_url]}
+        type="text"
+        x-init="$el.focus()"
+        x-model.fill="sourceUrl"
+      />
+      <p class="mt-1 text-sm leading-5 text-theme-on-surface-muted" x-text="sourceTypeHelp"></p>
+    </section>
     <.input
+      :if={!@new_source}
       field={f[:original_url]}
       type="text"
       label="Source URL"

--- a/test/pinchflat/sources_test.exs
+++ b/test/pinchflat/sources_test.exs
@@ -316,6 +316,77 @@ defmodule Pinchflat.SourcesTest do
       assert source.index_frequency_minutes == 0
     end
 
+    test "creates a source when the explicit channel type matches inspected metadata" do
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
+
+      attrs = %{
+        media_profile_id: media_profile_fixture().id,
+        original_url: "https://www.youtube.com/channel/abc123",
+        source_type: :channel
+      }
+
+      assert {:ok, %Source{collection_type: :channel}} =
+               Sources.create_source(attrs, run_post_commit_tasks: false)
+    end
+
+    test "creates a source when the explicit playlist type matches inspected metadata" do
+      expect(YtDlpRunnerMock, :run, &playlist_mock/5)
+
+      attrs = %{
+        media_profile_id: media_profile_fixture().id,
+        original_url: "https://www.youtube.com/playlist?list=abc123",
+        source_type: :playlist
+      }
+
+      assert {:ok, %Source{collection_type: :playlist}} =
+               Sources.create_source(attrs, run_post_commit_tasks: false)
+    end
+
+    test "creates a source when the explicit video type matches inspected metadata" do
+      expect(YtDlpRunnerMock, :run, &video_mock/5)
+
+      attrs = %{
+        media_profile_id: media_profile_fixture().id,
+        original_url: "https://www.youtube.com/watch?v=72maj9FLQZI",
+        source_type: :video
+      }
+
+      assert {:ok, %Source{collection_type: :video}} =
+               Sources.create_source(attrs, run_post_commit_tasks: false)
+    end
+
+    test "rejects an explicit type when inspected metadata resolves to another type" do
+      expect(YtDlpRunnerMock, :run, &channel_mock/5)
+
+      attrs = %{
+        media_profile_id: media_profile_fixture().id,
+        original_url: "https://www.youtube.com/channel/abc123",
+        source_type: :playlist
+      }
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Sources.create_source(attrs, run_post_commit_tasks: false)
+
+      assert errors_on(changeset).original_url == [
+               "the selected source type is Playlist, but this URL resolves to a Channel; choose Channel or Automatic"
+             ]
+    end
+
+    test "rejects an explicit video type for an obvious channel URL without inspection" do
+      attrs = %{
+        media_profile_id: media_profile_fixture().id,
+        original_url: "https://www.youtube.com/channel/abc123",
+        source_type: :video
+      }
+
+      assert {:error, %Ecto.Changeset{} = changeset} =
+               Sources.create_source(attrs, run_post_commit_tasks: false)
+
+      assert errors_on(changeset).original_url == [
+               "could not inspect this URL as a Video; check the URL or choose Automatic"
+             ]
+    end
+
     test "adds an error if the runner fails" do
       expect(YtDlpRunnerMock, :run, fn _url, :get_source_details, _opts, _ot, _addl -> {:error, "some error", 1} end)
 

--- a/test/pinchflat/yt_dlp/media_collection_test.exs
+++ b/test/pinchflat/yt_dlp/media_collection_test.exs
@@ -201,6 +201,32 @@ defmodule Pinchflat.YtDlp.MediaCollectionTest do
                filepath: "/tmp/test/media/one-off.mp4"
              } = res
     end
+
+    test "explicit video inspection uses no-playlist and preserves video metadata" do
+      expect(YtDlpRunnerMock, :run, fn @video_url, :get_source_details, opts, _ot, addl_opts ->
+        assert :no_playlist in opts
+        refute Keyword.has_key?(addl_opts, :source_type)
+
+        {:ok,
+         Phoenix.json_library().encode!(%{
+           id: "72maj9FLQZI",
+           title: "One-Off Video",
+           channel: "PinchflatTestChannel",
+           channel_id: "UCQH2",
+           playlist_id: nil,
+           playlist_title: nil,
+           filename: "/tmp/test/media/one-off.mp4"
+         })}
+      end)
+
+      assert {:ok, %{detected_type: :video}} =
+               MediaCollection.get_source_details(@video_url, [], source_type: :video)
+    end
+
+    test "rejects an obvious channel or playlist URL selected as a video before inspection" do
+      assert {:error, "URL is not a single video"} =
+               MediaCollection.get_source_details(@channel_url, [], source_type: :video)
+    end
   end
 
   describe "get_source_metadata/1" do

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -95,19 +95,31 @@ defmodule PinchflatWeb.SourceControllerTest do
   describe "new source" do
     test "renders form", %{conn: conn} do
       conn = get(conn, ~p"/sources/new")
-      assert html_response(conn, 200) =~ "New Source"
-      assert html_response(conn, 200) =~ "Source Metadata"
-      assert html_response(conn, 200) =~ "Lock Source Name"
-      assert html_response(conn, 200) =~ "Lock Description"
-      assert html_response(conn, 200) =~ "Delay Automatic Download"
-      assert html_response(conn, 200) =~ "Download Public and Unlisted Media"
-      assert html_response(conn, 200) =~ "Download Members-only Media"
-      assert html_response(conn, 200) =~ "YouTube Player Client"
-      assert html_response(conn, 200) =~ "Default"
-      assert html_response(conn, 200) =~ "Web Creator"
-      assert html_response(conn, 200) =~ "Members-only media may fail without cookies"
-      assert html_response(conn, 200) =~ "How source folders work"
-      assert html_response(conn, 200) =~ "Insert media profile template"
+      response = html_response(conn, 200)
+
+      assert response =~ "New Source"
+      assert response =~ "Source Type"
+      assert response =~ "Automatic"
+      assert response =~ "Channel"
+      assert response =~ "Playlist"
+      assert response =~ "Video"
+      assert response =~ "Channel URL"
+      assert response =~ "Playlist URL"
+      assert response =~ "Video URL"
+      assert response =~ "preserves existing PinchYT behavior."
+      refute response =~ ~S(PinchYT\'s)
+      assert response =~ "Source Metadata"
+      assert response =~ "Lock Source Name"
+      assert response =~ "Lock Description"
+      assert response =~ "Delay Automatic Download"
+      assert response =~ "Download Public and Unlisted Media"
+      assert response =~ "Download Members-only Media"
+      assert response =~ "YouTube Player Client"
+      assert response =~ "Default"
+      assert response =~ "Web Creator"
+      assert response =~ "Members-only media may fail without cookies"
+      assert response =~ "How source folders work"
+      assert response =~ "Insert media profile template"
     end
 
     test "renders source folder picker options from existing media directories", %{conn: conn} do
@@ -183,6 +195,24 @@ defmodule PinchflatWeb.SourceControllerTest do
     test "renders errors when data is invalid", %{conn: conn, invalid_attrs: invalid_attrs} do
       conn = post(conn, ~p"/sources", source: invalid_attrs)
       assert html_response(conn, 200) =~ "New Source"
+    end
+
+    test "preserves the selected source type and URL after an inspection error", %{
+      conn: conn,
+      create_attrs: create_attrs
+    } do
+      source_attrs =
+        Map.merge(create_attrs, %{
+          source_type: "video",
+          original_url: "https://www.youtube.com/channel/explicit-video-mismatch"
+        })
+
+      response = conn |> post(~p"/sources", source: source_attrs) |> html_response(200)
+
+      assert response =~ "could not inspect this URL as a Video"
+      assert response =~ ~r/name="source\[source_type\]"[^>]*value="video"/
+      assert response =~ "https://www.youtube.com/channel/explicit-video-mismatch"
+      assert response =~ "Video URL"
     end
 
     test "renders a cookie compatibility error for the selected player client", %{


### PR DESCRIPTION
## Summary

- Add a transient source type choice to the New Source form: Automatic, Channel, Playlist, or Video.
- Preserve Automatic URL detection while validating explicit type selections against yt-dlp metadata.
- Show type-specific URL labels and help, preserve form state after safe validation errors, and retain single-video behavior.

## Verification

- Docker targeted suite: 219 tests, 0 failures.
- Full PR10 suite: 1,673 tests, 0 failures.
- `mix format --check-formatted` passed.
- `mix compile --warnings-as-errors` passed.
- `yarn run ui:check-theme` passed.
- `mix sobelow --config` passed with only the repository's existing low-confidence findings.
- DevTools page 3 verified Automatic default, Channel/Playlist/Video labels and help, safe validation state retention, LiveView connectivity, and no new source-type or x-data console errors.

The draft PR is intentionally left unmerged for independent verification.