### PR TITLE
Improve source statistics and media grouping

### DIFF
--- a/lib/pinchflat/media/media.ex
+++ b/lib/pinchflat/media/media.ex
@@ -30,6 +30,51 @@ defmodule Pinchflat.Media do
   end
 
   @doc """
+  Returns mutually exclusive media statistics for a source.
+
+  The direct-status aggregate applies this precedence to legacy rows that match
+  more than one predicate: downloaded, unavailable or removed, failed,
+  prevented, then skipped. A second aggregate counts only policy-eligible
+  pending rows after excluding those higher-precedence statuses. The skipped
+  bucket is then split into pending and unavailable/skipped, so the five
+  returned counts cover every media item without one query per status.
+
+  Returns a map with `:downloaded`, `:pending`, `:failed`, `:prevented`, and
+  `:unavailable` counts.
+  """
+  def source_media_statistics(%Source{} = source) do
+    direct_counts = source_media_direct_status_counts(source)
+
+    pending_count =
+      MediaQuery.new()
+      |> MediaQuery.require_assoc(:media_profile)
+      |> where(
+        ^dynamic(
+          [mi, _source, _media_profile],
+          # Keep nullable failure fields explicit: SQL `NOT` over a NULL
+          # comparison is NULL and would otherwise hide healthy pending rows.
+          ^MediaQuery.for_source(source) and
+            ^MediaQuery.pending() and
+            is_nil(mi.unavailable_at) and
+            is_nil(mi.culled_at) and
+            is_nil(mi.last_error) and
+            (is_nil(mi.error_type) or mi.error_type != :permanent)
+        )
+      )
+      |> Repo.aggregate(:count, :id)
+
+    skipped_count = Map.get(direct_counts, :skipped, 0)
+
+    %{
+      downloaded: Map.get(direct_counts, :downloaded, 0),
+      pending: pending_count,
+      failed: Map.get(direct_counts, :failed, 0),
+      prevented: Map.get(direct_counts, :prevented, 0),
+      unavailable: max(skipped_count - pending_count, 0) + Map.get(direct_counts, :unavailable, 0)
+    }
+  end
+
+  @doc """
   Preloads associations used by API serialization.
 
   Returns [%MediaItem{}, ...] | %MediaItem{}.
@@ -319,6 +364,59 @@ defmodule Pinchflat.Media do
     |> MediaQuery.require_assoc(:media_profile)
     |> where(^dynamic(^MediaQuery.download_failed()))
   end
+
+  defp source_media_direct_status_counts(%Source{} = source) do
+    from(mi in MediaQuery.new(),
+      where: ^MediaQuery.for_source(source),
+      group_by:
+        fragment(
+          """
+          CASE
+            WHEN ? IS NOT NULL THEN 'downloaded'
+            WHEN ? IS NOT NULL OR ? IS NOT NULL THEN 'unavailable'
+            WHEN ? IS NOT NULL OR ? = 'permanent' THEN 'failed'
+            WHEN ? = 1 THEN 'prevented'
+            ELSE 'skipped'
+          END
+          """,
+          mi.media_filepath,
+          mi.unavailable_at,
+          mi.culled_at,
+          mi.last_error,
+          mi.error_type,
+          mi.prevent_download
+        ),
+      select: %{
+        status:
+          fragment(
+            """
+            CASE
+              WHEN ? IS NOT NULL THEN 'downloaded'
+              WHEN ? IS NOT NULL OR ? IS NOT NULL THEN 'unavailable'
+              WHEN ? IS NOT NULL OR ? = 'permanent' THEN 'failed'
+              WHEN ? = 1 THEN 'prevented'
+              ELSE 'skipped'
+            END
+            """,
+            mi.media_filepath,
+            mi.unavailable_at,
+            mi.culled_at,
+            mi.last_error,
+            mi.error_type,
+            mi.prevent_download
+          ),
+        count: count(mi.id)
+      }
+    )
+    |> Repo.all()
+    |> Enum.into(%{}, fn %{status: status, count: count} -> {direct_status_key(status), count} end)
+  end
+
+  defp direct_status_key("downloaded"), do: :downloaded
+  defp direct_status_key("unavailable"), do: :unavailable
+  defp direct_status_key("failed"), do: :failed
+  defp direct_status_key("prevented"), do: :prevented
+  defp direct_status_key("skipped"), do: :skipped
 
   defp do_delete_media_files(media_item) do
     mapped_struct = Map.from_struct(media_item)

--- a/lib/pinchflat_web/controllers/sources/source_controller.ex
+++ b/lib/pinchflat_web/controllers/sources/source_controller.ex
@@ -181,11 +181,14 @@ defmodule PinchflatWeb.Sources.SourceController do
         conn |> put_status(:ok) |> json(source)
 
       _ ->
+        media_statistics = Media.source_media_statistics(source)
+
         render(conn, :show,
           source: source,
           active_tab: active_tab,
           tab_href: fn tab -> ~p"/sources/#{source}?#{[tab: tab]}" end,
-          selection_media_items: selection_media_items
+          selection_media_items: selection_media_items,
+          media_statistics: media_statistics
         )
     end
   end

--- a/lib/pinchflat_web/controllers/sources/source_html.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html.ex
@@ -57,6 +57,46 @@ defmodule PinchflatWeb.Sources.SourceHTML do
   def collection_type_icon(_), do: "hero-question-mark-circle"
 
   @doc """
