### PR TITLE
Add a poster-grid source library view

### DIFF
--- a/lib/pinchflat_web/components/core_components.ex
+++ b/lib/pinchflat_web/components/core_components.ex
@@ -301,6 +301,7 @@ defmodule PinchflatWeb.CoreComponents do
   attr :options, :list, doc: "the options to pass to Phoenix.HTML.Form.options_for_select/2"
   attr :multiple, :boolean, default: false, doc: "the multiple flag for select inputs"
   attr :inputclass, :string, default: ""
+  attr :aria_label, :string, default: nil
 
   attr :rest, :global, include: ~w(accept autocomplete capture cols disabled form list max maxlength min minlength
                 multiple pattern placeholder readonly required rows size step)
@@ -400,6 +401,7 @@ defmodule PinchflatWeb.CoreComponents do
             value="true"
             checked={@checked}
             class="peer sr-only"
+            aria-label={@aria_label}
             {@rest}
           />
           <div class="block h-8 w-14 rounded-full border border-theme-outline bg-theme-surface-5 shadow-inner transition peer-checked:border-theme-primary/70 peer-checked:bg-theme-primary-container peer-disabled:opacity-50">

--- a/lib/pinchflat_web/controllers/sources/source_html/index.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/index.html.heex
@@ -28,6 +28,7 @@
         session: %{
           "initial_sort_key" => :custom_name,
           "initial_sort_direction" => :asc,
+          "initial_view_mode" => :table,
           "results_per_page" => 10
         }
       )}

--- a/lib/pinchflat_web/controllers/sources/source_live/index_table_live.ex
+++ b/lib/pinchflat_web/controllers/sources/source_live/index_table_live.ex
@@ -9,9 +9,41 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLive do
   alias Pinchflat.Repo
   alias Pinchflat.Sources.Source
   alias Pinchflat.Media.MediaItem
+  alias PinchflatWeb.Sources.SourceHTML
+
+  @default_view_mode :table
 
   def source_download_mode_label(%{selection_mode: :manual}), do: "Delayed Downloads"
   def source_download_mode_label(%{selection_mode: _selection_mode}), do: "Automatic Downloads"
+
+  @doc """
+  Returns the poster URL used by the source library card.
+
+  The endpoint applies the same artwork fallback as the podcast feed, so a
+  source poster, fanart image, or downloaded media thumbnail can be used.
+  """
+  def source_poster_url(source), do: source |> source_struct() |> SourceHTML.poster_preview_url()
+
+  @doc """
+  Returns the initials used while a source poster is unavailable.
+  """
+  def source_initials(source), do: SourceHTML.source_initials(source)
+
+  @doc """
+  Describes source download progress without treating an unknown or empty
+  denominator as complete.
+
+  Returns a map with `:state`, `:label`, and either a `:percent` or `nil`.
+  """
+  def source_progress(%{media_count: nil}),
+    do: %{state: :unknown, label: "Progress unavailable: total unknown", percent: nil}
+
+  def source_progress(%{media_count: 0}), do: %{state: :empty, label: "No indexed media yet", percent: 0}
+
+  def source_progress(%{media_count: total, downloaded_count: downloaded}) when total > 0 do
+    percent = min(div(downloaded * 100, total), 100)
+    %{state: :known, label: "#{downloaded} of #{total} indexed items downloaded", percent: percent}
+  end
 
   def mount(_params, session, socket) do
     limit = session["results_per_page"]
@@ -20,7 +52,8 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLive do
       Map.merge(
         %{
           sort_key: session["initial_sort_key"],
-          sort_direction: session["initial_sort_direction"]
+          sort_direction: session["initial_sort_direction"],
+          view_mode: normalize_view_mode(session["initial_view_mode"])
         },
         get_pagination_attributes(sources_query(), 1, limit)
       )
@@ -54,6 +87,14 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLive do
     |> then(&{:noreply, &1})
   end
 
+  def handle_event("view_change", %{"view" => view_mode}, socket) do
+    {:noreply, assign(socket, :view_mode, normalize_view_mode(view_mode))}
+  end
+
+  def handle_info({:source_enabled_updated, _source_id}, socket) do
+    {:noreply, set_sources(socket)}
+  end
+
   defp sort_attr(:pending_count), do: dynamic([s, mp, dl, pe], pe.pending_count)
   defp sort_attr(:downloaded_count), do: dynamic([s, mp, dl], dl.downloaded_count)
   defp sort_attr(:media_size_bytes), do: dynamic([s, mp, dl], dl.media_size_bytes)
@@ -61,6 +102,12 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLive do
   defp sort_attr(:custom_name), do: dynamic([s], fragment("? COLLATE NOCASE", s.custom_name))
   defp sort_attr(:enabled), do: dynamic([s], s.enabled)
   defp sort_attr(:collection_type), do: dynamic([s], s.collection_type)
+
+  defp normalize_view_mode(mode) when mode in [:grid, "grid"], do: :grid
+  defp normalize_view_mode(_mode), do: @default_view_mode
+
+  defp source_struct(%Source{} = source), do: source
+  defp source_struct(source), do: struct(Source, source)
 
   defp set_sources(%{assigns: assigns} = socket) do
     sources =
@@ -92,6 +139,13 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLive do
         group_by: m.source_id
       )
 
+    indexed_subquery =
+      from(
+        m in MediaItem,
+        select: %{media_count: count(m.id), source_id: m.source_id},
+        group_by: m.source_id
+      )
+
     from s in Source,
       as: :source,
       inner_join: mp in assoc(s, :media_profile),
@@ -99,13 +153,16 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLive do
       on: d.source_id == s.id,
       left_join: p in subquery(pending_subquery),
       on: p.source_id == s.id,