+  Renders the compact media statistics summary shown on a source detail page.
+  """
+  attr :statistics, :map, required: true
+
+  def source_statistics(assigns) do
+    assigns =
+      assign(assigns, :statistics_items, [
+        {:downloaded, "Downloaded", "theme-status-success"},
+        {:pending, "Pending", "theme-status-info"},
+        {:failed, "Failed", "theme-status-error"},
+        {:prevented, "Prevented", "theme-status-warning"},
+        {:unavailable, "Unavailable / Skipped", "text-theme-on-surface-muted"}
+      ])
+
+    ~H"""
+    <section
+      id="source-media-statistics"
+      aria-labelledby="source-media-statistics-title"
+      class="theme-surface-accent mb-6 rounded-m3-lg px-4 py-3 sm:px-5"
+    >
+      <h3 id="source-media-statistics-title" class="sr-only">Source media statistics</h3>
+      <dl class="grid grid-cols-2 divide-x divide-y divide-theme-outline/50 sm:grid-cols-5 sm:divide-y-0">
+        <div
+          :for={{key, label, value_class} <- @statistics_items}
+          class="flex min-w-0 flex-col gap-1 px-3 py-2 first:pl-0 last:pr-0 sm:px-4"
+        >
+          <dt class="truncate text-xs font-medium uppercase tracking-wide text-theme-on-surface-muted">{label}</dt>
+          <dd
+            class={["text-xl font-semibold tabular-nums", value_class]}
+            aria-label={"#{label}: #{Map.fetch!(@statistics, key)}"}
+          >
+            <.localized_number number={Map.fetch!(@statistics, key)} />
+          </dd>
+        </div>
+      </dl>
+    </section>
+    """
+  end
+
+  @doc """
   The "why is nothing downloading?" banner. Renders **only the first** blocking
   condition — the most fundamental one, since fixing it may well clear the rest —
   and renders nothing at all when the source is healthy. There is deliberately no

--- a/lib/pinchflat_web/controllers/sources/source_html/media_item_table_live.ex
+++ b/lib/pinchflat_web/controllers/sources/source_html/media_item_table_live.ex
@@ -78,215 +78,253 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
           </div>
         </div>
       </header>
-      <div class="space-y-4 md:hidden">
-        <article :for={media_item <- @records} class="theme-surface-accent space-y-4 rounded-m3-lg p-4">
-          <div class="flex items-center justify-between gap-3">
-            <div class="min-w-0 flex-1 space-y-2">
-              <div
-                :if={@media_state == "pending"}
-                class="text-xs font-medium uppercase tracking-wide text-theme-on-surface-muted"
-              >
-                Queue #{Map.get(@queue_positions, media_item.id, "-")}
-              </div>
-              <div class="flex items-start gap-2">
-                <.icon
-                  :if={media_item.last_error}
-                  name="hero-exclamation-circle-solid"
-                  class="theme-status-error mt-0.5 shrink-0"
-                />
-                <.failure_badge :if={@media_state == "failed"} error_type={media_item.error_type} />
-                <div class="min-w-0">
-                  <.subtle_link href={~p"/sources/#{@source.id}/media/#{media_item.id}"}>
-                    <span class="block whitespace-normal break-words font-medium text-theme-on-surface">
-                      {media_item.title}
-                    </span>
-                  </.subtle_link>
-                </div>
-              </div>
-            </div>
-
-            <div class="flex items-center gap-2">
-              <.icon_button
-                :if={@media_state not in ["downloaded", "failed"]}
-                icon_name="hero-arrow-down-tray"
-                class="h-10 w-10"
-                phx-click="force_download"
-                phx-value-media-id={media_item.id}
-                data-confirm="Are you sure you want to force a download of this media?"
-                tooltip="Force Download"
-                tooltip_position="bottom-left"
+      <div :for={group <- @grouped_records} class="space-y-4">
+        <section
+          class="theme-surface-accent rounded-m3-lg"
+          x-data={"{ open: #{group.open?} }"}
+        >
+          <h3>
+            <button
+              type="button"
+              class="flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-base font-semibold text-theme-on-surface focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-theme-primary sm:px-5"
+              aria-controls={year_content_id(@media_state, group.year)}
+              aria-expanded={to_string(group.open?)}
+              aria-label={"Toggle #{year_label(group.year)} media"}
+              x-bind:aria-expanded="open.toString()"
+              x-on:click="open = !open"
+            >
+              <span>{year_label(group.year)}</span>
+              <.icon
+                name="hero-chevron-down"
+                class="h-5 w-5 shrink-0 text-theme-on-surface-muted transition"
+                x-bind:class="open ? 'rotate-180' : ''"
+                aria-hidden="true"
               />
-              <.icon_button
-                :if={@media_state == "failed" and media_item.error_type != :permanent}
-                icon_name="hero-arrow-path"
-                class="h-10 w-10"
-                phx-click="retry_download"
-                phx-value-media-id={media_item.id}
-                data-confirm="Retry this download now?"
-                tooltip="Retry Now"
-                tooltip_position="bottom-left"
-              />
-              <.icon_button
-                :if={@media_state == "failed" and media_item.error_type == :permanent}
-                icon_name="hero-arrow-path"
-                class="h-10 w-10"
-                phx-click="force_download"
-                phx-value-media-id={media_item.id}
-                data-confirm="Force a retry of this permanent failure?"
-                tooltip="Force Retry"
-                tooltip_position="bottom-left"
-              />
-              <.icon_button
-                :if={Map.has_key?(@tasks_by_media_item_id, media_item.id)}
-                icon_name="hero-stop-solid"
-                variant="danger"
-                class="h-10 w-10"
-                phx-click="stop_download"
-                phx-value-task-id={Map.fetch!(@tasks_by_media_item_id, media_item.id).id}
-                phx-value-media-id={media_item.id}
-                data-confirm="Are you sure you want to stop this download?"
-                tooltip="Stop Download"
-                tooltip_position="bottom-left"
-              />
-              <.icon_link href={~p"/sources/#{@source.id}/media/#{media_item.id}/edit"} icon="hero-pencil-square" />
-            </div>
-          </div>
+            </button>
+          </h3>
 
           <div
-            :if={media_item.last_error}
-            class="theme-danger-panel whitespace-pre-wrap break-words rounded-m3-sm p-3 text-xs"
+            id={year_content_id(@media_state, group.year)}
+            class="border-t border-theme-outline/50 px-2 pb-2 pt-2 sm:px-3"
+            x-cloak
+            x-show="open"
           >