+      left_join: i in subquery(indexed_subquery),
+      on: i.source_id == s.id,
       where: is_nil(s.marked_for_deletion_at) and is_nil(mp.marked_for_deletion_at),
       preload: [media_profile: mp],
       select: map(s, ^Source.__schema__(:fields)),
       select_merge: %{
         downloaded_count: coalesce(d.downloaded_count, 0),
         pending_count: coalesce(p.pending_count, 0),
-        media_size_bytes: coalesce(d.media_size_bytes, 0)
+        media_size_bytes: coalesce(d.media_size_bytes, 0),
+        media_count: coalesce(i.media_count, 0)
       }
   end
 end

--- a/lib/pinchflat_web/controllers/sources/source_live/index_table_live.ex
+++ b/lib/pinchflat_web/controllers/sources/source_live/index_table_live.ex
@@ -155,8 +155,9 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLive do
       on: p.source_id == s.id,
       left_join: i in subquery(indexed_subquery),
       on: i.source_id == s.id,
+      left_join: md in assoc(s, :metadata),
       where: is_nil(s.marked_for_deletion_at) and is_nil(mp.marked_for_deletion_at),
-      preload: [media_profile: mp],
+      preload: [media_profile: mp, metadata: md],
       select: map(s, ^Source.__schema__(:fields)),
       select_merge: %{
         downloaded_count: coalesce(d.downloaded_count, 0),

--- a/lib/pinchflat_web/controllers/sources/source_live/index_table_live.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_live/index_table_live.html.heex
@@ -1,162 +1,59 @@
 <div>
-  <div class="space-y-4 md:hidden">
-    <article :for={source <- @sources} class="theme-surface-accent space-y-4 rounded-m3-lg p-4">
-      <div class="flex items-center justify-between gap-3">
-        <div class="min-w-0 flex-1 space-y-2">
-          <div class="flex items-start gap-3">
-            <span
-              class={[
-                "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
-                if(source.selection_mode == :manual,
-                  do: "theme-badge-warning",
-                  else: "theme-badge-success"
-                )
-              ]}
-              title={source_download_mode_label(source)}
-            >
-              <.icon
-                name={if source.selection_mode == :manual, do: "hero-clock", else: "hero-bolt"}
-                class={"h-4 w-4 #{if(source.selection_mode == :manual, do: "theme-status-warning", else: "theme-status-success")}"}
-              />
-            </span>
+  <div class="mb-4 flex flex-wrap items-center justify-between gap-3 border-b border-theme-outline/70 pb-3">
+    <div>
+      <p class="text-sm font-medium text-theme-on-surface">Source view</p>
+      <p class="text-xs text-theme-on-surface-muted">Choose a table or poster library layout.</p>
+    </div>
 
-            <div class="min-w-0 flex-1">
-              <.subtle_link href={~p"/sources/#{source.id}"}>
-                <span class="block break-words font-medium text-theme-on-surface">{source.custom_name}</span>
-              </.subtle_link>
-              <.subtle_link href={~p"/media_profiles/#{source.media_profile_id}"}>
-                <span class="mt-1 block text-sm text-theme-on-surface-muted">{source.media_profile.name}</span>
-              </.subtle_link>
-            </div>
-          </div>
-        </div>
-
-        <div class="flex shrink-0 items-center gap-1.5">
-          <.form
-            for={%{}}
-            as={:start_source}
-            action={~p"/sources/#{source.id}/start_all"}
-            method="post"
-            x-data="{ submitting: false }"
-            x-on:submit="submitting = true"
-          >
-            <input type="hidden" name="return_to" value={~p"/sources"} />
-            <.icon_button
-              icon_name="hero-play-solid"
-              variant="primary"
-              type="submit"
-              class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
-              icon_class="h-4 w-4"
-              title="Start all"
-              aria-label="Start all"
-              data-confirm={"Start downloads for #{source.custom_name}?"}
-              x-bind:disabled="submitting"
-            />
-          </.form>
-
-          <.form
-            for={%{}}
-            as={:pause_source}
-            action={~p"/sources/#{source.id}/pause_all"}
-            method="post"
-            x-data="{ submitting: false }"
-            x-on:submit="submitting = true"
-          >
-            <input type="hidden" name="return_to" value={~p"/sources"} />
-            <.icon_button
-              icon_name="hero-pause-solid"
-              variant="warning"
-              type="submit"
-              class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
-              icon_class="h-4 w-4"
-              title="Pause all"
-              aria-label="Pause all"
-              data-confirm={"Pause downloads for #{source.custom_name}?"}
-              x-bind:disabled="submitting"
-            />
-          </.form>
-
-          <.form
-            for={%{}}
-            as={:stop_source}
-            action={~p"/sources/#{source.id}/stop_all"}
-            method="post"
-            x-data="{ submitting: false }"
-            x-on:submit="submitting = true"
-          >
-            <input type="hidden" name="return_to" value={~p"/sources"} />
-            <.icon_button
-              icon_name="hero-stop-solid"
-              variant="danger-solid"
-              type="submit"
-              class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
-              icon_class="h-4 w-4"
-              title="Stop all"
-              aria-label="Stop all"
-              data-confirm={"Stop downloads for #{source.custom_name}?"}
-              x-bind:disabled="submitting"
-            />
-          </.form>
-
-          <.icon_link href={~p"/sources/#{source.id}/edit"} icon="hero-pencil-square" class="mx-1" />
-          <.icon_link
-            href={~p"/sources/#{source.id}"}
-            icon="hero-trash"
-            method="delete"
-            data-confirm={"Delete #{source.custom_name}? This deletes the source only and does not delete files."}
-            aria-label={"Delete #{source.custom_name}"}
-            title="Delete source"
-            class="mx-1 hover:text-theme-error"
-          />
-        </div>
-      </div>
-
-      <dl class="grid grid-cols-1 gap-3 text-sm">
-        <div class="flex items-start justify-between gap-3">
-          <dt class="text-theme-on-surface-muted">Pending</dt>
-          <dd class="text-right text-theme-on-surface">
-            <.subtle_link href={~p"/sources/#{source.id}/#tab-pending"}>
-              <.localized_number number={source.pending_count} />
-            </.subtle_link>
-          </dd>
-        </div>
-        <div class="flex items-start justify-between gap-3">
-          <dt class="text-theme-on-surface-muted">Downloaded</dt>
-          <dd class="text-right text-theme-on-surface">
-            <.subtle_link href={~p"/sources/#{source.id}/#tab-downloaded"}>
-              <.localized_number number={source.downloaded_count} />
-            </.subtle_link>
-          </dd>
-        </div>
-        <div class="flex items-start justify-between gap-3">
-          <dt class="text-theme-on-surface-muted">Size</dt>
-          <dd class="text-right text-theme-on-surface">
-            <.readable_filesize byte_size={source.media_size_bytes} />
-          </dd>
-        </div>
-        <div class="flex items-start justify-between gap-3">
-          <dt class="text-theme-on-surface-muted">Enabled</dt>
-          <dd class="text-right">
-            <.live_component
-              module={PinchflatWeb.Sources.SourceLive.SourceEnableToggle}
-              source={source}
-              id={"source_#{source.id}_enabled_mobile"}
-            />
-          </dd>
-        </div>
-      </dl>
-    </article>
+    <div
+      class="inline-flex items-center gap-1 rounded-m3-sm border border-theme-outline bg-theme-surface p-1"
+      role="group"
+      aria-label="Source view"
+    >
+      <button
+        type="button"
+        class={[
+          "inline-flex items-center gap-2 rounded-m3-xs px-3 py-2 text-sm font-medium transition",
+          if(@view_mode == :table,
+            do: "bg-theme-primary text-theme-on-primary",
+            else: "text-theme-on-surface-muted hover:bg-theme-surface-2 hover:text-theme-on-surface"
+          )
+        ]}
+        phx-click="view_change"
+        phx-value-view="table"
+        aria-pressed={to_string(@view_mode == :table)}
+        data-view-toggle="table"
+      >
+        <.icon name="hero-list-bullet" class="h-4 w-4" aria-hidden="true" /> Table
+      </button>
+      <button
+        type="button"
+        class={[
+          "inline-flex items-center gap-2 rounded-m3-xs px-3 py-2 text-sm font-medium transition",
+          if(@view_mode == :grid,
+            do: "bg-theme-primary text-theme-on-primary",
+            else: "text-theme-on-surface-muted hover:bg-theme-surface-2 hover:text-theme-on-surface"
+          )
+        ]}
+        phx-click="view_change"
+        phx-value-view="grid"
+        aria-pressed={to_string(@view_mode == :grid)}
+        data-view-toggle="grid"
+      >
+        <.icon name="hero-squares-2x2" class="h-4 w-4" aria-hidden="true" /> Poster grid
+      </button>
+    </div>
   </div>
 
-  <div class="hidden md:flex md:flex-col md:min-w-max">
-    <.table rows={@sources} sort_key={@sort_key} sort_direction={@sort_direction}>
-      <:col :let={source} label="Name" sort_key="custom_name" class="max-w-md whitespace-normal align-middle">
-        <div class="flex min-w-0 flex-col gap-2">
-          <div class="flex min-w-0 items-center gap-3">
-            <div class="flex min-w-0 flex-1 items-center gap-2">
+  <div :if={@view_mode == :table}>
+    <div class="space-y-4 md:hidden">
+      <article :for={source <- @sources} class="theme-surface-accent space-y-4 rounded-m3-lg p-4">
+        <div class="flex items-center justify-between gap-3">
+          <div class="min-w-0 flex-1 space-y-2">
+            <div class="flex items-start gap-3">
               <span
                 class={[
-                  "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full",
+                  "inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
                   if(source.selection_mode == :manual,
                     do: "theme-badge-warning",
                     else: "theme-badge-success"
@@ -168,134 +65,399 @@
                   name={if source.selection_mode == :manual, do: "hero-clock", else: "hero-bolt"}
                   class={"h-4 w-4 #{if(source.selection_mode == :manual, do: "theme-status-warning", else: "theme-status-success")}"}
                 />
-                <span class="sr-only">{source_download_mode_label(source)}</span>
               </span>
 
-              <div class="min-w-0 flex-1 leading-6 break-words whitespace-normal">
-                <.subtle_link href={~p"/sources/#{source.id}"}>{source.custom_name}</.subtle_link>
+              <div class="min-w-0 flex-1">
+                <.subtle_link href={~p"/sources/#{source.id}"}>
+                  <span class="block break-words font-medium text-theme-on-surface">{source.custom_name}</span>
+                </.subtle_link>
+                <.subtle_link href={~p"/media_profiles/#{source.media_profile_id}"}>
+                  <span class="mt-1 block text-sm text-theme-on-surface-muted">{source.media_profile.name}</span>
+                </.subtle_link>
+              </div>
+            </div>
+          </div>
+
+          <div class="flex shrink-0 items-center gap-1.5">
+            <.form
+              for={%{}}
+              as={:start_source}
+              action={~p"/sources/#{source.id}/start_all"}
+              method="post"
+              x-data="{ submitting: false }"
+              x-on:submit="submitting = true"
+            >
+              <input type="hidden" name="return_to" value={~p"/sources"} />
+              <.icon_button
+                icon_name="hero-play-solid"
+                variant="primary"
+                type="submit"
+                class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
+                icon_class="h-4 w-4"
+                title="Start all"
+                aria-label="Start all"
+                data-confirm={"Start downloads for #{source.custom_name}?"}
+                x-bind:disabled="submitting"
+              />
+            </.form>
+
+            <.form
+              for={%{}}
+              as={:pause_source}
+              action={~p"/sources/#{source.id}/pause_all"}
+              method="post"
+              x-data="{ submitting: false }"
+              x-on:submit="submitting = true"
+            >
+              <input type="hidden" name="return_to" value={~p"/sources"} />
+              <.icon_button
+                icon_name="hero-pause-solid"
+                variant="warning"
+                type="submit"
+                class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
+                icon_class="h-4 w-4"
+                title="Pause all"
+                aria-label="Pause all"
+                data-confirm={"Pause downloads for #{source.custom_name}?"}
+                x-bind:disabled="submitting"
+              />
+            </.form>
+
+            <.form
+              for={%{}}
+              as={:stop_source}
+              action={~p"/sources/#{source.id}/stop_all"}
+              method="post"
+              x-data="{ submitting: false }"
+              x-on:submit="submitting = true"
+            >
+              <input type="hidden" name="return_to" value={~p"/sources"} />
+              <.icon_button
+                icon_name="hero-stop-solid"
+                variant="danger-solid"
+                type="submit"
+                class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
+                icon_class="h-4 w-4"
+                title="Stop all"
+                aria-label="Stop all"
+                data-confirm={"Stop downloads for #{source.custom_name}?"}
+                x-bind:disabled="submitting"
+              />
+            </.form>
+
+            <.icon_link href={~p"/sources/#{source.id}/edit"} icon="hero-pencil-square" class="mx-1" />
+            <.icon_link
+              href={~p"/sources/#{source.id}"}
+              icon="hero-trash"
+              method="delete"
+              data-confirm={"Delete #{source.custom_name}? This deletes the source only and does not delete files."}
+              aria-label={"Delete #{source.custom_name}"}
+              title="Delete source"
+              class="mx-1 hover:text-theme-error"
+            />
+          </div>
+        </div>
+
+        <dl class="grid grid-cols-1 gap-3 text-sm">
+          <div class="flex items-start justify-between gap-3">
+            <dt class="text-theme-on-surface-muted">Pending</dt>
+            <dd class="text-right text-theme-on-surface">
+              <.subtle_link href={~p"/sources/#{source.id}/#tab-pending"}>
+                <.localized_number number={source.pending_count} />
+              </.subtle_link>
+            </dd>
+          </div>
+          <div class="flex items-start justify-between gap-3">
+            <dt class="text-theme-on-surface-muted">Downloaded</dt>
+            <dd class="text-right text-theme-on-surface">
+              <.subtle_link href={~p"/sources/#{source.id}/#tab-downloaded"}>
+                <.localized_number number={source.downloaded_count} />
+              </.subtle_link>
+            </dd>
+          </div>
+          <div class="flex items-start justify-between gap-3">
+            <dt class="text-theme-on-surface-muted">Size</dt>
+            <dd class="text-right text-theme-on-surface">
+              <.readable_filesize byte_size={source.media_size_bytes} />
+            </dd>
+          </div>
+          <div class="flex items-start justify-between gap-3">
+            <dt class="text-theme-on-surface-muted">Enabled</dt>
+            <dd class="text-right">
+              <.live_component
+                module={PinchflatWeb.Sources.SourceLive.SourceEnableToggle}
+                source={source}
+                id={"source_#{source.id}_enabled_mobile"}
+              />
+            </dd>
+          </div>
+        </dl>
+      </article>
+    </div>
+
+    <div id="source-table" data-view="table" class="hidden md:flex md:flex-col md:min-w-max">
+      <.table rows={@sources} sort_key={@sort_key} sort_direction={@sort_direction}>
+        <:col :let={source} label="Name" sort_key="custom_name" class="max-w-md whitespace-normal align-middle">
+          <div class="flex min-w-0 flex-col gap-2">
+            <div class="flex min-w-0 items-center gap-3">
+              <div class="flex min-w-0 flex-1 items-center gap-2">
+                <span
+                  class={[
+                    "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full",
+                    if(source.selection_mode == :manual,
+                      do: "theme-badge-warning",
+                      else: "theme-badge-success"
+                    )
+                  ]}
+                  title={source_download_mode_label(source)}
+                >
+                  <.icon
+                    name={if source.selection_mode == :manual, do: "hero-clock", else: "hero-bolt"}
+                    class={"h-4 w-4 #{if(source.selection_mode == :manual, do: "theme-status-warning", else: "theme-status-success")}"}
+                  />
+                  <span class="sr-only">{source_download_mode_label(source)}</span>
+                </span>
+
+                <div class="min-w-0 flex-1 leading-6 break-words whitespace-normal">
+                  <.subtle_link href={~p"/sources/#{source.id}"}>{source.custom_name}</.subtle_link>
+                </div>
+              </div>
+
+              <div class="ml-auto flex shrink-0 items-center gap-1.5 self-center">
+                <.form
+                  for={%{}}
+                  as={:start_source}
+                  action={~p"/sources/#{source.id}/start_all"}
+                  method="post"
+                  x-data="{ submitting: false }"
+                  x-on:submit="submitting = true"
+                >
+                  <input type="hidden" name="return_to" value={~p"/sources"} />
+                  <.icon_button
+                    icon_name="hero-play-solid"
+                    variant="primary"
+                    type="submit"
+                    class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
+                    icon_class="h-4 w-4"
+                    title="Start all"
+                    aria-label="Start all"
+                    data-confirm={"Start downloads for #{source.custom_name}?"}
+                    x-bind:disabled="submitting"
+                  />
+                </.form>
+
+                <.form
+                  for={%{}}
+                  as={:pause_source}
+                  action={~p"/sources/#{source.id}/pause_all"}
+                  method="post"
+                  x-data="{ submitting: false }"
+                  x-on:submit="submitting = true"
+                >
+                  <input type="hidden" name="return_to" value={~p"/sources"} />
+                  <.icon_button
+                    icon_name="hero-pause-solid"
+                    variant="warning"
+                    type="submit"
+                    class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
+                    icon_class="h-4 w-4"
+                    title="Pause all"
+                    aria-label="Pause all"
+                    data-confirm={"Pause downloads for #{source.custom_name}?"}
+                    x-bind:disabled="submitting"
+                  />
+                </.form>
+
+                <.form
+                  for={%{}}
+                  as={:stop_source}
+                  action={~p"/sources/#{source.id}/stop_all"}
+                  method="post"
+                  x-data="{ submitting: false }"
+                  x-on:submit="submitting = true"
+                >
+                  <input type="hidden" name="return_to" value={~p"/sources"} />
+                  <.icon_button
+                    icon_name="hero-stop-solid"
+                    variant="danger-solid"
+                    type="submit"
+                    class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
+                    icon_class="h-4 w-4"
+                    title="Stop all"
+                    aria-label="Stop all"
+                    data-confirm={"Stop downloads for #{source.custom_name}?"}
+                    x-bind:disabled="submitting"
+                  />
+                </.form>
+              </div>
+            </div>
+          </div>
+        </:col>
+
+        <:col :let={source} label="Type" sort_key="collection_type">
+          <PinchflatWeb.Sources.SourceHTML.collection_type_badge collection_type={source.collection_type} />
+        </:col>
+
+        <:col :let={source} label="Pending" sort_key="pending_count">
+          <.subtle_link href={~p"/sources/#{source.id}/#tab-pending"}>
+            <.localized_number number={source.pending_count} />
+          </.subtle_link>
+        </:col>
+
+        <:col :let={source} label="Downloaded" sort_key="downloaded_count">
+          <.subtle_link href={~p"/sources/#{source.id}/#tab-downloaded"}>
+            <.localized_number number={source.downloaded_count} />
+          </.subtle_link>
+        </:col>
+
+        <:col :let={source} label="Size" sort_key="media_size_bytes">
+          <.readable_filesize byte_size={source.media_size_bytes} />
+        </:col>
+
+        <:col :let={source} label="Media Profile" sort_key="media_profile_name" class="truncate max-w-xs">
+          <.subtle_link href={~p"/media_profiles/#{source.media_profile_id}"}>{source.media_profile.name}</.subtle_link>
+        </:col>
+
+        <:col :let={source} label="Enabled?" sort_key="enabled">
+          <.live_component
+            module={PinchflatWeb.Sources.SourceLive.SourceEnableToggle}
+            source={source}
+            id={"source_#{source.id}_enabled"}
+          />
+        </:col>
+
+        <:col :let={source} label="" class="align-middle">
+          <div class="flex h-full items-center justify-center">
+            <.icon_link href={~p"/sources/#{source.id}/edit"} icon="hero-pencil-square" class="mx-1" />
+            <.icon_link
+              href={~p"/sources/#{source.id}"}
+              icon="hero-trash"
+              method="delete"
+              data-confirm={"Delete #{source.custom_name}? This deletes the source only and does not delete files."}
+              aria-label={"Delete #{source.custom_name}"}
+              title="Delete source"
+              class="mx-1 hover:text-theme-error"
+            />
+          </div>
+        </:col>
+      </.table>
+
+      <section class="my-5 flex justify-center">
+        <.live_pagination_controls page_number={@page} total_pages={@total_pages} />
+      </section>
+    </div>
+  </div>
+
+  <div :if={@view_mode == :grid}>
+    <div
+      id="source-poster-grid"
+      data-view="poster-grid"
+      class="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3 2xl:grid-cols-4"
+    >
+      <article
+        :for={source <- @sources}
+        id={"source-card-#{source.id}"}
+        data-source-id={source.id}
+        class="theme-surface-accent group relative overflow-hidden transition hover:border-theme-primary/70 hover:shadow-m3-2"
+      >
+        <.link
+          href={~p"/sources/#{source.id}"}
+          class="absolute inset-0 z-0 rounded-m3-lg focus-visible:ring-2 focus-visible:ring-theme-primary focus-visible:ring-offset-2 focus-visible:ring-offset-theme-bg"
+          aria-label={"Open source #{source.custom_name}"}
+        >
+          <span class="sr-only">Open source {source.custom_name}</span>
+        </.link>
+
+        <div class="relative z-10 pointer-events-none flex h-full flex-col">
+          <div
+            x-data="{ image_loaded: false }"
+            class="relative aspect-[16/10] overflow-hidden bg-theme-surface-4"
+          >
+            <div
+              x-show="!image_loaded"
+              class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-theme-primary-container/30 p-4 text-center text-theme-on-primary-container"
+              data-artwork-fallback
+            >
+              <span class="inline-flex h-16 w-16 items-center justify-center rounded-full bg-theme-primary/20 text-xl font-bold">
+                {source_initials(source)}
+              </span>
+              <span class="text-sm font-medium">Artwork unavailable</span>
+            </div>
+            <img
+              src={source_poster_url(source)}
+              alt={"Artwork for #{source.custom_name}"}
+              class="pointer-events-none absolute inset-0 h-full w-full object-cover"
+              x-on:load="image_loaded = true"
+              x-on:error="image_loaded = false; $event.target.classList.add('hidden')"
+            />
+          </div>
+
+          <div class="flex flex-1 flex-col gap-4 p-4">
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <h3 class="break-words text-base font-semibold text-theme-on-surface">{source.custom_name}</h3>
+                <p class="mt-1 truncate text-sm text-theme-on-surface-muted">{source.media_profile.name}</p>
+              </div>
+              <div class="pointer-events-auto shrink-0">
+                <.live_component
+                  module={PinchflatWeb.Sources.SourceLive.SourceEnableToggle}
+                  source={source}
+                  id={"source_#{source.id}_enabled_grid"}
+                />
               </div>
             </div>
 
-            <div class="ml-auto flex shrink-0 items-center gap-1.5 self-center">
-              <.form
-                for={%{}}
-                as={:start_source}
-                action={~p"/sources/#{source.id}/start_all"}
-                method="post"
-                x-data="{ submitting: false }"
-                x-on:submit="submitting = true"
+            <div class="flex items-center justify-between gap-2 text-sm">
+              <PinchflatWeb.Sources.SourceHTML.collection_type_badge collection_type={source.collection_type} />
+              <span
+                class={if(source.enabled, do: "theme-status-success", else: "theme-status-warning")}
+                data-monitored-state
               >
-                <input type="hidden" name="return_to" value={~p"/sources"} />
-                <.icon_button
-                  icon_name="hero-play-solid"
-                  variant="primary"
-                  type="submit"
-                  class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
-                  icon_class="h-4 w-4"
-                  title="Start all"
-                  aria-label="Start all"
-                  data-confirm={"Start downloads for #{source.custom_name}?"}
-                  x-bind:disabled="submitting"
-                />
-              </.form>
+                {if source.enabled, do: "Monitored", else: "Not monitored"}
+              </span>
+            </div>
 
-              <.form
-                for={%{}}
-                as={:pause_source}
-                action={~p"/sources/#{source.id}/pause_all"}
-                method="post"
-                x-data="{ submitting: false }"
-                x-on:submit="submitting = true"
-              >
-                <input type="hidden" name="return_to" value={~p"/sources"} />
-                <.icon_button
-                  icon_name="hero-pause-solid"
-                  variant="warning"
-                  type="submit"
-                  class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
-                  icon_class="h-4 w-4"
-                  title="Pause all"
-                  aria-label="Pause all"
-                  data-confirm={"Pause downloads for #{source.custom_name}?"}
-                  x-bind:disabled="submitting"
-                />
-              </.form>
+            <dl class="grid grid-cols-2 gap-3 text-sm">
+              <div class="rounded-m3-sm bg-theme-surface-2/70 p-3">
+                <dt class="text-theme-on-surface-muted">Downloaded</dt>
+                <dd class="mt-1 font-semibold text-theme-on-surface">
+                  <.localized_number number={source.downloaded_count} />
+                </dd>
+              </div>
+              <div class="rounded-m3-sm bg-theme-surface-2/70 p-3">
+                <dt class="text-theme-on-surface-muted">Pending</dt>
+                <dd class="mt-1 font-semibold text-theme-on-surface">
+                  <.localized_number number={source.pending_count} />
+                </dd>
+              </div>
+            </dl>
 
-              <.form
-                for={%{}}
-                as={:stop_source}
-                action={~p"/sources/#{source.id}/stop_all"}
-                method="post"
-                x-data="{ submitting: false }"
-                x-on:submit="submitting = true"
+            <% progress = source_progress(source) %>
+            <div class="mt-auto space-y-2" data-progress-state={progress.state}>
+              <div class="flex items-center justify-between gap-3 text-xs">
+                <span class="text-theme-on-surface-muted">Download progress</span>
+                <span class="text-right text-theme-on-surface-muted">{progress.label}</span>
+              </div>
+              <div
+                :if={progress.state == :known}
+                class="h-2 overflow-hidden rounded-full bg-theme-surface-4"
+                role="progressbar"
+                aria-label={"Download progress for #{source.custom_name}"}
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow={progress.percent}
+                aria-valuetext={progress.label}
               >
-                <input type="hidden" name="return_to" value={~p"/sources"} />
-                <.icon_button
-                  icon_name="hero-stop-solid"
-                  variant="danger-solid"
-                  type="submit"
-                  class="h-8 w-8 border active:brightness-90 disabled:opacity-60"
-                  icon_class="h-4 w-4"
-                  title="Stop all"
-                  aria-label="Stop all"
-                  data-confirm={"Stop downloads for #{source.custom_name}?"}
-                  x-bind:disabled="submitting"
-                />
-              </.form>
+                <div class="h-full rounded-full bg-theme-primary transition-all" style={"width: #{progress.percent}%"}>
+                </div>
+              </div>
             </div>
           </div>
         </div>
-      </:col>
+      </article>
+    </div>
 
-      <:col :let={source} label="Type" sort_key="collection_type">
-        <PinchflatWeb.Sources.SourceHTML.collection_type_badge collection_type={source.collection_type} />
-      </:col>
-
-      <:col :let={source} label="Pending" sort_key="pending_count">
-        <.subtle_link href={~p"/sources/#{source.id}/#tab-pending"}>
-          <.localized_number number={source.pending_count} />
-        </.subtle_link>
-      </:col>
-
-      <:col :let={source} label="Downloaded" sort_key="downloaded_count">
-        <.subtle_link href={~p"/sources/#{source.id}/#tab-downloaded"}>
-          <.localized_number number={source.downloaded_count} />
-        </.subtle_link>
-      </:col>
-
-      <:col :let={source} label="Size" sort_key="media_size_bytes">
-        <.readable_filesize byte_size={source.media_size_bytes} />
-      </:col>
-
-      <:col :let={source} label="Media Profile" sort_key="media_profile_name" class="truncate max-w-xs">
-        <.subtle_link href={~p"/media_profiles/#{source.media_profile_id}"}>{source.media_profile.name}</.subtle_link>
-      </:col>
-
-      <:col :let={source} label="Enabled?" sort_key="enabled">
-        <.live_component
-          module={PinchflatWeb.Sources.SourceLive.SourceEnableToggle}
-          source={source}
-          id={"source_#{source.id}_enabled"}
-        />
-      </:col>
-
-      <:col :let={source} label="" class="align-middle">
-        <div class="flex h-full items-center justify-center">
-          <.icon_link href={~p"/sources/#{source.id}/edit"} icon="hero-pencil-square" class="mx-1" />
-          <.icon_link
-            href={~p"/sources/#{source.id}"}
-            icon="hero-trash"
-            method="delete"
-            data-confirm={"Delete #{source.custom_name}? This deletes the source only and does not delete files."}
-            aria-label={"Delete #{source.custom_name}"}
-            title="Delete source"
-            class="mx-1 hover:text-theme-error"
-          />
-        </div>
-      </:col>
-    </.table>
-
-    <section class="flex justify-center my-5">
+    <section class="my-5 flex justify-center">
       <.live_pagination_controls page_number={@page} total_pages={@total_pages} />
     </section>
   </div>

--- a/lib/pinchflat_web/controllers/sources/source_live/index_table_live.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_live/index_table_live.html.heex
@@ -198,7 +198,7 @@
     <div id="source-table" data-view="table" class="hidden md:flex md:flex-col md:min-w-max">
       <.table rows={@sources} sort_key={@sort_key} sort_direction={@sort_direction}>
         <:col :let={source} label="Name" sort_key="custom_name" class="max-w-md whitespace-normal align-middle">
-          <div class="flex min-w-0 flex-col gap-2">
+          <div data-source-id={source.id} class="flex min-w-0 flex-col gap-2">
             <div class="flex min-w-0 items-center gap-3">
               <div class="flex min-w-0 flex-1 items-center gap-2">
                 <span
@@ -358,7 +358,7 @@
         :for={source <- @sources}
         id={"source-card-#{source.id}"}
         data-source-id={source.id}
-        class="theme-surface-accent group relative overflow-hidden transition hover:border-theme-primary/70 hover:shadow-m3-2"
+        class="theme-surface-accent group relative overflow-hidden transition hover:border-theme-primary/70 hover:shadow-m3-2 focus-within:ring-2 focus-within:ring-theme-primary focus-within:ring-offset-2 focus-within:ring-offset-theme-bg"
       >
         <.link
           href={~p"/sources/#{source.id}"}

--- a/lib/pinchflat_web/controllers/sources/source_live/source_enable_toggle.ex
+++ b/lib/pinchflat_web/controllers/sources/source_live/source_enable_toggle.ex
@@ -15,7 +15,13 @@ defmodule PinchflatWeb.Sources.SourceLive.SourceEnableToggle do
         phx-target={@myself}
         class="enabled_toggle_form"
       >
-        <.input id={"#{@dom_id_base}_input"} field={f[:enabled]} type="toggle" />
+        <.input
+          id={"#{@dom_id_base}_input"}
+          field={f[:enabled]}
+          type="toggle"
+          aria_label={"Monitor #{source_label(@source)}"}
+        />
+        <p :if={@error} class="mt-1 text-xs theme-status-error" role="alert">{@error}</p>
       </.form>
     </div>
     """
@@ -25,6 +31,8 @@ defmodule PinchflatWeb.Sources.SourceLive.SourceEnableToggle do
     initial_data = %{
       dom_id_base: dom_id_base(assigns.id),
       source_id: assigns.source.id,
+      source: assigns.source,
+      error: nil,
       form: Sources.change_source(%Source{}, assigns.source)
     }
 
@@ -34,12 +42,31 @@ defmodule PinchflatWeb.Sources.SourceLive.SourceEnableToggle do
   end
 
   def handle_event("update", %{"source" => source_params}, %{assigns: assigns} = socket) do
-    assigns.source_id
-    |> Sources.get_source!()
-    |> Sources.update_source(source_params)
+    source = Sources.get_source!(assigns.source_id)
 
-    {:noreply, socket}
+    case Sources.update_source(source, source_params) do
+      {:ok, updated_source} ->
+        send(self(), {:source_enabled_updated, updated_source.id})
+
+        {:noreply,
+         assign(socket,
+           source: updated_source,
+           error: nil,
+           form: Sources.change_source(updated_source)
+         )}
+
+      {:error, _changeset} ->
+        {:noreply,
+         assign(socket,
+           source: source,
+           error: "Could not update monitoring state.",
+           form: Sources.change_source(source)
+         )}
+    end
   end
+
+  defp source_label(%{custom_name: custom_name}) when is_binary(custom_name), do: custom_name
+  defp source_label(_source), do: "source"
 
   defp dom_id_base(component_id), do: "source_enable_toggle_#{component_id}"
 end

--- a/test/pinchflat_web/controllers/sources/index_table_live_test.exs
+++ b/test/pinchflat_web/controllers/sources/index_table_live_test.exs
@@ -86,6 +86,25 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
       assert grid_html =~ ~s(aria-label="Monitor Grid candidate")
     end
 
+    test "renders the same exact source ID set in table and poster-grid views", %{conn: conn} do
+      sources = [
+        source_fixture(custom_name: "Grid candidate A"),
+        source_fixture(custom_name: "Grid candidate B")
+      ]
+
+      {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: create_session())
+
+      expected_ids = sources |> Enum.map(& &1.id) |> MapSet.new()
+      table_ids = source_ids(render_element(view, "#source-table"))
+
+      click_element(view, ~s([data-view-toggle="grid"]))
+
+      grid_ids = source_ids(render_element(view, "#source-poster-grid"))
+
+      assert table_ids == expected_ids
+      assert grid_ids == table_ids
+    end
+
     test "keeps the sorted page while switching views", %{conn: conn} do
       source_a = source_fixture(custom_name: "Source_A")
       source_b = source_fixture(custom_name: "Source_B")
@@ -295,6 +314,21 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
       assert %{enabled: false} = Repo.get!(Source, target.id)
       assert %{enabled: true} = Repo.get!(Source, other.id)
     end
+
+    test "shows an error and restores the checked state when monitoring update fails", %{conn: conn} do
+      source = source_fixture(custom_name: "Toggle failure", enabled: true)
+
+      {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: create_session())
+      click_element(view, ~s([data-view-toggle="grid"]))
+
+      view
+      |> element("#source_enable_toggle_source_#{source.id}_enabled_grid_form")
+      |> render_change(%{source: %{"enabled" => "not-a-boolean"}})
+
+      assert render(view) =~ "Could not update monitoring state."
+      assert render_element(view, "#source_enable_toggle_source_#{source.id}_enabled_grid_input") =~ "checked"
+      assert %{enabled: true} = Repo.get!(Source, source.id)
+    end
   end
 
   defp click_element(view, selector, text_filter \\ nil) do
@@ -314,6 +348,13 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
     |> render_element(selector)
     |> String.replace(~r/<[^>]*>/, "")
     |> String.trim()
+  end
+
+  defp source_ids(html) do
+    ~r/data-source-id="(\d+)"/
+    |> Regex.scan(html, capture: :all_but_first)
+    |> Enum.map(fn [id] -> String.to_integer(id) end)
+    |> MapSet.new()
   end
 
   defp create_session do

--- a/test/pinchflat_web/controllers/sources/index_table_live_test.exs
+++ b/test/pinchflat_web/controllers/sources/index_table_live_test.exs
@@ -66,6 +66,60 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
       assert cell_text(view, "tbody tr:first-child td:nth-of-type(3)") == "1"
       assert cell_text(view, "tbody tr:first-child td:nth-of-type(4)") == "1"
     end
+
+    test "renders the table view by default and exposes an accessible grid toggle", %{conn: conn} do
+      source = source_fixture(custom_name: "Grid candidate")
+
+      {:ok, view, html} = live_isolated(conn, IndexTableLive, session: create_session())
+
+      assert html =~ ~s(data-view="table")
+      assert html =~ ~s(data-view-toggle="grid")
+      assert html =~ ~s(aria-pressed="false")
+      assert html =~ source.custom_name
+
+      click_element(view, ~s([data-view-toggle="grid"]))
+
+      grid_html = render_element(view, "#source-poster-grid")
+      assert grid_html =~ source.custom_name
+      assert grid_html =~ ~s(data-artwork-fallback)
+      assert grid_html =~ ~s(aria-label="Open source Grid candidate")
+      assert grid_html =~ ~s(aria-label="Monitor Grid candidate")
+    end
+
+    test "keeps the sorted page while switching views", %{conn: conn} do
+      source_a = source_fixture(custom_name: "Source_A")
+      source_b = source_fixture(custom_name: "Source_B")
+
+      session = Map.merge(create_session(), %{"results_per_page" => 1})
+      {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: session)
+
+      click_element(view, "span.pagination-next")
+      assert render_element(view, "#source-table") =~ source_b.custom_name
+      refute render_element(view, "#source-table") =~ source_a.custom_name
+
+      click_element(view, ~s([data-view-toggle="grid"]))
+
+      assert render_element(view, "#source-poster-grid") =~ source_b.custom_name
+      refute render_element(view, "#source-poster-grid") =~ source_a.custom_name
+      assert render(view) =~ "Page"
+
+      click_element(view, ~s([data-view-toggle="table"]))
+      assert render_element(view, "#source-table") =~ source_b.custom_name
+      refute render_element(view, "#source-table") =~ source_a.custom_name
+    end
+  end
+
+  describe "poster-grid progress" do
+    test "does not claim completion when the total is empty or unknown" do
+      assert %{state: :empty, percent: 0, label: "No indexed media yet"} =
+               IndexTableLive.source_progress(%{media_count: 0, downloaded_count: 0})
+
+      assert %{state: :unknown, percent: nil} =
+               IndexTableLive.source_progress(%{media_count: nil, downloaded_count: 0})
+
+      assert %{state: :known, percent: 50, label: "1 of 2 indexed items downloaded"} =
+               IndexTableLive.source_progress(%{media_count: 2, downloaded_count: 1})
+    end
   end
 
   describe "when testing sorting" do
@@ -226,6 +280,21 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
 
       assert %{enabled: false} = Repo.get!(Source, source.id)
     end
+
+    test "updates only the source whose poster-grid toggle changed", %{conn: conn} do
+      target = source_fixture(custom_name: "Target source", enabled: true)
+      other = source_fixture(custom_name: "Other source", enabled: true)
+
+      {:ok, view, _html} = live_isolated(conn, IndexTableLive, session: create_session())
+      click_element(view, ~s([data-view-toggle="grid"]))
+
+      view
+      |> element("#source_enable_toggle_source_#{target.id}_enabled_grid_form")
+      |> render_change(%{source: %{"enabled" => false}})
+
+      assert %{enabled: false} = Repo.get!(Source, target.id)
+      assert %{enabled: true} = Repo.get!(Source, other.id)
+    end
   end
 
   defp click_element(view, selector, text_filter \\ nil) do
@@ -251,6 +320,7 @@ defmodule PinchflatWeb.Sources.SourceLive.IndexTableLiveTest do
     %{
       "initial_sort_key" => :custom_name,
       "initial_sort_direction" => :asc,
+      "initial_view_mode" => :table,
       "results_per_page" => 10
     }
   end


### PR DESCRIPTION
## Summary

- Add a semantic Material 3 table/poster-grid toggle to the source library.
- Reuse the existing source query, sorting, pagination, counts, and LiveView state in both layouts.
- Add artwork/fallback cards, honest progress states, accessible source navigation, and monitored toggles with safe error handling.
- Add focused LiveView regressions for view state, pagination, progress, accessibility, and target-only toggling.

## Repair follow-up

- Make keyboard focus visible with a card-level `focus-within` ring while preserving whole-card navigation and keeping the monitor toggle outside the link.
- Preload source metadata through the paginated source query's joined preload, removing per-card metadata queries from poster URL rendering.
- Compare exact `data-source-id` sets between table and poster-grid views.
- Cover monitored-toggle failure with an alert, database rollback, and checked-state restoration.

## Verification

- Docker focused source-library LiveView tests: 23 tests, 0 failures.
- Docker focused toggle-component tests: 4 tests, 0 failures.
- Docker full `mix test`: 1,679 tests, 0 failures.
- Docker `mix format --check-formatted`, `mix compile --warnings-as-errors`, Credo, `yarn run ui:check-theme`, Sobelow, and `git diff --check` passed.
- Sobelow reported only the three existing low-confidence warnings in unchanged diagnostics files.
- Browser DOM smoke test on page 3 confirmed HTTP 200, table/grid source-ID parity, sorting preservation, artwork fallback, named controls, honest progress, and no new console errors.
- Fresh independent Sol verification: PASS on commit `61dd5e53e4efeff7680db56d91b2d4bab296304b`.
- Known environment-only issue: Prettier cannot scan `/app/.agents/skills` through the Docker junction (`EPERM`).
- The generated ERD artifact was restored, and the pre-existing untracked `plans/` directory was preserved.