-            {media_item.last_error}
+            <div class="space-y-4 md:hidden">
+              <article :for={media_item <- group.records} class="theme-surface-accent space-y-4 rounded-m3-lg p-4">
+                <div class="flex items-center justify-between gap-3">
+                  <div class="min-w-0 flex-1 space-y-2">
+                    <div
+                      :if={@media_state == "pending"}
+                      class="text-xs font-medium uppercase tracking-wide text-theme-on-surface-muted"
+                    >
+                      Queue #{Map.get(@queue_positions, media_item.id, "-")}
+                    </div>
+                    <div class="flex items-start gap-2">
+                      <.icon
+                        :if={media_item.last_error}
+                        name="hero-exclamation-circle-solid"
+                        class="theme-status-error mt-0.5 shrink-0"
+                      />
+                      <.failure_badge :if={@media_state == "failed"} error_type={media_item.error_type} />
+                      <div class="min-w-0">
+                        <.subtle_link href={~p"/sources/#{@source.id}/media/#{media_item.id}"}>
+                          <span class="block whitespace-normal break-words font-medium text-theme-on-surface">
+                            {media_item.title}
+                          </span>
+                        </.subtle_link>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="flex items-center gap-2">
+                    <.icon_button
+                      :if={@media_state not in ["downloaded", "failed"]}
+                      icon_name="hero-arrow-down-tray"
+                      class="h-10 w-10"
+                      phx-click="force_download"
+                      phx-value-media-id={media_item.id}
+                      data-confirm="Are you sure you want to force a download of this media?"
+                      tooltip="Force Download"
+                      tooltip_position="bottom-left"
+                    />
+                    <.icon_button
+                      :if={@media_state == "failed" and media_item.error_type != :permanent}
+                      icon_name="hero-arrow-path"
+                      class="h-10 w-10"
+                      phx-click="retry_download"
+                      phx-value-media-id={media_item.id}
+                      data-confirm="Retry this download now?"
+                      tooltip="Retry Now"
+                      tooltip_position="bottom-left"
+                    />
+                    <.icon_button
+                      :if={@media_state == "failed" and media_item.error_type == :permanent}
+                      icon_name="hero-arrow-path"
+                      class="h-10 w-10"
+                      phx-click="force_download"
+                      phx-value-media-id={media_item.id}
+                      data-confirm="Force a retry of this permanent failure?"
+                      tooltip="Force Retry"
+                      tooltip_position="bottom-left"
+                    />
+                    <.icon_button
+                      :if={Map.has_key?(@tasks_by_media_item_id, media_item.id)}
+                      icon_name="hero-stop-solid"
+                      variant="danger"
+                      class="h-10 w-10"
+                      phx-click="stop_download"
+                      phx-value-task-id={Map.fetch!(@tasks_by_media_item_id, media_item.id).id}
+                      phx-value-media-id={media_item.id}
+                      data-confirm="Are you sure you want to stop this download?"
+                      tooltip="Stop Download"
+                      tooltip_position="bottom-left"
+                    />
+                    <.icon_link href={~p"/sources/#{@source.id}/media/#{media_item.id}/edit"} icon="hero-pencil-square" />
+                  </div>
+                </div>
+
+                <div
+                  :if={media_item.last_error}
+                  class="theme-danger-panel whitespace-pre-wrap break-words rounded-m3-sm p-3 text-xs"
+                >
+                  {media_item.last_error}
+                </div>
+
+                <dl class="grid grid-cols-1 gap-3 text-sm">
+                  <div class="flex items-start justify-between gap-3">
+                    <dt class="text-theme-on-surface-muted">Upload Date</dt>
+                    <dd class="text-right text-theme-on-surface">{upload_date_label(media_item.uploaded_at)}</dd>
+                  </div>
+                  <div class="flex items-start justify-between gap-3">
+                    <dt class="text-theme-on-surface-muted">Availability</dt>
+                    <dd class="text-right"><.availability_badge availability={media_item.availability} /></dd>
+                  </div>
+                  <div class="flex items-start justify-between gap-3">
+                    <dt class="text-theme-on-surface-muted">Size / Progress</dt>
+                    <dd class="max-w-[65%] text-right text-theme-on-surface">
+                      <.progress_details media_item={media_item} task={Map.get(@tasks_by_media_item_id, media_item.id)} />
+                    </dd>
+                  </div>
+                  <div :if={@media_state == "other"} class="flex items-start justify-between gap-3">
+                    <dt class="text-theme-on-surface-muted">Status</dt>
+                    <dd class="text-right text-theme-on-surface">
+                      <% status = media_status(media_item) %>
+                      <.tooltip tooltip={status.tooltip} position="bottom-right" tooltip_class="w-64">
+                        <span class={["flex items-center gap-1.5", status.class]}>
+                          <.icon name={status.icon} class="w-5 h-5 shrink-0" />
+                          <span>{status.label}</span>
+                        </span>
+                      </.tooltip>
+                    </dd>
+                  </div>
+                </dl>
+              </article>
+            </div>
+
+            <div class="hidden md:block">
+              <.table rows={group.records}>
+                <:col :let={media_item} :if={@media_state == "pending"} label="#" class="w-16 text-center">
+                  {Map.get(@queue_positions, media_item.id, "-")}
+                </:col>
+
+                <:col :let={media_item} label="Title" class="max-w-sm">
+                  <section class="space-y-2">
+                    <div class="flex items-start space-x-1 gap-2">
+                      <.icon
+                        :if={media_item.last_error}
+                        name="hero-exclamation-circle-solid"
+                        class="theme-status-error shrink-0"
+                      />
+                      <.failure_badge :if={@media_state == "failed"} error_type={media_item.error_type} />
+                      <.icon_button
+                        :if={@media_state not in ["downloaded", "failed"]}
+                        icon_name="hero-arrow-down-tray"
+                        class="h-10 w-10"
+                        phx-click="force_download"
+                        phx-value-media-id={media_item.id}
+                        data-confirm="Are you sure you want to force a download of this media?"
+                        tooltip="Force Download"
+                        tooltip_position="bottom-left"
+                      />
+                      <.icon_button
+                        :if={@media_state == "failed" and media_item.error_type != :permanent}
+                        icon_name="hero-arrow-path"
+                        class="h-10 w-10"
+                        phx-click="retry_download"
+                        phx-value-media-id={media_item.id}
+                        data-confirm="Retry this download now?"
+                        tooltip="Retry Now"
+                        tooltip_position="bottom-left"
+                      />
+                      <.icon_button
+                        :if={@media_state == "failed" and media_item.error_type == :permanent}
+                        icon_name="hero-arrow-path"
+                        class="h-10 w-10"
+                        phx-click="force_download"
+                        phx-value-media-id={media_item.id}
+                        data-confirm="Force a retry of this permanent failure?"
+                        tooltip="Force Retry"
+                        tooltip_position="bottom-left"
+                      />
+                      <.subtle_link href={~p"/sources/#{@source.id}/media/#{media_item.id}"}>
+                        <span class="block whitespace-normal break-words">{media_item.title}</span>
+                      </.subtle_link>
+                    </div>
+
+                    <div :if={media_item.last_error} class="theme-status-error whitespace-pre-wrap break-words text-xs">
+                      {media_item.last_error}
+                    </div>
+                  </section>
+                </:col>
+
+                <:col :let={media_item} :if={@media_state == "other"} label="Status">
+                  <% status = media_status(media_item) %>
+                  <.tooltip tooltip={status.tooltip} position="bottom-right" tooltip_class="w-64">
+                    <span class={["flex items-center gap-1.5", status.class]}>
+                      <.icon name={status.icon} class="w-5 h-5 shrink-0" />
+                      <span>{status.label}</span>
+                    </span>
+                  </.tooltip>
+                </:col>
+
+                <:col :let={media_item} label="Availability">
+                  <.availability_badge availability={media_item.availability} />
+                </:col>
+
+                <:col :let={media_item} label="Upload Date">{upload_date_label(media_item.uploaded_at)}</:col>
+
+                <:col :let={media_item} label="Size / Progress">
+                  <.progress_details media_item={media_item} task={Map.get(@tasks_by_media_item_id, media_item.id)} />
+                </:col>
+
+                <:col :let={media_item} label="Action">
+                  <.icon_button
+                    :if={Map.has_key?(@tasks_by_media_item_id, media_item.id)}
+                    icon_name="hero-stop-solid"
+                    variant="danger"
+                    class="h-10 w-10"
+                    phx-click="stop_download"
+                    phx-value-task-id={Map.fetch!(@tasks_by_media_item_id, media_item.id).id}
+                    phx-value-media-id={media_item.id}
+                    data-confirm="Are you sure you want to stop this download?"
+                    tooltip="Stop Download"
+                    tooltip_position="bottom-left"
+                  />
+                  <span :if={!Map.has_key?(@tasks_by_media_item_id, media_item.id)} class="text-theme-on-surface-muted">-</span>
+                </:col>
+                <:col :let={media_item} label="" class="align-middle text-right">
+                  <div class="flex justify-end">
+                    <.icon_link
+                      href={~p"/sources/#{@source.id}/media/#{media_item.id}/edit"}
+                      icon="hero-pencil-square"
+                      class="mr-4"
+                    />
+                  </div>
+                </:col>
+              </.table>
+            </div>
           </div>
-
-          <dl class="grid grid-cols-1 gap-3 text-sm">
-            <div class="flex items-start justify-between gap-3">
-              <dt class="text-theme-on-surface-muted">Upload Date</dt>
-              <dd class="text-right text-theme-on-surface">{DateTime.to_date(media_item.uploaded_at)}</dd>
-            </div>
-            <div class="flex items-start justify-between gap-3">
-              <dt class="text-theme-on-surface-muted">Availability</dt>
-              <dd class="text-right"><.availability_badge availability={media_item.availability} /></dd>
-            </div>
-            <div class="flex items-start justify-between gap-3">
-              <dt class="text-theme-on-surface-muted">Size / Progress</dt>
-              <dd class="max-w-[65%] text-right text-theme-on-surface">
-                <.progress_details media_item={media_item} task={Map.get(@tasks_by_media_item_id, media_item.id)} />
-              </dd>
-            </div>
-            <div :if={@media_state == "other"} class="flex items-start justify-between gap-3">
-              <dt class="text-theme-on-surface-muted">Status</dt>
-              <dd class="text-right text-theme-on-surface">
-                <% status = media_status(media_item) %>
-                <.tooltip tooltip={status.tooltip} position="bottom-right" tooltip_class="w-64">
-                  <span class={["flex items-center gap-1.5", status.class]}>
-                    <.icon name={status.icon} class="w-5 h-5 shrink-0" />
-                    <span>{status.label}</span>
-                  </span>
-                </.tooltip>
-              </dd>
-            </div>
-          </dl>
-        </article>
-      </div>
-
-      <div class="hidden md:block">
-        <.table rows={@records}>
-          <:col :let={media_item} :if={@media_state == "pending"} label="#" class="w-16 text-center">
-            {Map.get(@queue_positions, media_item.id, "-")}
-          </:col>
-
-          <:col :let={media_item} label="Title" class="max-w-sm">
-            <section class="space-y-2">
-              <div class="flex items-start space-x-1 gap-2">
-                <.icon :if={media_item.last_error} name="hero-exclamation-circle-solid" class="theme-status-error shrink-0" />
-                <.failure_badge :if={@media_state == "failed"} error_type={media_item.error_type} />
-                <.icon_button
-                  :if={@media_state not in ["downloaded", "failed"]}
-                  icon_name="hero-arrow-down-tray"
-                  class="h-10 w-10"
-                  phx-click="force_download"
-                  phx-value-media-id={media_item.id}
-                  data-confirm="Are you sure you want to force a download of this media?"
-                  tooltip="Force Download"
-                  tooltip_position="bottom-left"
-                />
-                <.icon_button
-                  :if={@media_state == "failed" and media_item.error_type != :permanent}
-                  icon_name="hero-arrow-path"
-                  class="h-10 w-10"
-                  phx-click="retry_download"
-                  phx-value-media-id={media_item.id}
-                  data-confirm="Retry this download now?"
-                  tooltip="Retry Now"
-                  tooltip_position="bottom-left"
-                />
-                <.icon_button
-                  :if={@media_state == "failed" and media_item.error_type == :permanent}
-                  icon_name="hero-arrow-path"
-                  class="h-10 w-10"
-                  phx-click="force_download"
-                  phx-value-media-id={media_item.id}
-                  data-confirm="Force a retry of this permanent failure?"
-                  tooltip="Force Retry"
-                  tooltip_position="bottom-left"
-                />
-                <.subtle_link href={~p"/sources/#{@source.id}/media/#{media_item.id}"}>
-                  <span class="block whitespace-normal break-words">{media_item.title}</span>
-                </.subtle_link>
-              </div>
-
-              <div :if={media_item.last_error} class="theme-status-error whitespace-pre-wrap break-words text-xs">
-                {media_item.last_error}
-              </div>
-            </section>
-          </:col>
-
-          <:col :let={media_item} :if={@media_state == "other"} label="Status">
-            <% status = media_status(media_item) %>
-            <.tooltip tooltip={status.tooltip} position="bottom-right" tooltip_class="w-64">
-              <span class={["flex items-center gap-1.5", status.class]}>
-                <.icon name={status.icon} class="w-5 h-5 shrink-0" />
-                <span>{status.label}</span>
-              </span>
-            </.tooltip>
-          </:col>
-
-          <:col :let={media_item} label="Availability">
-            <.availability_badge availability={media_item.availability} />
-          </:col>
-
-          <:col :let={media_item} label="Upload Date">{DateTime.to_date(media_item.uploaded_at)}</:col>
-
-          <:col :let={media_item} label="Size / Progress">
-            <.progress_details media_item={media_item} task={Map.get(@tasks_by_media_item_id, media_item.id)} />
-          </:col>
-
-          <:col :let={media_item} label="Action">
-            <.icon_button
-              :if={Map.has_key?(@tasks_by_media_item_id, media_item.id)}
-              icon_name="hero-stop-solid"
-              variant="danger"
-              class="h-10 w-10"
-              phx-click="stop_download"
-              phx-value-task-id={Map.fetch!(@tasks_by_media_item_id, media_item.id).id}
-              phx-value-media-id={media_item.id}
-              data-confirm="Are you sure you want to stop this download?"
-              tooltip="Stop Download"
-              tooltip_position="bottom-left"
-            />
-            <span :if={!Map.has_key?(@tasks_by_media_item_id, media_item.id)} class="text-theme-on-surface-muted">-</span>
-          </:col>
-          <:col :let={media_item} label="" class="align-middle text-right">
-            <div class="flex justify-end">
-              <.icon_link
-                href={~p"/sources/#{@source.id}/media/#{media_item.id}/edit"}
-                icon="hero-pencil-square"
-                class="mr-4"
-              />
-            </div>
-          </:col>
-        </.table>
+        </section>
       </div>
       <section class="flex justify-center mt-5">
         <.live_pagination_controls page_number={@page} total_pages={@total_pages} />
@@ -466,7 +504,7 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
     else
       records =
         fetch_records(base_query, page)
-        |> order_by(desc: :uploaded_at)
+        |> order_by(desc: :uploaded_at, desc: :id)
         |> Repo.all()
 
       build_pagination_attrs(
@@ -514,7 +552,7 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
     else
       records =
         fetch_records(filtered_base_query, page)
-        |> order_by(desc: fragment("rank"), desc: :uploaded_at)
+        |> order_by(desc: fragment("rank"), desc: :uploaded_at, desc: :id)
         |> Repo.all()
 
       build_pagination_attrs(
@@ -622,9 +660,36 @@ defmodule PinchflatWeb.Sources.MediaItemTableLive do
 
     attrs
     |> Map.put(:records, ordered_records)
+    |> Map.put(:grouped_records, group_records_by_year(ordered_records))
     |> Map.put(:tasks_by_media_item_id, tasks_by_media_item_id)
     |> Map.put(:queue_positions, build_queue_positions(queue_base_query, ordered_records, media_state))
   end
+
+  defp group_records_by_year(records) do
+    records
+    |> Enum.group_by(&uploaded_year(&1.uploaded_at))
+    |> Enum.sort_by(fn {year, _records} -> year_sort_key(year) end)
+    |> Enum.with_index()
+    |> Enum.map(fn {{year, year_records}, index} ->
+      %{year: year, records: year_records, open?: index == 0}
+    end)
+  end
+
+  defp uploaded_year(nil), do: :unknown
+  defp uploaded_year(%DateTime{year: year}), do: year
+
+  defp year_sort_key(:unknown), do: {1, 0}
+  defp year_sort_key(year), do: {0, -year}
+
+  defp year_label(:unknown), do: "Unknown year"
+  defp year_label(year), do: to_string(year)
+
+  defp year_content_id(media_state, year) do
+    "media-year-#{media_state}-#{if year == :unknown, do: "unknown", else: year}"
+  end
+
+  defp upload_date_label(nil), do: "Unknown"
+  defp upload_date_label(%DateTime{} = uploaded_at), do: DateTime.to_date(uploaded_at)
 
   defp fetch_download_tasks(records) do
     media_item_ids = Enum.map(records, & &1.id)

--- a/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/sources/source_html/show.html.heex
@@ -74,6 +74,8 @@
       </div>
     </section>
 
+    <.source_statistics statistics={@media_statistics} />
+
     <.tabbed_layout active_tab={@active_tab} tab_href={@tab_href}>
       <:tab_append><.actions_dropdown source={@source} conn={@conn} /></:tab_append>
 

--- a/test/pinchflat/media_test.exs
+++ b/test/pinchflat/media_test.exs
@@ -48,6 +48,132 @@ defmodule Pinchflat.MediaTest do
     end
   end
 
+  describe "source_media_statistics/1" do
+    test "counts each source media item in one mutually exclusive bucket" do
+      media_profile = media_profile_fixture(%{shorts_behaviour: :exclude})
+      source = source_fixture(%{media_profile_id: media_profile.id})
+
+      _downloaded = media_item_fixture(%{source_id: source.id})
+      _pending = media_item_fixture(%{source_id: source.id, media_filepath: nil})
+
+      _failed =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          last_error: "Network is unreachable"
+        })
+
+      _prevented =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          prevent_download: true,
+          download_prevented_reason: :manual
+        })
+
+      _unavailable =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          prevent_download: true,
+          unavailable_at: now(),
+          unavailable_reason: "Private video"
+        })
+
+      _filtered =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          short_form_content: true
+        })
+
+      assert Media.source_media_statistics(source) == %{
+               downloaded: 1,
+               pending: 1,
+               failed: 1,
+               prevented: 1,
+               unavailable: 2
+             }
+    end
+
+    test "uses precedence for legacy rows that match multiple predicates" do
+      source = source_fixture()
+
+      _downloaded_wins =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: "/video/legacy.mp4",
+          last_error: "old error",
+          prevent_download: true,
+          unavailable_at: now(),
+          culled_at: now()
+        })
+
+      _unavailable_wins =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          last_error: "Video unavailable",
+          prevent_download: true,
+          unavailable_at: now()
+        })
+
+      _failed_wins =
+        media_item_fixture(%{
+          source_id: source.id,
+          media_filepath: nil,
+          last_error: "Permanent failure",
+          error_type: :permanent,
+          prevent_download: true,
+          download_prevented_reason: :error
+        })
+
+      assert Media.source_media_statistics(source) == %{
+               downloaded: 1,
+               pending: 0,
+               failed: 1,
+               prevented: 0,
+               unavailable: 1
+             }
+    end
+
+    test "uses a bounded aggregate query set rather than one query per status" do
+      source = source_fixture()
+
+      for _index <- 1..8 do
+        media_item_fixture(%{source_id: source.id, media_filepath: nil})
+      end
+
+      parent = self()
+      handler_id = "source-media-statistics-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:pinchflat, :repo, :query],
+        fn _event, _measurements, metadata, _config ->
+          send(parent, {:source_statistics_query, metadata.query})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      assert %{pending: 8} = Media.source_media_statistics(source)
+
+      queries =
+        Stream.repeatedly(fn ->
+          receive do
+            {:source_statistics_query, query} -> query
+          after
+            0 -> :done
+          end
+        end)
+        |> Enum.take_while(&(&1 != :done))
+
+      assert length(queries) == 2
+    end
+  end
+
   describe "list_upgradeable_media_items/0" do
     setup do
       media_profile = media_profile_fixture(%{redownload_delay_days: 4})

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -536,6 +536,36 @@ defmodule PinchflatWeb.SourceControllerTest do
   end
 
   describe "show source" do
+    test "renders source media statistics with mutually exclusive counts", %{conn: conn} do
+      source = source_fixture()
+
+      media_item_fixture(source_id: source.id)
+      media_item_fixture(source_id: source.id)
+
+      for _index <- 1..3 do
+        media_item_fixture(source_id: source.id, media_filepath: nil)
+      end
+
+      media_item_fixture(source_id: source.id, media_filepath: nil, last_error: "Network is unreachable")
+
+      media_item_fixture(
+        source_id: source.id,
+        media_filepath: nil,
+        prevent_download: true,
+        download_prevented_reason: :manual
+      )
+
+      media_item_fixture(source_id: source.id, media_filepath: nil, unavailable_at: DateTime.utc_now())
+
+      response = conn |> get(~p"/sources/#{source}") |> html_response(200)
+
+      assert response =~ ~s(aria-label="Downloaded: 2")
+      assert response =~ ~s(aria-label="Pending: 3")
+      assert response =~ ~s(aria-label="Failed: 1")
+      assert response =~ ~s(aria-label="Prevented: 1")
+      assert response =~ ~s(aria-label="Unavailable / Skipped: 1")
+    end
+
     test "renders delayed download summary for manual playlists", %{conn: conn} do
       source = source_fixture(%{collection_type: :playlist, selection_mode: :manual, download_media: false})
 

--- a/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
+++ b/test/pinchflat_web/controllers/sources/media_item_table_live_test.exs
@@ -36,6 +36,38 @@ defmodule PinchflatWeb.Sources.MediaItemTableLiveTest do
       assert html =~ "Members-only"
       assert html =~ media_item.title
     end
+
+    test "groups records by newest upload year and exposes accessible collapse state", %{conn: conn, source: source} do
+      newest =
+        media_item_fixture(
+          source_id: source.id,
+          title: "NEWEST_YEAR_ITEM",
+          uploaded_at: ~U[2025-06-01 12:00:00Z]
+        )
+
+      older =
+        media_item_fixture(
+          source_id: source.id,
+          title: "OLDER_YEAR_ITEM",
+          uploaded_at: ~U[2024-06-01 12:00:00Z]
+        )
+
+      {:ok, _view, html} = live_isolated(conn, MediaItemTableLive, session: create_session(source, "downloaded"))
+
+      newest_id = ~s(id="media-year-downloaded-2025")
+      older_id = ~s(id="media-year-downloaded-2024")
+
+      assert html =~ newest.title
+      assert html =~ older.title
+      assert html =~ ~s(aria-label="Toggle 2025 media")
+      assert html =~ ~s(aria-label="Toggle 2024 media")
+      assert html =~ ~s(aria-expanded="true")
+      assert html =~ ~s(aria-expanded="false")
+      assert html =~ ~s(aria-controls="media-year-downloaded-2025")
+      assert html =~ ~s(x-show="open")
+
+      assert elem(:binary.match(html, newest_id), 0) < elem(:binary.match(html, older_id), 0)
+    end
   end
 
   describe "media_state" do


### PR DESCRIPTION
## Summary

- Add a compact source media statistics bar with mutually exclusive Downloaded, Pending, Failed, Prevented, and Unavailable / Skipped counts.
- Group the current paginated media page by upload year with newest-first sections and accessible collapse controls.
- Preserve existing filters, pagination, retry actions, task progress, and media-state behavior.

## Verification

- Docker focused tests: 204 passed.
- Docker full suite: 1,684 passed.
- Docker format check, compile with warnings as errors, Credo, UI theme check, Sobelow, and `git diff --check` passed.
- Sobelow reported only the three pre-existing low-confidence findings in unchanged diagnostics files.
- Browser page-3 smoke test: `/sources/1` rendered all five statistics labels/counts; Downloaded tab rendered the 2026 year disclosure and media table; collapsing it removed the media DOM while retaining the control and pagination.
- Fresh independent Sol verification: PASS on commit `e4da219abe9255ee8d72c405b59f4c720289a22e`.
- Known environment-only issue: Prettier cannot scan `/app/.agents/skills` through the Docker junction (`EPERM`).
- Generated `priv/repo/erd.png` was restored byte-for-byte. The pre-existing untracked `plans/` directory was preserved.
