### PR TITLE
Add channel discovery suggestions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ pinchflat.db.backup-*
 
 build.log
 /.codex-local-build-pr/
+/.agents/**
 /.gitattributes
 /.ai/mcp/mcp.json
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,3 @@
 assets/vendor/
+/.agents/**
+/plans/**

--- a/assets/js/alpine_helpers.js
+++ b/assets/js/alpine_helpers.js
@@ -44,6 +44,8 @@ window.settingsPage = () => ({
       'notifications notify apprise server webhook discord telegram email external base url public pinchflat',
     extractor:
       'extractor youtube api key sleep interval throughput download workers indexing metadata concurrency restrict filenames ascii ignore unavailable members-only private time format 12h 24h clock database compaction vacuum sqlite',
+    discovery:
+      'discovery channel suggestions scheduled scan mention mentions metadata featured subscribed',
     ytdlp:
       'yt-dlp ytdlp youtube-dl update nightly stable pinned version base config force-ipv4 retries fragment-retries socket-timeout ipv4',
     codec: 'codec video audio avc m4a remux preference mp4',

--- a/config/config.exs
+++ b/config/config.exs
@@ -41,6 +41,21 @@ config :pinchflat,
   # instant. Kept low by default (and tied to YT_DLP_WORKER_CONCURRENCY at runtime)
   # so we don't hammer YouTube and earn a rate-limit/IP ban. Overridden in runtime.exs.
   reconcile_backfill_concurrency: 2,
+  channel_discovery: [
+    max_sources: 100,
+    max_candidates: 100,
+    max_validated: 50,
+    sample_pool_size: 50,
+    sample_size: 12,
+    max_metadata_bytes: 512 * 1024,
+    max_text_bytes: 1 * 1024 * 1024,
+    max_entries: 25,
+    max_output_bytes: 256 * 1024,
+    validation_concurrency: 4,
+    validation_timeout: 5_000,
+    featured_timeout: 15_000,
+    validation_refresh_after_seconds: 86_400
+  ],
   timezone: "UTC",
   base_route_path: "/"
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -169,6 +169,10 @@ config :pinchflat, Oban,
        {"#{current_minute} #{current_hour} * * *", Pinchflat.YtDlp.UpdateWorker},
        {"0 1 * * *", Pinchflat.Downloading.MediaRetentionWorker},
        {"0 2 * * *", Pinchflat.Downloading.MediaQualityUpgradeWorker},
+       # Discovery is opt-in in the database. The worker cancels this cheap
+       # scheduled job while disabled, so a setting change does not require a
+       # runtime config reload or a scheduler restart.
+       {"0 3 * * *", Pinchflat.Discovery.Worker},
        # Monthly, after retention (1AM) and quality upgrades (2AM) have had a
        # chance to delete records whose space the VACUUM can then reclaim
        {"0 3 1 * *", Pinchflat.Diagnostics.DatabaseMaintenanceWorker}

--- a/docker/docker-compose.preview.yml
+++ b/docker/docker-compose.preview.yml
@@ -3,7 +3,7 @@ name: pinchyt-preview
 services:
   pot-provider:
     image: brainicism/bgutil-ytdlp-pot-provider:2.0.0
-    profiles: ["pot-provider"]
+    profiles: ['pot-provider']
     restart: unless-stopped
     # The provider is intentionally internal-only. Do not add a ports mapping.
     healthcheck:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,7 +3,7 @@ name: pinchyt
 services:
   pot-provider:
     image: brainicism/bgutil-ytdlp-pot-provider:2.0.0
-    profiles: ["pot-provider"]
+    profiles: ['pot-provider']
     restart: unless-stopped
     # The provider is intentionally internal-only. Do not add a ports mapping.
     healthcheck:

--- a/lib/pinchflat/discovery.ex
+++ b/lib/pinchflat/discovery.ex
@@ -1,0 +1,831 @@
+defmodule Pinchflat.Discovery do
+  @moduledoc """
+  The channel discovery context.
+
+  Suggestions are keyed by the stable external channel ID. Every generator
+  feeds the same normalization, exclusion, validation, scoring, and idempotent
+  persistence path. Dismissed and accepted suggestions remain terminal so a
+  later scan cannot silently make them visible again.
+  """
+
+  import Ecto.Query, warn: false
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.FeaturedGenerator
+  alias Pinchflat.Discovery.MentionGenerator
+  alias Pinchflat.Discovery.Normalizer
+  alias Pinchflat.Discovery.Sample
+  alias Pinchflat.Discovery.Scoring
+  alias Pinchflat.Discovery.Suggestion
+  alias Pinchflat.Discovery.Validator
+  alias Pinchflat.Repo
+  alias Pinchflat.Settings
+  alias Pinchflat.Sources.Source
+
+  @visible_states [:candidate, :validated]
+  @terminal_states [:dismissed, :accepted]
+  @max_evidence_length 512
+  @max_generators_count 16
+  @max_generators_length 256
+  @max_score 100
+  @max_channel_name_length 200
+  @max_url_length 2_048
+  @default_sample_size 12
+  @default_pool_size 50
+  @default_max_candidates 100
+
+  @completion_topic "channel_discovery"
+  @completion_event "scan_completed"
+
+  @doc """
+  Returns visible suggestions ordered by descending score and stable ID.
+
+  Terminal suggestions are excluded unless `include_terminal: true` or an
+  explicit `states:` option is supplied.
+  """
+  def list_suggestions(opts \\ []) do
+    states = states_for_listing(opts)
+
+    Suggestion
+    |> where([suggestion], suggestion.state in ^states)
+    |> order_by([suggestion], desc: suggestion.score, asc: suggestion.id)
+    |> maybe_limit(Keyword.get(opts, :limit))
+    |> Repo.all()
+  end
+
+  @doc """
+  Returns all dismissed suggestions.
+  """
+  def list_dismissed_suggestions, do: list_suggestions(states: [:dismissed])
+
+  @doc """
+  Gets a suggestion by its database ID.
+
+  Raises `Ecto.NoResultsError` when the suggestion does not exist.
+  """
+  def get_suggestion!(id), do: Repo.get!(Suggestion, id)
+
+  @doc """
+  Gets a suggestion by its database ID, or returns nil.
+  """
+  def get_suggestion(id), do: Repo.get(Suggestion, id)
+
+  @doc """
+  Gets a suggestion by its stable external channel ID.
+  """
+  def get_suggestion_by_external_channel_id(external_channel_id) do
+    Repo.get_by(Suggestion, external_channel_id: external_channel_id)
+  end
+
+  @doc """
+  Returns external channel IDs that must not be suggested again.
+
+  This includes subscribed channel sources and terminal suggestions. Values are
+  stable IDs, not display names or mutable URLs.
+  """
+  def excluded_channel_ids do
+    (existing_source_channel_ids() ++ terminal_suggestion_channel_ids())
+    |> Enum.uniq()
+  end
+
+  @doc """
+  Returns the PubSub topic used for scan completion notifications.
+  """
+  def completion_topic, do: @completion_topic
+
+  @doc """
+  Returns the event name used for scan completion notifications.
+  """
+  def completion_event, do: @completion_event
+
+  @doc """
+  Subscribes the caller to discovery scan completion broadcasts.
+  """
+  def subscribe, do: Phoenix.PubSub.subscribe(Pinchflat.PubSub, @completion_topic)
+
+  @doc """
+  Normalizes raw generator references into candidates and deduplicates evidence.
+  """
+  def normalize_candidates(references, generator, opts \\ []) when is_list(references) do
+    self_references = Keyword.get(opts, :self_references, [])
+    self_keys = self_reference_keys(self_references)
+
+    references
+    |> Enum.flat_map(fn
+      %Candidate{} = candidate ->
+        reference_key = if is_map(candidate.reference), do: Map.get(candidate.reference, :key), else: nil
+
+        if reference_key in self_keys do
+          []
+        else
+          [add_generator(candidate, generator)]
+        end
+
+      reference ->
+        case Normalizer.normalize_reference(reference, self_references: self_references) do
+          nil ->
+            []
+
+          normalized ->
+            attrs = if is_map(reference), do: reference, else: %{}
+            [Candidate.from_reference(normalized, generator, attrs)]
+        end
+    end)
+    |> Candidate.deduplicate()
+  end
+
+  @doc """
+  Excludes candidates matching existing subscribed channels or dismissed rows.
+
+  `:existing_sources` and `:dismissed_suggestions` may be supplied as lists to
+  keep this function useful in isolated tests. Without them, the local database
+  is queried.
+  """
+  def exclude_candidates(candidates, opts \\ []) when is_list(candidates) do
+    existing_sources = Keyword.get_lazy(opts, :existing_sources, &list_existing_channel_sources/0)
+    dismissed_suggestions = Keyword.get_lazy(opts, :dismissed_suggestions, &list_dismissed_suggestion_records/0)
+
+    excluded =
+      (Enum.flat_map(existing_sources, &identity_records/1) ++ Enum.flat_map(dismissed_suggestions, &identity_records/1))
+      |> Enum.reduce(%{keys: MapSet.new(), ids: MapSet.new(), urls: MapSet.new()}, &add_identity/2)
+
+    Enum.reject(candidates, fn %Candidate{} = candidate -> excluded_candidate?(candidate, excluded) end)
+  end
+
+  @doc """
+  Inserts or updates a suggestion by `external_channel_id`.
+
+  Existing dismissed or accepted rows are returned unchanged. Evidence,
+  generator provenance, and scores are bounded before persistence, and a
+  validated row receives a validation timestamp on its first insert.
+  """
+  def upsert_suggestion(%Candidate{} = candidate), do: upsert_suggestion(candidate_attrs(candidate))
+
+  def upsert_suggestion(attrs) when is_map(attrs) do
+    attrs = normalize_attrs(attrs)
+
+    cond do
+      blank?(attrs.external_channel_id) ->
+        {:error, Suggestion.changeset(%Suggestion{}, attrs)}
+
+      not Normalizer.valid_channel_id?(attrs.external_channel_id) ->
+        {:error, :invalid_channel_id}
+
+      attrs.external_channel_id in existing_source_channel_ids() ->
+        {:error, :existing_source}
+
+      true ->
+        do_upsert(attrs.external_channel_id, attrs)
+    end
+  end
+
+  @doc """
+  Compatibility alias for callers that treat the first persistence as a create.
+  """
+  def create_suggestion(attrs), do: upsert_suggestion(attrs)
+
+  @doc """
+  Returns a changeset for a suggestion without persisting it.
+  """
+  def change_suggestion(%Suggestion{} = suggestion, attrs \\ %{}) do
+    Suggestion.changeset(suggestion, attrs)
+  end
+
+  @doc """
+  Updates a suggestion using its schema changeset.
+  """
+  def update_suggestion(%Suggestion{} = suggestion, attrs) do
+    suggestion
+    |> Suggestion.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Marks a suggestion as dismissed.
+
+  An already accepted suggestion remains accepted.
+  """
+  def dismiss_suggestion(%Suggestion{state: :accepted} = suggestion), do: {:ok, suggestion}
+  def dismiss_suggestion(%Suggestion{} = suggestion), do: update_suggestion(suggestion, %{state: :dismissed})
+  def dismiss_suggestion(id), do: id |> get_suggestion!() |> dismiss_suggestion()
+
+  @doc """
+  Marks a suggestion as accepted.
+
+  An already dismissed suggestion remains dismissed.
+  """
+  def accept_suggestion(%Suggestion{state: :dismissed} = suggestion), do: {:ok, suggestion}
+  def accept_suggestion(%Suggestion{} = suggestion), do: update_suggestion(suggestion, %{state: :accepted})
+  def accept_suggestion(id), do: id |> get_suggestion!() |> accept_suggestion()
+
+  @doc """
+  Restores a dismissed suggestion to the validated state.
+  """
+  def restore_suggestion(%Suggestion{state: :dismissed} = suggestion),
+    do: update_suggestion(suggestion, %{state: :validated})
+
+  def restore_suggestion(%Suggestion{} = suggestion), do: {:ok, suggestion}
+  def restore_suggestion(id), do: id |> get_suggestion!() |> restore_suggestion()
+
+  @doc """
+  Runs the bounded discovery pipeline and persists validated suggestions.
+
+  The scan respects the global and per-generator settings by default. Pass
+  `manual: true` to run an explicit scan even while the scheduled feature gate
+  is disabled. Generator functions, source lists, validation, and randomness
+  remain injectable for focused tests.
+  """
+  def scan(opts \\ []) do
+    result = do_scan(opts)
+
+    if Keyword.get(opts, :broadcast, false) do
+      broadcast_completion(completion_payload(result))
+    end
+
+    result
+  end
+
+  @doc """
+  Persists validated candidates without creating duplicate rows.
+  """
+  def persist_suggestions(candidates, opts \\ []) when is_list(candidates) do
+    now = Keyword.get(opts, :now) || now()
+
+    Enum.reduce_while(candidates, {:ok, []}, fn %Candidate{} = candidate, {:ok, persisted} ->
+      attrs = candidate_attrs(candidate) |> Map.put(:state, :validated) |> Map.put(:validated_at, now)
+
+      case upsert_suggestion(attrs) do
+        {:ok, suggestion} -> {:cont, {:ok, [suggestion | persisted]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, suggestions} -> {:ok, Enum.reverse(suggestions)}
+      error -> error
+    end
+  end
+
+  @doc """
+  Selects a bounded random display sample from persisted validated suggestions.
+  """
+  def sample_suggestions(opts \\ []) do
+    sample_size = Keyword.get(opts, :sample_size, default(:sample_size) || @default_sample_size)
+    pool_size = Keyword.get(opts, :pool_size, default(:sample_pool_size) || @default_pool_size)
+    random_fun = Keyword.get(opts, :random_fun, &Enum.take_random/2)
+
+    list_suggestions(states: [:validated], limit: pool_size)
+    |> Enum.map(&candidate_from_suggestion/1)
+    |> Sample.select(sample_size, max_pool: pool_size, random_fun: random_fun, score_fun: & &1.score)
+  end
+
+  @doc """
+  Broadcasts a safe completion payload to discovery subscribers.
+  """
+  def broadcast_completion(payload) when is_map(payload) do
+    Phoenix.PubSub.broadcast(
+      Pinchflat.PubSub,
+      @completion_topic,
+      %Phoenix.Socket.Broadcast{topic: @completion_topic, event: @completion_event, payload: payload}
+    )
+  end
+
+  @doc """
+  Returns the maximum evidence length applied by the context.
+  """
+  def max_evidence_length, do: @max_evidence_length
+
+  @doc """
+  Returns the maximum generator provenance length applied by the context.
+  """
+  def max_generators_length, do: @max_generators_length
+
+  @doc """
+  Returns the maximum score applied by the context.
+  """
+  def max_score, do: @max_score
+
+  defp do_scan(opts) do
+    manual? = Keyword.get(opts, :manual, false)
+    enabled? = Keyword.get_lazy(opts, :enabled, fn -> Settings.get!(:channel_discovery_enabled) end)
+
+    if not manual? and not enabled? do
+      {:ok, disabled_result()}
+    else
+      run_enabled_scan(opts)
+    end
+  end
+
+  defp run_enabled_scan(opts) do
+    generator_opts = Keyword.get(opts, :generator_opts, [])
+
+    max_candidates =
+      bounded_integer(
+        Keyword.get(opts, :max_candidates, default(:max_candidates) || @default_max_candidates),
+        @default_max_candidates
+      )
+
+    {generator_candidates, generator_errors} =
+      [:mention, :featured]
+      |> Enum.reduce({[], []}, fn generator, {candidates, errors} ->
+        if generator_enabled?(generator, opts) do
+          case run_generator(generator, opts, generator_opts) do
+            {:ok, generated} -> {candidates ++ normalize_candidates(generated, generator), errors}
+            {:error, reason} -> {candidates, [%{generator: generator, reason: safe_reason(reason)} | errors]}
+          end
+        else
+          {candidates, errors}
+        end
+      end)
+
+    candidates =
+      generator_candidates
+      |> Candidate.deduplicate()
+      |> exclude_candidates(opts)
+      |> Enum.take(max_candidates)
+      |> exclude_recently_validated(opts)
+
+    validation_opts = Keyword.get(opts, :validation_opts, [])
+    validation = Validator.validate(candidates, validation_opts)
+
+    validated_candidates =
+      validation.validated
+      |> Candidate.deduplicate()
+      |> exclude_candidates(opts)
+      |> Enum.map(fn candidate -> Candidate.with_score(candidate, Scoring.score(candidate)) end)
+
+    persist_opts = if Keyword.has_key?(opts, :now), do: [now: Keyword.get(opts, :now)], else: []
+
+    with {:ok, suggestions} <- persist_suggestions(validated_candidates, persist_opts) do
+      {:ok,
+       %{
+         status: :completed,
+         candidate_count: length(candidates),
+         validated_count: length(validated_candidates),
+         inserted_count: length(suggestions),
+         generator_errors: Enum.reverse(generator_errors),
+         validation_rejections: rejection_counts(validation.rejected),
+         suggestions: suggestions
+       }}
+    end
+  end
+
+  defp run_generator(:mention, opts, generator_opts) do
+    invoke_generator(generator_fun(opts, :mention), generator_opts, &MentionGenerator.generate/1)
+  end
+
+  defp run_generator(:featured, opts, generator_opts) do
+    invoke_generator(generator_fun(opts, :featured), generator_opts, &FeaturedGenerator.generate/1)
+  end
+
+  defp invoke_generator(nil, generator_opts, default_fun), do: safe_call(fn -> default_fun.(generator_opts) end)
+
+  defp invoke_generator(fun, generator_opts, _default_fun) when is_function(fun, 1),
+    do: safe_call(fn -> fun.(generator_opts) end)
+
+  defp invoke_generator(fun, _generator_opts, _default_fun) when is_function(fun, 0), do: safe_call(fun)
+  defp invoke_generator(_fun, _generator_opts, _default_fun), do: {:error, :generator_failed}
+
+  defp safe_call(fun) do
+    case fun.() do
+      {:ok, candidates} when is_list(candidates) -> {:ok, candidates}
+      candidates when is_list(candidates) -> {:ok, candidates}
+      {:error, reason} -> {:error, safe_reason(reason)}
+      _ -> {:error, :generator_failed}
+    end
+  rescue
+    _error -> {:error, :generator_failed}
+  catch
+    :exit, _reason -> {:error, :generator_failed}
+  end
+
+  defp generator_fun(opts, generator) do
+    opts
+    |> Keyword.get(:generator_funs, %{})
+    |> Map.get(generator)
+  end
+
+  defp generator_enabled?(:mention, opts) do
+    Keyword.get_lazy(opts, :mentions_enabled, fn -> Settings.get!(:channel_discovery_mentions_enabled) end)
+  end
+
+  defp generator_enabled?(:featured, opts) do
+    Keyword.get_lazy(opts, :featured_enabled, fn -> Settings.get!(:channel_discovery_featured_enabled) end)
+  end
+
+  defp add_generator(%Candidate{} = candidate, generator) do
+    %{candidate | generators: Enum.uniq([to_string(generator) | List.wrap(candidate.generators)])}
+  end
+
+  defp self_reference_keys(references) do
+    references
+    |> List.wrap()
+    |> Enum.flat_map(fn reference ->
+      case Normalizer.normalize_reference(reference) do
+        %{key: key} -> [key]
+        nil -> []
+      end
+    end)
+    |> MapSet.new()
+  end
+
+  defp exclude_recently_validated(candidates, opts) do
+    refresh_after =
+      bounded_integer(
+        Keyword.get(
+          opts,
+          :validation_refresh_after_seconds,
+          default(:validation_refresh_after_seconds) || 86_400
+        ),
+        86_400
+      )
+
+    if refresh_after == 0 do
+      candidates
+    else
+      now = Keyword.get(opts, :now) || now()
+      channel_ids = candidates |> Enum.map(& &1.external_channel_id) |> Enum.filter(&is_binary/1) |> Enum.uniq()
+
+      if channel_ids == [] do
+        candidates
+      else
+        recently_validated_ids =
+          opts
+          |> Keyword.get_lazy(:existing_suggestions, fn -> recently_validated_suggestions(channel_ids) end)
+          |> Enum.filter(&recently_validated?(&1, now, refresh_after))
+          |> Enum.map(&value_for(&1, :external_channel_id))
+          |> MapSet.new()
+
+        Enum.reject(candidates, &MapSet.member?(recently_validated_ids, &1.external_channel_id))
+      end
+    end
+  end
+
+  defp recently_validated_suggestions(channel_ids) do
+    Repo.all(
+      from suggestion in Suggestion,
+        where: suggestion.state == ^:validated and suggestion.external_channel_id in ^channel_ids,
+        select: %{
+          external_channel_id: suggestion.external_channel_id,
+          state: suggestion.state,
+          validated_at: suggestion.validated_at
+        }
+    )
+  end
+
+  defp recently_validated?(suggestion, now, refresh_after) do
+    state = value_for(suggestion, :state)
+    validated_at = value_for(suggestion, :validated_at)
+
+    state in [:validated, "validated"] and is_struct(validated_at, DateTime) and
+      DateTime.diff(now, validated_at, :second) < refresh_after
+  end
+
+  defp list_existing_channel_sources do
+    Repo.all(from source in Source, where: source.collection_type == ^:channel)
+  end
+
+  defp list_dismissed_suggestion_records do
+    Repo.all(from suggestion in Suggestion, where: suggestion.state in ^@terminal_states)
+  end
+
+  defp identity_records(%Source{} = source) do
+    [
+      %{
+        collection_id: source.collection_id,
+        canonical_url: source.original_url,
+        external_channel_id: source.collection_id
+      }
+    ]
+  end
+
+  defp identity_records(%Suggestion{} = suggestion) do
+    [
+      %{
+        collection_id: nil,
+        canonical_url: suggestion.canonical_url,
+        external_channel_id: suggestion.external_channel_id
+      }
+    ]
+  end
+
+  defp identity_records(source) when is_map(source), do: [source]
+  defp identity_records(_source), do: []
+
+  defp add_identity(record, excluded) do
+    refs = [
+      identity_value(record, :external_channel_id),
+      identity_value(record, :collection_id),
+      identity_value(record, :canonical_url) || identity_value(record, :original_url)
+    ]
+
+    Enum.reduce(refs, excluded, fn
+      value, acc when is_binary(value) ->
+        case Normalizer.normalize_reference(value) do
+          %{key: key} = reference ->
+            acc
+            |> Map.update!(:keys, &MapSet.put(&1, key))
+            |> maybe_add_id(reference)
+            |> maybe_add_url(reference)
+
+          nil ->
+            if String.starts_with?(value, "http"), do: Map.update!(acc, :urls, &MapSet.put(&1, value)), else: acc
+        end
+
+      _value, acc ->
+        acc
+    end)
+  end
+
+  defp identity_value(record, key), do: Map.get(record, key, Map.get(record, Atom.to_string(key)))
+
+  defp maybe_add_id(acc, %{external_channel_id: id}) when is_binary(id),
+    do: Map.update!(acc, :ids, &MapSet.put(&1, id))
+
+  defp maybe_add_id(acc, _reference), do: acc
+
+  defp maybe_add_url(acc, %{canonical_url: url}) when is_binary(url),
+    do: Map.update!(acc, :urls, &MapSet.put(&1, url))
+
+  defp maybe_add_url(acc, _reference), do: acc
+
+  defp excluded_candidate?(%Candidate{} = candidate, excluded) do
+    reference_key = if is_map(candidate.reference), do: Map.get(candidate.reference, :key), else: nil
+
+    reference_key in excluded.keys or
+      candidate.external_channel_id in excluded.ids or
+      candidate.canonical_url in excluded.urls
+  end
+
+  defp existing_source_channel_ids do
+    from(source in Source,
+      where: source.collection_type == ^:channel and not is_nil(source.collection_id),
+      select: source.collection_id
+    )
+    |> Repo.all()
+    |> Enum.filter(&is_binary/1)
+  end
+
+  defp terminal_suggestion_channel_ids do
+    from(suggestion in Suggestion,
+      where: suggestion.state in ^@terminal_states,
+      select: suggestion.external_channel_id
+    )
+    |> Repo.all()
+    |> Enum.filter(&is_binary/1)
+  end
+
+  defp do_upsert(external_channel_id, attrs) do
+    case get_suggestion_by_external_channel_id(external_channel_id) do
+      nil -> insert_suggestion(attrs)
+      %Suggestion{state: state} = suggestion when state in @terminal_states -> {:ok, suggestion}
+      %Suggestion{} = suggestion -> update_existing_suggestion(suggestion, attrs)
+    end
+  end
+
+  defp insert_suggestion(attrs) do
+    attrs = maybe_set_validation_timestamp(attrs)
+    changeset = Suggestion.changeset(%Suggestion{}, attrs)
+
+    case Repo.insert(changeset, on_conflict: :nothing, conflict_target: [:external_channel_id]) do
+      {:ok, %Suggestion{id: nil}} -> do_upsert(attrs.external_channel_id, attrs)
+      result -> result
+    end
+  end
+
+  defp update_existing_suggestion(%Suggestion{} = suggestion, attrs) do
+    state = merge_state(suggestion.state, attrs.state)
+
+    attrs =
+      attrs
+      |> Map.put(:state, state)
+      |> maybe_preserve_validation_timestamp(suggestion)
+
+    suggestion
+    |> Suggestion.changeset(attrs)
+    |> Repo.update()
+  end
+
+  defp maybe_set_validation_timestamp(%{state: :validated} = attrs),
+    do: Map.put_new(attrs, :validated_at, now())
+
+  defp maybe_set_validation_timestamp(attrs), do: attrs
+
+  defp maybe_preserve_validation_timestamp(%{validated_at: nil} = attrs, %Suggestion{validated_at: nil}) do
+    if attrs.state == :validated, do: Map.put(attrs, :validated_at, now()), else: attrs
+  end
+
+  defp maybe_preserve_validation_timestamp(attrs, %Suggestion{validated_at: validated_at}) do
+    if Map.has_key?(attrs, :validated_at), do: attrs, else: Map.put(attrs, :validated_at, validated_at)
+  end
+
+  defp merge_state(:candidate, :validated), do: :validated
+  defp merge_state(state, _incoming_state), do: state
+
+  defp normalize_attrs(attrs) do
+    external_channel_id = attrs |> value_for(:external_channel_id) |> normalize_string()
+    state = normalize_state(value_for(attrs, :state))
+
+    normalized = %{
+      external_channel_id: external_channel_id,
+      canonical_url:
+        bounded_string(value_for(attrs, :canonical_url), @max_url_length) || canonical_url(external_channel_id),
+      channel_name: bounded_string(value_for(attrs, :channel_name), @max_channel_name_length) || external_channel_id,
+      artwork_url: bounded_string(value_for(attrs, :artwork_url), @max_url_length),
+      evidence: bounded_evidence(value_for(attrs, :evidence)),
+      score: bounded_score(value_for(attrs, :score)),
+      state: state
+    }
+
+    normalized
+    |> maybe_put_validated_at(attrs)
+    |> maybe_put_generators(attrs)
+  end
+
+  defp maybe_put_validated_at(normalized, attrs) do
+    if has_key?(attrs, :validated_at),
+      do: Map.put(normalized, :validated_at, value_for(attrs, :validated_at)),
+      else: normalized
+  end
+
+  defp maybe_put_generators(normalized, attrs) do
+    if has_key?(attrs, :generators),
+      do: Map.put(normalized, :generators, bounded_generators(value_for(attrs, :generators))),
+      else: normalized
+  end
+
+  defp candidate_attrs(%Candidate{} = candidate) do
+    handle = if is_map(candidate.reference), do: Map.get(candidate.reference, :handle), else: nil
+
+    %{
+      external_channel_id: candidate.external_channel_id,
+      canonical_url: candidate.canonical_url,
+      channel_name: candidate.channel_name || handle || candidate.external_channel_id,
+      artwork_url: candidate.artwork_url,
+      evidence: Candidate.evidence(candidate),
+      generators: candidate.generators,
+      score: Scoring.score(candidate),
+      state: :candidate
+    }
+  end
+
+  defp candidate_from_suggestion(%Suggestion{} = suggestion) do
+    reference = %{
+      kind: :channel_id,
+      key: "channel_id:" <> suggestion.external_channel_id,
+      external_channel_id: suggestion.external_channel_id,
+      handle: nil,
+      canonical_url: suggestion.canonical_url
+    }
+
+    %Candidate{
+      reference: reference,
+      canonical_url: suggestion.canonical_url,
+      external_channel_id: suggestion.external_channel_id,
+      channel_name: suggestion.channel_name,
+      artwork_url: suggestion.artwork_url,
+      evidence: suggestion.evidence,
+      score: suggestion.score,
+      generators: parse_generators(suggestion.generators),
+      mentions: 0
+    }
+  end
+
+  defp rejection_counts(rejections), do: rejections |> Enum.map(& &1.reason) |> Enum.frequencies()
+
+  defp disabled_result do
+    %{
+      status: :disabled,
+      candidate_count: 0,
+      validated_count: 0,
+      inserted_count: 0,
+      generator_errors: [],
+      validation_rejections: %{},
+      suggestions: []
+    }
+  end
+
+  defp completion_payload({:ok, result}) do
+    Map.take(result, [
+      :status,
+      :candidate_count,
+      :validated_count,
+      :inserted_count,
+      :generator_errors,
+      :validation_rejections
+    ])
+  end
+
+  defp completion_payload({:error, _reason}),
+    do: %{status: :failed, candidate_count: 0, validated_count: 0, inserted_count: 0}
+
+  defp states_for_listing(opts) do
+    cond do
+      Keyword.has_key?(opts, :states) -> normalize_states(Keyword.get(opts, :states))
+      Keyword.get(opts, :include_terminal, false) -> Suggestion.states()
+      true -> @visible_states
+    end
+  end
+
+  defp normalize_states(states) do
+    states |> List.wrap() |> Enum.map(&normalize_state/1) |> Enum.filter(&(&1 in Suggestion.states())) |> Enum.uniq()
+  end
+
+  defp normalize_state(nil), do: :validated
+  defp normalize_state(state) when state in [:candidate, :validated, :dismissed, :accepted], do: state
+
+  defp normalize_state(state) when is_binary(state) do
+    Enum.find(Suggestion.states(), state, &(Atom.to_string(&1) == state))
+  end
+
+  defp normalize_state(state), do: state
+
+  defp bounded_evidence(nil), do: ""
+
+  defp bounded_evidence(evidence) when is_list(evidence) do
+    evidence |> Enum.map_join(", ", &to_string/1) |> bounded_evidence()
+  end
+
+  defp bounded_evidence(evidence), do: evidence |> to_string() |> String.trim() |> String.slice(0, @max_evidence_length)
+
+  defp bounded_generators(nil), do: ""
+
+  defp bounded_generators(generators) when is_list(generators) do
+    generators
+    |> Enum.map_join(",", &to_string/1)
+    |> bounded_generators()
+  end
+
+  defp bounded_generators(generators) do
+    generators
+    |> to_string()
+    |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+    |> Enum.sort()
+    |> Enum.take(@max_generators_count)
+    |> Enum.join(",")
+    |> String.slice(0, @max_generators_length)
+  end
+
+  defp parse_generators(generators) do
+    generators
+    |> bounded_generators()
+    |> String.split(",", trim: true)
+  end
+
+  defp bounded_score(score) when is_integer(score), do: score |> max(0) |> min(@max_score)
+
+  defp bounded_score(score) when is_binary(score) do
+    case Integer.parse(score) do
+      {score, ""} -> bounded_score(score)
+      _ -> 0
+    end
+  end
+
+  defp bounded_score(_score), do: 0
+
+  defp canonical_url(nil), do: nil
+  defp canonical_url(external_channel_id), do: Normalizer.channel_url(external_channel_id)
+
+  defp normalize_string(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      value -> value
+    end
+  end
+
+  defp normalize_string(_value), do: nil
+
+  defp bounded_string(value, max_length) do
+    case normalize_string(value) do
+      nil -> nil
+      value -> String.slice(value, 0, max_length)
+    end
+  end
+
+  defp value_for(attrs, key), do: Map.get(attrs, key, Map.get(attrs, Atom.to_string(key)))
+  defp has_key?(attrs, key), do: Map.has_key?(attrs, key) or Map.has_key?(attrs, Atom.to_string(key))
+  defp blank?(nil), do: true
+  defp blank?(value), do: String.trim(value) == ""
+
+  defp maybe_limit(query, nil), do: query
+  defp maybe_limit(query, limit) when is_integer(limit) and limit >= 0, do: limit(query, ^limit)
+  defp maybe_limit(query, _limit), do: query
+
+  defp default(key), do: Application.get_env(:pinchflat, :channel_discovery, []) |> Keyword.get(key)
+  defp bounded_integer(value, fallback) when is_integer(value), do: max(value, 0) |> min(fallback)
+  defp bounded_integer(_value, fallback), do: fallback
+  defp now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+
+  defp safe_reason(reason)
+       when reason in [
+              :generator_failed,
+              :featured_unavailable,
+              :runner_failed,
+              :malformed_response,
+              :persistence_failed
+            ],
+       do: reason
+
+  defp safe_reason(_reason), do: :generator_failed
+end

--- a/lib/pinchflat/discovery/candidate.ex
+++ b/lib/pinchflat/discovery/candidate.ex
@@ -1,0 +1,125 @@
+defmodule Pinchflat.Discovery.Candidate do
+  @moduledoc """
+  An in-memory channel candidate shared by discovery generators and validation.
+  """
+
+  defstruct [
+    :reference,
+    :canonical_url,
+    :external_channel_id,
+    :channel_name,
+    :artwork_url,
+    evidence: nil,
+    score: 0,
+    generators: [],
+    mentions: 0
+  ]
+
+  @type t :: %__MODULE__{
+          reference: map() | nil,
+          canonical_url: binary() | nil,
+          external_channel_id: binary() | nil,
+          channel_name: binary() | nil,
+          artwork_url: binary() | nil,
+          evidence: binary() | nil,
+          score: non_neg_integer(),
+          generators: [binary()],
+          mentions: non_neg_integer()
+        }
+
+  @doc """
+  Builds a candidate from a normalized channel reference.
+  """
+  def from_reference(reference, generator, attrs \\ %{}) when is_map(reference) do
+    attrs = Map.new(attrs)
+    generator = generator_name(generator)
+
+    %__MODULE__{
+      reference: reference,
+      canonical_url: attr_value(attrs, :canonical_url) || Map.get(reference, :canonical_url),
+      external_channel_id: attr_value(attrs, :external_channel_id) || Map.get(reference, :external_channel_id),
+      channel_name: attr_value(attrs, :channel_name),
+      artwork_url: attr_value(attrs, :artwork_url),
+      generators: [generator],
+      mentions: non_negative_integer(attr_value(attrs, :mentions) || if(generator == "mention", do: 1, else: 0))
+    }
+  end
+
+  @doc """
+  Merges evidence for two candidates that have the same pre-validation key.
+  """
+  def merge(%__MODULE__{} = first, %__MODULE__{} = second) do
+    %__MODULE__{
+      first
+      | canonical_url: first.canonical_url || second.canonical_url,
+        external_channel_id: first.external_channel_id || second.external_channel_id,
+        channel_name: first.channel_name || second.channel_name,
+        artwork_url: first.artwork_url || second.artwork_url,
+        score: max(first.score || 0, second.score || 0),
+        generators: normalize_generators(first.generators ++ second.generators),
+        mentions: non_negative_integer(first.mentions) + non_negative_integer(second.mentions)
+    }
+  end
+
+  @doc """
+  Deduplicates candidates deterministically by the supplied key function.
+  """
+  def deduplicate(candidates, key_fun \\ &key/1) do
+    candidates
+    |> Enum.filter(&match?(%__MODULE__{}, &1))
+    |> Enum.reduce(%{}, fn candidate, acc ->
+      Map.update(acc, key_fun.(candidate), candidate, &merge(&1, candidate))
+    end)
+    |> Map.values()
+    |> Enum.sort_by(fn candidate -> to_string(key_fun.(candidate)) end)
+  end
+
+  @doc """
+  Returns the stable key used before validation.
+  """
+  def key(%__MODULE__{external_channel_id: id}) when is_binary(id), do: "channel_id:" <> id
+  def key(%__MODULE__{reference: %{key: key}}) when is_binary(key), do: key
+  def key(%__MODULE__{canonical_url: url}) when is_binary(url), do: url
+
+  def key(%__MODULE__{} = candidate) do
+    "candidate:" <> Base.encode16(:crypto.hash(:sha256, :erlang.term_to_binary(candidate.reference)), case: :lower)
+  end
+
+  @doc """
+  Adds a deterministic score to a candidate.
+  """
+  def with_score(%__MODULE__{} = candidate, score) when is_integer(score) and score >= 0 do
+    %{candidate | score: score}
+  end
+
+  @doc """
+  Returns a human-readable evidence label for display and storage.
+  """
+  def evidence(%__MODULE__{} = candidate) do
+    candidate.generators
+    |> normalize_generators()
+    |> Enum.map_join(", ", fn
+      "mention" -> "Mentioned in local metadata"
+      "featured" -> "Featured by a subscribed channel"
+      generator -> generator
+    end)
+  end
+
+  defp generator_name(generator) when is_atom(generator), do: Atom.to_string(generator)
+  defp generator_name(generator) when is_binary(generator), do: generator
+  defp generator_name(generator), do: to_string(generator)
+
+  defp attr_value(attrs, key), do: Map.get(attrs, key, Map.get(attrs, Atom.to_string(key)))
+
+  defp normalize_generators(generators) do
+    generators
+    |> List.wrap()
+    |> Enum.map(&generator_name/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp non_negative_integer(value) when is_integer(value), do: max(value, 0)
+  defp non_negative_integer(_value), do: 0
+end

--- a/lib/pinchflat/discovery/featured_generator.ex
+++ b/lib/pinchflat/discovery/featured_generator.ex
@@ -1,0 +1,352 @@
+defmodule Pinchflat.Discovery.FeaturedGenerator do
+  @moduledoc """
+  Finds channels exposed by the featured tab of subscribed channels.
+
+  Calls go through the configured yt-dlp runner, with cookies disabled and
+  bounded command output. Only validated-looking channel identifiers and safe
+  display metadata leave this module; raw command output is never returned or
+  persisted.
+  """
+
+  @behaviour Pinchflat.Discovery.Generator
+
+  import Ecto.Query, warn: false
+
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.Normalizer
+  alias Pinchflat.Repo
+  alias Pinchflat.Sources.Source
+
+  @default_max_sources 50
+  @default_max_candidates 100
+  @default_max_entries 25
+  @default_max_output_bytes 256 * 1024
+  @default_timeout 15_000
+  @absolute_max_sources 500
+  @absolute_max_candidates 500
+  @absolute_max_entries 100
+  @absolute_max_output_bytes 1 * 1024 * 1024
+  @absolute_timeout 60_000
+
+  @doc """
+  Queries a bounded set of subscribed channel sources for featured channels.
+  """
+  @impl true
+  def generate(opts \\ []) do
+    result = generate_with_errors(opts)
+
+    if result.candidates == [] and result.errors != [] do
+      {:error, :featured_unavailable}
+    else
+      {:ok, result.candidates |> Candidate.deduplicate() |> Enum.take(max_candidates(opts))}
+    end
+  end
+
+  @doc """
+  Returns candidates and safe per-source failures for a partial scan.
+  """
+  def generate_with_errors(opts \\ []) do
+    max_sources =
+      bounded_integer(
+        Keyword.get(opts, :max_sources, default(:max_sources) || @default_max_sources),
+        @default_max_sources,
+        @absolute_max_sources
+      )
+
+    sources = Keyword.get_lazy(opts, :sources, fn -> list_sources(max_sources) end)
+
+    fetch_fun =
+      case Keyword.fetch(opts, :fetch_fun) do
+        {:ok, fun} -> {:injected, fun}
+        :error -> :default
+      end
+
+    timeout = featured_timeout(opts)
+
+    sources
+    |> Enum.take(max_sources)
+    |> Enum.reduce(%{candidates: [], errors: []}, fn source, result ->
+      case fetch_source(fetch_fun, source, opts, timeout) do
+        {:ok, candidates} ->
+          %{result | candidates: Enum.take(result.candidates ++ candidates, max_candidates(opts))}
+
+        {:error, reason} ->
+          %{result | errors: [%{source_id: source_id(source), reason: safe_reason(reason)} | result.errors]}
+      end
+    end)
+    |> Map.update!(:candidates, &Candidate.deduplicate/1)
+    |> Map.update!(:errors, &Enum.reverse/1)
+  end
+
+  @doc """
+  Returns the `/featured` URL used for a subscribed channel.
+  """
+  def featured_url(%Source{} = source), do: featured_url(Map.from_struct(source))
+
+  def featured_url(source) when is_map(source) do
+    reference =
+      [source_value(source, :collection_id), source_value(source, :original_url)]
+      |> Enum.find_value(&Normalizer.normalize_reference/1)
+
+    case reference do
+      %{kind: :channel_id, external_channel_id: channel_id} ->
+        Normalizer.channel_url(channel_id) <> "/featured"
+
+      %{kind: :handle, handle: handle} ->
+        "https://www.youtube.com/@#{handle}/featured"
+
+      _ ->
+        append_featured_suffix(source_value(source, :original_url))
+    end
+  end
+
+  defp list_sources(max_sources) do
+    Repo.all(
+      from source in Source,
+        where: source.collection_type == :channel,
+        order_by: [asc: source.id],
+        limit: ^max_sources
+    )
+  end
+
+  defp fetch_featured(source, opts) do
+    runner = Keyword.get(opts, :runner, Application.get_env(:pinchflat, :yt_dlp_runner))
+    url = featured_url(source)
+
+    max_entries =
+      bounded_integer(
+        Keyword.get(opts, :max_entries, default(:max_entries) || @default_max_entries),
+        @default_max_entries,
+        @absolute_max_entries
+      )
+
+    max_output_bytes =
+      bounded_integer(
+        Keyword.get(opts, :max_output_bytes, default(:max_output_bytes) || @default_max_output_bytes),
+        @default_max_output_bytes,
+        @absolute_max_output_bytes
+      )
+
+    command_opts = [:skip_download, :ignore_no_formats_error, :no_warnings, :flat_playlist, playlist_end: max_entries]
+    addl_opts = [use_cookies: false, skip_sleep_interval: true, timeout: featured_timeout(opts)]
+
+    with true <- is_binary(url),
+         {:ok, output} <- runner.run(url, :channel_discovery_featured, command_opts, "playlist:%()j", addl_opts),
+         {:ok, bounded_output} <- bounded_output(output, max_output_bytes),
+         {:ok, records} <- decode_records(bounded_output, max_entries) do
+      {:ok, records |> Enum.flat_map(&candidate_from_record/1) |> Enum.take(max_entries)}
+    else
+      false -> {:error, :source_url_missing}
+      {:error, _reason, _status} -> {:error, :runner_failed}
+      {:error, reason} -> {:error, safe_reason(reason)}
+      _ -> {:error, :malformed_response}
+    end
+  end
+
+  defp fetch_source(:default, source, opts, timeout), do: fetch_default(source, opts, timeout)
+  defp fetch_source({:injected, fetch_fun}, source, opts, _timeout), do: safe_fetch(fetch_fun, source, opts)
+
+  defp fetch_default(source, opts, timeout) do
+    task = Task.async(fn -> safe_fetch(&fetch_featured/2, source, opts) end)
+
+    case Task.yield(task, timeout) do
+      {:ok, result} ->
+        result
+
+      nil ->
+        Task.shutdown(task, :brutal_kill)
+        {:error, :timeout}
+    end
+  end
+
+  defp safe_fetch(fetch_fun, source, opts) do
+    try do
+      result =
+        cond do
+          is_function(fetch_fun, 2) -> fetch_fun.(source, opts)
+          is_function(fetch_fun, 1) -> fetch_fun.(source)
+          true -> {:error, :invalid_fetch_fun}
+        end
+
+      case result do
+        {:ok, candidates} when is_list(candidates) -> {:ok, candidates}
+        candidates when is_list(candidates) -> {:ok, candidates}
+        {:error, reason} -> {:error, safe_reason(reason)}
+        _ -> {:error, :malformed_response}
+      end
+    rescue
+      _error -> {:error, :runner_failed}
+    catch
+      :exit, _reason -> {:error, :runner_failed}
+    end
+  end
+
+  defp bounded_output(output, max_output_bytes) when is_binary(output) do
+    if byte_size(output) <= max_output_bytes, do: {:ok, output}, else: {:error, :output_too_large}
+  end
+
+  defp bounded_output(_output, _max_output_bytes), do: {:error, :malformed_response}
+
+  defp decode_records(output, max_entries) do
+    trimmed_output = output |> String.trim() |> strip_output_prefix()
+
+    case Phoenix.json_library().decode(trimmed_output) do
+      {:ok, decoded} when is_map(decoded) ->
+        {:ok, [decoded]}
+
+      {:ok, decoded} when is_list(decoded) ->
+        {:ok, Enum.take(decoded, max_entries)}
+
+      _ ->
+        decode_json_lines(output, max_entries)
+    end
+  end
+
+  defp decode_json_lines(output, max_entries) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.take(max_entries)
+    |> Enum.reduce_while([], fn line, records ->
+      case Phoenix.json_library().decode(line |> strip_output_prefix() |> String.trim()) do
+        {:ok, decoded} -> {:cont, [decoded | records]}
+        _ -> {:halt, :malformed}
+      end
+    end)
+    |> case do
+      :malformed -> {:error, :malformed_response}
+      [] -> {:error, :malformed_response}
+      records -> {:ok, Enum.reverse(records)}
+    end
+  end
+
+  defp strip_output_prefix("playlist:" <> json), do: json
+  defp strip_output_prefix(json), do: json
+
+  defp candidate_from_record(record) when is_map(record) do
+    own_candidate = candidate_from_map(record)
+    nested = record |> nested_records() |> Enum.flat_map(&candidate_from_record/1)
+    own_candidate ++ nested
+  end
+
+  defp candidate_from_record(_record), do: []
+
+  defp candidate_from_map(record) do
+    reference_value =
+      [
+        Map.get(record, "channel_id"),
+        Map.get(record, "channel_url"),
+        Map.get(record, "uploader_url"),
+        Map.get(record, "url"),
+        Map.get(record, "id")
+      ]
+      |> Enum.find_value(&normalize_reference/1)
+
+    case reference_value do
+      nil -> []
+      reference -> [Candidate.from_reference(reference, :featured, record_attrs(record))]
+    end
+  end
+
+  defp nested_records(record) do
+    [Map.get(record, "entries"), Map.get(record, "featured_channels"), Map.get(record, "featured")]
+    |> Enum.flat_map(fn
+      values when is_list(values) -> values
+      value when is_map(value) -> [value]
+      _ -> []
+    end)
+  end
+
+  defp normalize_reference(value) when is_binary(value) do
+    Normalizer.normalize_reference(value)
+  end
+
+  defp normalize_reference(_value), do: nil
+
+  defp record_attrs(record) do
+    %{
+      channel_name: first_binary(record, ["channel", "channel_name", "uploader", "name", "title"]),
+      artwork_url: first_artwork_url(record)
+    }
+  end
+
+  defp first_binary(record, keys) do
+    Enum.find_value(keys, fn key ->
+      case Map.get(record, key) do
+        value when is_binary(value) and byte_size(value) > 0 -> String.slice(String.trim(value), 0, 200)
+        _ -> nil
+      end
+    end)
+  end
+
+  defp first_artwork_url(record) do
+    [
+      Map.get(record, "artwork_url"),
+      Map.get(record, "thumbnail_url"),
+      Map.get(record, "thumbnail"),
+      Map.get(record, "avatar")
+    ]
+    |> Enum.find_value(fn value ->
+      if safe_http_url?(value), do: String.slice(String.trim(value), 0, 2_048)
+    end)
+  end
+
+  defp safe_http_url?(value) when is_binary(value) do
+    String.starts_with?(value, "https://") or String.starts_with?(value, "http://")
+  end
+
+  defp safe_http_url?(_value), do: false
+
+  defp append_featured_suffix(url) when is_binary(url) do
+    url = String.trim_trailing(url, "/")
+
+    base_url =
+      Enum.find_value(["featured", "videos", "shorts", "streams", "live"], url, fn suffix ->
+        marker = "/" <> suffix
+        if String.ends_with?(url, marker), do: binary_part(url, 0, byte_size(url) - byte_size(marker))
+      end)
+
+    base_url <> "/featured"
+  end
+
+  defp append_featured_suffix(_url), do: nil
+
+  defp source_value(source, key) when is_map(source), do: Map.get(source, key, Map.get(source, Atom.to_string(key)))
+
+  defp source_id(source) do
+    case source_value(source, :id) do
+      id when is_integer(id) -> id
+      _ -> nil
+    end
+  end
+
+  defp max_candidates(opts) do
+    bounded_integer(
+      Keyword.get(opts, :max_candidates, default(:max_candidates) || @default_max_candidates),
+      @default_max_candidates,
+      @absolute_max_candidates
+    )
+  end
+
+  defp featured_timeout(opts) do
+    bounded_integer(
+      Keyword.get(opts, :timeout, default(:featured_timeout) || @default_timeout),
+      @default_timeout,
+      @absolute_timeout
+    )
+    |> max(1)
+  end
+
+  defp bounded_integer(value, _fallback, maximum) when is_integer(value), do: value |> max(0) |> min(maximum)
+  defp bounded_integer(_value, fallback, maximum), do: max(fallback, 0) |> min(maximum)
+
+  defp default(key) do
+    Application.get_env(:pinchflat, :channel_discovery, [])
+    |> Keyword.get(key)
+  end
+
+  defp safe_reason(reason)
+       when reason in [:runner_failed, :malformed_response, :output_too_large, :source_url_missing, :timeout],
+       do: reason
+
+  defp safe_reason(_reason), do: :runner_failed
+end

--- a/lib/pinchflat/discovery/generator.ex
+++ b/lib/pinchflat/discovery/generator.ex
@@ -1,0 +1,13 @@
+defmodule Pinchflat.Discovery.Generator do
+  @moduledoc """
+  Behaviour implemented by bounded channel discovery generators.
+
+  Generators return in-memory candidates only. Persistence, exclusion, validation,
+  scoring, and sampling belong to `Pinchflat.Discovery` so every source of
+  candidates follows the same safety and identity rules.
+  """
+
+  alias Pinchflat.Discovery.Candidate
+
+  @callback generate(keyword()) :: {:ok, [Candidate.t()]} | {:error, atom()}
+end

--- a/lib/pinchflat/discovery/mention_generator.ex
+++ b/lib/pinchflat/discovery/mention_generator.ex
@@ -1,0 +1,297 @@
+defmodule Pinchflat.Discovery.MentionGenerator do
+  @moduledoc """
+  Mines locally stored source descriptions and metadata for channel references.
+
+  This generator never contacts YouTube. File sizes, source rows, text, and
+  candidates are bounded so a malformed or unexpectedly large metadata file
+  cannot turn a discovery scan into an unbounded read.
+  """
+
+  @behaviour Pinchflat.Discovery.Generator
+
+  import Ecto.Query, warn: false
+
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.Normalizer
+  alias Pinchflat.Metadata.SourceMetadata
+  alias Pinchflat.Repo
+  alias Pinchflat.Sources.Source
+
+  @default_max_sources 100
+  @default_max_candidates 100
+  @default_max_metadata_bytes 512 * 1024
+  @default_max_text_bytes 1 * 1024 * 1024
+  @absolute_max_sources 500
+  @absolute_max_candidates 500
+  @absolute_max_metadata_bytes 4 * 1024 * 1024
+  @absolute_max_text_bytes 4 * 1024 * 1024
+
+  @doc """
+  Returns mention candidates from at most the configured number of local sources.
+
+  `:sources` and `:read_metadata_fun` are injectable for tests and maintenance
+  jobs that already have a bounded source list. The default reader accepts the
+  compressed metadata files written by the existing metadata helpers.
+  """
+  @impl true
+  def generate(opts \\ []) do
+    generate_with_errors(opts).candidates
+    |> Candidate.deduplicate()
+    |> then(&{:ok, &1})
+  end
+
+  @doc """
+  Returns candidates and safe per-source read errors without exposing metadata.
+  """
+  def generate_with_errors(opts \\ []) do
+    max_sources =
+      bounded_integer(
+        Keyword.get(opts, :max_sources, default(:max_sources) || @default_max_sources),
+        @default_max_sources,
+        @absolute_max_sources
+      )
+
+    max_candidates =
+      bounded_integer(
+        Keyword.get(opts, :max_candidates, default(:max_candidates) || @default_max_candidates),
+        @default_max_candidates,
+        @absolute_max_candidates
+      )
+
+    max_metadata_bytes =
+      bounded_integer(
+        Keyword.get(opts, :max_metadata_bytes, default(:max_metadata_bytes) || @default_max_metadata_bytes),
+        @default_max_metadata_bytes,
+        @absolute_max_metadata_bytes
+      )
+
+    max_text_bytes =
+      bounded_integer(
+        Keyword.get(opts, :max_text_bytes, default(:max_text_bytes) || @default_max_text_bytes),
+        @default_max_text_bytes,
+        @absolute_max_text_bytes
+      )
+
+    sources = Keyword.get_lazy(opts, :sources, fn -> list_sources(max_sources) end)
+    read_metadata_fun = Keyword.get(opts, :read_metadata_fun, &read_metadata/2)
+
+    sources
+    |> Enum.take(max_sources)
+    |> Enum.reduce(%{candidates: [], errors: []}, fn source, result ->
+      case candidates_for_source(source, read_metadata_fun, max_metadata_bytes, max_text_bytes) do
+        {:ok, candidates} ->
+          %{result | candidates: Enum.take(result.candidates ++ candidates, max_candidates)}
+
+        {:error, reason} ->
+          %{result | errors: [%{source_id: source_id(source), reason: safe_reason(reason)} | result.errors]}
+      end
+    end)
+    |> Map.update!(:candidates, &Candidate.deduplicate/1)
+    |> Map.update!(:errors, &Enum.reverse/1)
+  end
+
+  @doc """
+  Extracts mention candidates from one source-like map or struct.
+  """
+  def candidates_for_source(
+        source,
+        read_metadata_fun \\ &read_metadata/2,
+        max_metadata_bytes \\ @default_max_metadata_bytes,
+        max_text_bytes \\ @default_max_text_bytes
+      ) do
+    metadata_result = read_metadata_for_source(source, read_metadata_fun, max_metadata_bytes)
+
+    case metadata_result do
+      {:ok, metadata} ->
+        text =
+          [source_value(source, :description), metadata]
+          |> Enum.map(&text_from_term/1)
+          |> Enum.reject(&(&1 == ""))
+          |> Enum.join("\n")
+          |> truncate_bytes(max_text_bytes)
+
+        self_references = [source_value(source, :collection_id), source_value(source, :original_url)]
+
+        candidates =
+          text
+          |> Normalizer.normalize(self_references: self_references)
+          |> Enum.map(&Candidate.from_reference(&1, :mention))
+
+        {:ok, candidates}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp list_sources(max_sources) do
+    Repo.all(
+      from s in Source,
+        left_join: metadata in SourceMetadata,
+        on: metadata.source_id == s.id,
+        order_by: [asc: s.id],
+        limit: ^max_sources,
+        select: %{
+          id: s.id,
+          collection_id: s.collection_id,
+          original_url: s.original_url,
+          description: s.description,
+          metadata_filepath: metadata.metadata_filepath
+        }
+    )
+  end
+
+  defp read_metadata_for_source(source, read_metadata_fun, max_metadata_bytes) do
+    case source_value(source, :metadata) do
+      metadata when is_map(metadata) ->
+        case source_value(metadata, :metadata_filepath) do
+          path when is_binary(path) and path != "" ->
+            safe_read_metadata(read_metadata_fun, path, max_metadata_bytes)
+
+          _ ->
+            {:ok, metadata}
+        end
+
+      _ ->
+        case source_value(source, :metadata_filepath) do
+          path when is_binary(path) and path != "" ->
+            safe_read_metadata(read_metadata_fun, path, max_metadata_bytes)
+
+          _ ->
+            {:ok, %{}}
+        end
+    end
+  end
+
+  defp safe_read_metadata(read_metadata_fun, path, max_metadata_bytes) do
+    try do
+      case read_metadata_fun.(path, max_metadata_bytes) do
+        {:ok, metadata} when is_map(metadata) -> {:ok, metadata}
+        metadata when is_map(metadata) -> {:ok, metadata}
+        {:error, reason} -> {:error, safe_reason(reason)}
+        _ -> {:error, :malformed_metadata}
+      end
+    rescue
+      _error -> {:error, :metadata_unreadable}
+    catch
+      :exit, _reason -> {:error, :metadata_unreadable}
+    end
+  end
+
+  defp read_metadata(path, max_metadata_bytes) do
+    case read_limited_compressed(path, max_metadata_bytes) do
+      {:ok, json} ->
+        case Phoenix.json_library().decode(json) do
+          {:ok, metadata} when is_map(metadata) -> {:ok, metadata}
+          _ -> {:error, :malformed_metadata}
+        end
+
+      {:error, :not_compressed} ->
+        with {:ok, stat} <- File.stat(path),
+             true <- stat.size <= max_metadata_bytes,
+             {:ok, json} <- File.read(path),
+             {:ok, metadata} when is_map(metadata) <- Phoenix.json_library().decode(json) do
+          {:ok, metadata}
+        else
+          _ -> {:error, :malformed_metadata}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp read_limited_compressed(path, max_metadata_bytes) do
+    case File.open(path, [:read, :compressed, :binary]) do
+      {:ok, device} ->
+        result = read_at_most(device, max_metadata_bytes + 1, <<>>)
+        File.close(device)
+
+        case result do
+          {:ok, data} when byte_size(data) <= max_metadata_bytes -> {:ok, data}
+          {:ok, _data} -> {:error, :metadata_too_large}
+          {:error, _reason} = error -> error
+        end
+
+      {:error, reason} when reason in [:enoent, :enotdir] ->
+        {:error, :metadata_missing}
+
+      {:error, reason} when reason in [:einval, :eisdir, :enotsup] ->
+        {:error, :not_compressed}
+
+      {:error, _reason} ->
+        {:error, :metadata_unreadable}
+    end
+  end
+
+  defp read_at_most(_device, remaining, acc) when remaining <= 0, do: {:ok, acc}
+
+  defp read_at_most(device, remaining, acc) do
+    case IO.binread(device, min(remaining, 64 * 1024)) do
+      :eof -> {:ok, acc}
+      {:error, reason} -> {:error, reason}
+      data when is_binary(data) -> read_at_most(device, remaining - byte_size(data), acc <> data)
+    end
+  end
+
+  defp text_from_term(value) when is_binary(value), do: value
+
+  defp text_from_term(value) when is_map(value) do
+    value
+    |> Map.values()
+    |> Enum.map(&text_from_term/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp text_from_term(value) when is_list(value) do
+    value
+    |> Enum.map(&text_from_term/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.join("\n")
+  end
+
+  defp text_from_term(_value), do: ""
+
+  defp truncate_bytes(_text, max_bytes) when max_bytes <= 0, do: ""
+  defp truncate_bytes(text, max_bytes) when byte_size(text) <= max_bytes, do: text
+
+  defp truncate_bytes(text, max_bytes) do
+    text
+    |> binary_part(0, max_bytes)
+    |> drop_incomplete_utf8()
+  end
+
+  defp drop_incomplete_utf8(prefix) do
+    if String.valid?(prefix) or byte_size(prefix) == 0 do
+      prefix
+    else
+      prefix
+      |> binary_part(0, byte_size(prefix) - 1)
+      |> drop_incomplete_utf8()
+    end
+  end
+
+  defp source_value(source, key) when is_map(source), do: Map.get(source, key, Map.get(source, Atom.to_string(key)))
+
+  defp source_id(source) do
+    case source_value(source, :id) do
+      id when is_integer(id) -> id
+      _ -> nil
+    end
+  end
+
+  defp bounded_integer(value, _fallback, maximum) when is_integer(value), do: value |> max(0) |> min(maximum)
+  defp bounded_integer(_value, fallback, maximum), do: max(fallback, 0) |> min(maximum)
+
+  defp default(key) do
+    Application.get_env(:pinchflat, :channel_discovery, [])
+    |> Keyword.get(key)
+  end
+
+  defp safe_reason(reason)
+       when reason in [:metadata_missing, :metadata_unreadable, :metadata_too_large, :malformed_metadata],
+       do: reason
+
+  defp safe_reason(_reason), do: :metadata_unreadable
+end

--- a/lib/pinchflat/discovery/normalizer.ex
+++ b/lib/pinchflat/discovery/normalizer.ex
@@ -1,0 +1,222 @@
+defmodule Pinchflat.Discovery.Normalizer do
+  @moduledoc """
+  Pure normalization for YouTube channel IDs, handles, and channel references.
+
+  It deliberately returns references rather than making network calls. A
+  handle is only a pre-validation key; the durable channel ID is established by
+  the bounded validation step.
+  """
+
+  @channel_id_regex ~r/^UC[A-Za-z0-9_-]{22}$/
+  @handle_regex ~r/^[A-Za-z0-9._-]{2,30}$/
+  @youtube_url_regex ~r{https?://(?:www\.|m\.)?(?:youtube\.com|youtu\.be)/[^\s<>"']+}i
+  @channel_id_token_regex ~r/\bUC[A-Za-z0-9_-]{20,}\b/
+  @handle_token_regex ~r/(?:^|[^A-Za-z0-9_])(@[A-Za-z0-9._-]{2,30})/
+  @channel_suffixes ~w(featured videos shorts streams live)
+  @reserved_custom_paths ~w(
+    about channel channels community c clip embed feed featured live membership
+    playlist playlists results shorts store user watch watch_videos videos
+  )
+
+  @doc """
+  Extracts normalized channel references from arbitrary local text.
+
+  Returns `%{kind: :channel_id | :handle, key: binary(), ...}` values. Invalid
+  and self-referential values are discarded and duplicates are removed.
+  """
+  def normalize(text, opts \\ [])
+
+  def normalize(text, opts) when is_binary(text) do
+    self_keys = self_reference_keys(Keyword.get(opts, :self_references, []))
+
+    text
+    |> extract_references()
+    |> Enum.reject(&(reference_key(&1) in self_keys))
+    |> Enum.uniq_by(&reference_key/1)
+  end
+
+  def normalize(_text, _opts), do: []
+
+  @doc """
+  Normalizes one channel ID, handle, or YouTube channel URL.
+  """
+  def normalize_reference(reference, opts \\ [])
+
+  def normalize_reference(%{key: _key} = reference, opts) do
+    if valid_reference?(reference) and
+         reference_key(reference) not in self_reference_keys(Keyword.get(opts, :self_references, [])) do
+      reference
+    end
+  end
+
+  def normalize_reference(reference, opts) when is_binary(reference) do
+    reference
+    |> extract_references()
+    |> Enum.find(fn normalized ->
+      reference_key(normalized) not in self_reference_keys(Keyword.get(opts, :self_references, []))
+    end)
+  end
+
+  def normalize_reference(%{external_channel_id: channel_id}, opts) when is_binary(channel_id),
+    do: normalize_reference(channel_id, opts)
+
+  def normalize_reference(%{"external_channel_id" => channel_id}, opts) when is_binary(channel_id),
+    do: normalize_reference(channel_id, opts)
+
+  def normalize_reference(%{channel_id: channel_id}, opts) when is_binary(channel_id),
+    do: normalize_reference(channel_id, opts)
+
+  def normalize_reference(%{"channel_id" => channel_id}, opts) when is_binary(channel_id),
+    do: normalize_reference(channel_id, opts)
+
+  def normalize_reference(%{channel_url: channel_url}, opts) when is_binary(channel_url),
+    do: normalize_reference(channel_url, opts)
+
+  def normalize_reference(%{"channel_url" => channel_url}, opts) when is_binary(channel_url),
+    do: normalize_reference(channel_url, opts)
+
+  def normalize_reference(%{url: url}, opts) when is_binary(url), do: normalize_reference(url, opts)
+  def normalize_reference(%{"url" => url}, opts) when is_binary(url), do: normalize_reference(url, opts)
+
+  def normalize_reference(%{original_url: url}, opts) when is_binary(url), do: normalize_reference(url, opts)
+
+  def normalize_reference(%{"original_url" => url}, opts) when is_binary(url),
+    do: normalize_reference(url, opts)
+
+  def normalize_reference(_reference, _opts), do: nil
+
+  @doc """
+  Returns the identity key for a normalized reference.
+  """
+  def reference_key(%{key: key}), do: key
+
+  @doc """
+  Returns whether a value is a syntactically valid YouTube channel ID.
+  """
+  def valid_channel_id?(value) when is_binary(value), do: Regex.match?(@channel_id_regex, String.trim(value))
+  def valid_channel_id?(_value), do: false
+
+  @doc """
+  Returns the canonical channel URL for a stable channel ID.
+  """
+  def channel_url(channel_id), do: "https://www.youtube.com/channel/#{channel_id}"
+
+  defp extract_references(text) do
+    url_refs =
+      @youtube_url_regex
+      |> Regex.scan(text, capture: :first)
+      |> Enum.flat_map(fn [url] -> maybe_parse_url(url) end)
+
+    id_refs =
+      @channel_id_token_regex
+      |> Regex.scan(text, capture: :first)
+      |> Enum.flat_map(fn [channel_id] -> maybe_channel_id(channel_id) end)
+
+    handle_refs =
+      @handle_token_regex
+      |> Regex.scan(text, capture: :all_but_first)
+      |> Enum.flat_map(fn [handle] -> maybe_handle(handle) end)
+
+    url_refs ++ id_refs ++ handle_refs
+  end
+
+  defp maybe_parse_url(url) do
+    url = trim_reference_punctuation(url)
+
+    case URI.parse(url) do
+      %URI{host: host, path: path} when is_binary(host) and is_binary(path) ->
+        parse_youtube_path(String.downcase(host), String.split(path, "/", trim: true))
+
+      _ ->
+        []
+    end
+  end
+
+  defp parse_youtube_path(host, _path) when host == "youtu.be", do: []
+  defp parse_youtube_path(host, _path) when host not in ["youtube.com", "www.youtube.com", "m.youtube.com"], do: []
+
+  defp parse_youtube_path(_host, ["channel", channel_id | rest]) do
+    if valid_channel_suffix?(rest), do: maybe_channel_id(channel_id), else: []
+  end
+
+  defp parse_youtube_path(_host, ["@" <> handle | rest]) do
+    if valid_channel_suffix?(rest), do: maybe_handle(handle), else: []
+  end
+
+  defp parse_youtube_path(_host, [prefix, handle | rest]) when prefix in ["user", "c"] do
+    if valid_channel_suffix?(rest), do: maybe_handle(handle), else: []
+  end
+
+  defp parse_youtube_path(_host, [custom_path | rest]) do
+    if custom_path not in @reserved_custom_paths and valid_channel_suffix?(rest) do
+      maybe_handle(custom_path)
+    else
+      []
+    end
+  end
+
+  defp parse_youtube_path(_host, _path), do: []
+
+  defp valid_channel_suffix?([]), do: true
+  defp valid_channel_suffix?(suffix), do: suffix == [List.last(suffix)] and List.last(suffix) in @channel_suffixes
+
+  defp maybe_channel_id(channel_id) do
+    if valid_channel_id?(channel_id) do
+      channel_id = String.trim(channel_id)
+
+      [
+        %{
+          kind: :channel_id,
+          key: "channel_id:" <> channel_id,
+          external_channel_id: channel_id,
+          handle: nil,
+          canonical_url: channel_url(channel_id)
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp maybe_handle(handle) do
+    handle = String.trim_leading(trim_reference_punctuation(handle), "@")
+
+    if Regex.match?(@handle_regex, handle) do
+      handle = String.downcase(handle)
+
+      [
+        %{
+          kind: :handle,
+          key: "handle:" <> handle,
+          external_channel_id: nil,
+          handle: handle,
+          canonical_url: "https://www.youtube.com/@#{handle}"
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp self_reference_keys(references) do
+    references
+    |> List.wrap()
+    |> Enum.flat_map(fn
+      %{key: key} = reference when is_binary(key) -> [reference]
+      reference when is_binary(reference) -> extract_references(reference)
+      _reference -> []
+    end)
+    |> MapSet.new(&reference_key/1)
+  end
+
+  defp valid_reference?(%{kind: :channel_id, external_channel_id: id}) do
+    valid_channel_id?(id)
+  end
+
+  defp valid_reference?(%{kind: :handle, handle: handle}), do: is_binary(handle) and Regex.match?(@handle_regex, handle)
+  defp valid_reference?(_reference), do: false
+
+  defp trim_reference_punctuation(reference) do
+    String.trim(reference, " \t\r\n.,;:!?)]}>\"")
+  end
+end

--- a/lib/pinchflat/discovery/sample.ex
+++ b/lib/pinchflat/discovery/sample.ex
@@ -1,0 +1,32 @@
+defmodule Pinchflat.Discovery.Sample do
+  @moduledoc """
+  Selects a bounded random display sample from a deterministically ordered pool.
+  """
+
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.Scoring
+
+  @default_pool_size 50
+
+  @doc """
+  Selects at most `sample_size` candidates from at most `max_pool` candidates.
+
+  `:random_fun` is injectable for tests and is the only source of randomness.
+  """
+  def select(candidates, sample_size, opts \\ []) when is_list(candidates) do
+    max_pool = opts |> Keyword.get(:max_pool, @default_pool_size) |> integer_at_least_zero() |> min(@default_pool_size)
+    sample_size = sample_size |> integer_at_least_zero() |> min(max_pool)
+    random_fun = Keyword.get(opts, :random_fun, &Enum.take_random/2)
+    score_fun = Keyword.get(opts, :score_fun, &Scoring.score/1)
+
+    candidates
+    |> Enum.filter(&match?(%Candidate{}, &1))
+    |> Enum.sort_by(fn candidate -> {-score_fun.(candidate), Candidate.key(candidate)} end)
+    |> Enum.take(max_pool)
+    |> random_fun.(sample_size)
+    |> Enum.take(sample_size)
+  end
+
+  defp integer_at_least_zero(value) when is_integer(value), do: max(value, 0)
+  defp integer_at_least_zero(_value), do: 0
+end

--- a/lib/pinchflat/discovery/scoring.ex
+++ b/lib/pinchflat/discovery/scoring.ex
@@ -1,0 +1,46 @@
+defmodule Pinchflat.Discovery.Scoring do
+  @moduledoc """
+  Deterministic scoring for validated channel candidates.
+  """
+
+  alias Pinchflat.Discovery.Candidate
+
+  @doc """
+  Scores a candidate from stored evidence only. Randomness is not used here.
+  """
+  def score(%Candidate{} = candidate) do
+    mention_points = min(non_negative_integer(candidate.mentions), 3) * 2
+
+    generator_points =
+      candidate.generators
+      |> List.wrap()
+      |> Enum.map(&to_string/1)
+      |> Enum.uniq()
+      |> Enum.reduce(0, fn
+        "mention", acc -> acc + 5
+        "featured", acc -> acc + 3
+        _, acc -> acc
+      end)
+
+    validation_points = 2
+    name_points = if non_empty_binary?(candidate.channel_name), do: 1, else: 0
+
+    generator_points + mention_points + validation_points + name_points
+  end
+
+  @doc """
+  Adds deterministic scores to candidates.
+  """
+  def score_candidates(candidates), do: Enum.map(candidates, &{&1, score(&1)})
+
+  @doc """
+  Returns the deterministic ordering key used by the display sampler.
+  """
+  def sort_key(%Candidate{} = candidate), do: {-score(candidate), Candidate.key(candidate)}
+
+  defp non_negative_integer(value) when is_integer(value), do: max(value, 0)
+  defp non_negative_integer(_value), do: 0
+
+  defp non_empty_binary?(value) when is_binary(value), do: String.trim(value) != ""
+  defp non_empty_binary?(_value), do: false
+end

--- a/lib/pinchflat/discovery/suggestion.ex
+++ b/lib/pinchflat/discovery/suggestion.ex
@@ -1,0 +1,56 @@
+defmodule Pinchflat.Discovery.Suggestion do
+  @moduledoc """
+  A validated channel suggestion produced by channel discovery.
+
+  The external channel ID is the durable identity. URLs, names, artwork, and
+  evidence are refreshed when a later scan sees the same channel.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @states [:candidate, :validated, :dismissed, :accepted]
+
+  schema "channel_discovery_suggestions" do
+    field :external_channel_id, :string
+    field :canonical_url, :string
+    field :channel_name, :string
+    field :artwork_url, :string
+    field :evidence, :string, default: ""
+    field :generators, :string, default: ""
+    field :score, :integer, default: 0
+    field :validated_at, :utc_datetime
+    field :state, Ecto.Enum, values: @states, default: :validated
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  def changeset(suggestion, attrs) do
+    suggestion
+    |> cast(attrs, [
+      :external_channel_id,
+      :canonical_url,
+      :channel_name,
+      :artwork_url,
+      :evidence,
+      :generators,
+      :score,
+      :validated_at,
+      :state
+    ])
+    |> validate_required([:external_channel_id, :canonical_url, :channel_name, :state])
+    |> validate_number(:score, greater_than_or_equal_to: 0)
+    |> unique_constraint(:external_channel_id)
+  end
+
+  @doc """
+  Returns whether the suggestion is hidden from normal discovery results.
+  """
+  def excluded?(%__MODULE__{state: state}), do: state in [:dismissed, :accepted]
+
+  @doc """
+  Returns the states used by persisted discovery suggestions.
+  """
+  def states, do: @states
+end

--- a/lib/pinchflat/discovery/validator.ex
+++ b/lib/pinchflat/discovery/validator.ex
@@ -1,0 +1,238 @@
+defmodule Pinchflat.Discovery.Validator do
+  @moduledoc """
+  Validates candidates with bounded concurrency, timeouts, and result counts.
+
+  The default validator uses the configured yt-dlp runner without cookies. A
+  `:validate_fun` can be injected for tests or a future validation backend. Raw
+  runner output and exception messages are converted to small atom outcomes.
+  """
+
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.Normalizer
+
+  @default_max_results 50
+  @default_max_concurrency 4
+  @default_timeout 5_000
+  @default_max_output_bytes 256 * 1024
+  @absolute_max_results 100
+  @absolute_max_concurrency 16
+  @absolute_timeout 60_000
+  @absolute_max_output_bytes 1 * 1024 * 1024
+
+  @type rejection :: %{candidate: Candidate.t(), reason: atom()}
+  @type result :: %{validated: [Candidate.t()], rejected: [rejection()]}
+
+  @doc """
+  Validates at most `:max_results` candidates.
+
+  Returns `%{validated: candidates, rejected: rejection_details}`. The
+  `:max_concurrency`, `:timeout`, and `:validate_fun` options are injectable.
+  """
+  @spec validate([Candidate.t()], keyword()) :: result()
+  def validate(candidates, opts \\ []) when is_list(candidates) do
+    max_results =
+      bounded_integer(
+        Keyword.get(opts, :max_results, default(:max_validated) || @default_max_results),
+        @default_max_results,
+        @absolute_max_results
+      )
+
+    max_concurrency =
+      bounded_integer(
+        Keyword.get(opts, :max_concurrency, default(:validation_concurrency) || @default_max_concurrency),
+        @default_max_concurrency,
+        @absolute_max_concurrency
+      )
+
+    timeout =
+      bounded_integer(
+        Keyword.get(opts, :timeout, default(:validation_timeout) || @default_timeout),
+        @default_timeout,
+        @absolute_timeout
+      )
+
+    max_output_bytes =
+      bounded_integer(
+        Keyword.get(opts, :max_output_bytes, default(:max_output_bytes) || @default_max_output_bytes),
+        @default_max_output_bytes,
+        @absolute_max_output_bytes
+      )
+
+    validate_fun = Keyword.get(opts, :validate_fun, &validate_with_yt_dlp/2)
+
+    candidates = candidates |> Enum.filter(&match?(%Candidate{}, &1)) |> Enum.take(max_results)
+
+    candidates
+    |> Task.async_stream(
+      fn candidate -> validate_one(candidate, validate_fun, max_output_bytes) end,
+      max_concurrency: max(max_concurrency, 1),
+      timeout: max(timeout, 1),
+      on_timeout: :kill_task,
+      ordered: true
+    )
+    |> Enum.zip(candidates)
+    |> Enum.reduce(%{validated: [], rejected: []}, fn
+      {{:ok, {:validated, validated_candidate}}, _candidate}, result ->
+        %{result | validated: [validated_candidate | result.validated]}
+
+      {{:ok, {:rejected, candidate, reason}}, _original_candidate}, result ->
+        %{result | rejected: [%{candidate: candidate, reason: reason} | result.rejected]}
+
+      {{:exit, :timeout}, candidate}, result ->
+        %{result | rejected: [%{candidate: candidate, reason: :timeout} | result.rejected]}
+
+      {{:exit, _reason}, candidate}, result ->
+        %{result | rejected: [%{candidate: candidate, reason: :error} | result.rejected]}
+    end)
+    |> then(fn result ->
+      %{
+        validated: result.validated |> Candidate.deduplicate() |> Enum.take(max_results),
+        rejected: Enum.reverse(result.rejected)
+      }
+    end)
+  end
+
+  @doc """
+  Alias for callers that prefer an explicit function name.
+  """
+  def validate_candidates(candidates, opts \\ []), do: validate(candidates, opts)
+
+  @doc """
+  Converts a validated candidate into its stable channel identity and metadata.
+  """
+  def normalize_validated_candidate(%Candidate{} = candidate, attrs) when is_map(attrs) do
+    external_channel_id = first_value(attrs, [:external_channel_id, :channel_id, "external_channel_id", "channel_id"])
+    channel_name = first_value(attrs, [:channel_name, :channel, :uploader, "channel_name", "channel", "uploader"])
+    artwork_url = first_value(attrs, [:artwork_url, :thumbnail_url, "artwork_url", "thumbnail_url"])
+
+    with true <- Normalizer.valid_channel_id?(external_channel_id),
+         true <- non_empty_binary?(channel_name) do
+      reference = %{
+        kind: :channel_id,
+        key: "channel_id:" <> external_channel_id,
+        external_channel_id: external_channel_id,
+        handle: nil,
+        canonical_url: Normalizer.channel_url(external_channel_id)
+      }
+
+      {:ok,
+       %Candidate{
+         candidate
+         | reference: reference,
+           canonical_url: Normalizer.channel_url(external_channel_id),
+           external_channel_id: external_channel_id,
+           channel_name: String.trim(channel_name) |> String.slice(0, 200),
+           artwork_url: bounded_artwork_url(artwork_url, candidate.artwork_url)
+       }}
+    else
+      false -> {:error, :malformed}
+    end
+  end
+
+  defp validate_one(candidate, validate_fun, max_output_bytes) do
+    result =
+      try do
+        cond do
+          is_function(validate_fun, 2) -> validate_fun.(candidate, max_output_bytes)
+          is_function(validate_fun, 1) -> validate_fun.(candidate)
+          true -> {:error, :error}
+        end
+      rescue
+        _error -> {:error, :error}
+      catch
+        :exit, _reason -> {:error, :error}
+      end
+
+    case result do
+      {:ok, %Candidate{} = validated_candidate} ->
+        case validated_candidate.external_channel_id do
+          id when is_binary(id) ->
+            case Normalizer.valid_channel_id?(id) do
+              true -> {:validated, validated_candidate}
+              false -> {:rejected, candidate, :missing}
+            end
+
+          _ ->
+            {:rejected, candidate, :missing}
+        end
+
+      {:ok, attrs} when is_map(attrs) ->
+        case normalize_validated_candidate(candidate, attrs) do
+          {:ok, validated_candidate} -> {:validated, validated_candidate}
+          {:error, reason} -> {:rejected, candidate, reason}
+        end
+
+      :ok ->
+        {:rejected, candidate, :malformed}
+
+      :missing ->
+        {:rejected, candidate, :missing}
+
+      :timeout ->
+        {:rejected, candidate, :timeout}
+
+      {:timeout, _details} ->
+        {:rejected, candidate, :timeout}
+
+      {:error, reason} ->
+        {:rejected, candidate, safe_reason(reason)}
+
+      _ ->
+        {:rejected, candidate, :malformed}
+    end
+  end
+
+  defp validate_with_yt_dlp(%Candidate{} = candidate, max_output_bytes) do
+    runner = Application.get_env(:pinchflat, :yt_dlp_runner)
+
+    command_opts = [:simulate, :skip_download, :ignore_no_formats_error, :no_warnings, playlist_end: 1]
+    output_template = "%(.{channel,channel_id,channel_url,uploader,thumbnails})j"
+    addl_opts = [use_cookies: false, skip_sleep_interval: true]
+
+    case runner.run(candidate.canonical_url, :channel_discovery_validate, command_opts, output_template, addl_opts) do
+      {:ok, output} when is_binary(output) and byte_size(output) <= max_output_bytes ->
+        case Phoenix.json_library().decode(String.trim(output)) do
+          {:ok, response} when is_map(response) -> response
+          _ -> {:error, :malformed}
+        end
+
+      {:ok, _output} ->
+        {:error, :output_too_large}
+
+      {:error, _output, _status} ->
+        {:error, :missing}
+
+      {:error, _reason} ->
+        {:error, :missing}
+
+      _ ->
+        {:error, :malformed}
+    end
+  end
+
+  defp first_value(map, keys) do
+    Enum.find_value(keys, fn key ->
+      case Map.get(map, key) do
+        value when is_binary(value) and byte_size(value) > 0 -> String.trim(value)
+        _ -> nil
+      end
+    end)
+  end
+
+  defp non_empty_binary?(value) when is_binary(value), do: String.trim(value) != ""
+  defp non_empty_binary?(_value), do: false
+
+  defp bounded_artwork_url(value, _fallback) when is_binary(value), do: String.slice(String.trim(value), 0, 2_048)
+  defp bounded_artwork_url(_value, fallback), do: fallback
+
+  defp bounded_integer(value, _fallback, maximum) when is_integer(value), do: value |> max(0) |> min(maximum)
+  defp bounded_integer(_value, fallback, maximum), do: max(fallback, 0) |> min(maximum)
+
+  defp default(key) do
+    Application.get_env(:pinchflat, :channel_discovery, [])
+    |> Keyword.get(key)
+  end
+
+  defp safe_reason(reason) when reason in [:missing, :timeout, :malformed, :error, :output_too_large], do: reason
+  defp safe_reason(_reason), do: :error
+end

--- a/lib/pinchflat/discovery/worker.ex
+++ b/lib/pinchflat/discovery/worker.ex
@@ -1,0 +1,61 @@
+defmodule Pinchflat.Discovery.Worker do
+  @moduledoc """
+  Runs a bounded channel discovery scan in Oban.
+
+  The worker is scheduled daily, but scheduled jobs cancel cheaply while the
+  global setting is disabled. Manual kickoff is explicit user intent and is
+  allowed to run while the scheduled gate is off.
+  """
+
+  use Oban.Worker,
+    queue: :local_data,
+    unique: [period: :infinity, states: :incomplete, fields: [:worker, :queue]],
+    max_attempts: 3,
+    tags: ["channel_discovery", "local_data"]
+
+  alias Pinchflat.Discovery
+  alias Pinchflat.Repo
+  alias Pinchflat.Settings
+
+  @doc """
+  Enqueues a manual discovery scan.
+
+  Returns `{:ok, %Oban.Job{}} | {:error, :duplicate_job} | {:error, term()}`.
+  """
+  def kickoff(opts \\ []) when is_list(opts) do
+    args = %{"manual" => true}
+    job_opts = Keyword.take(opts, [:schedule_in, :priority, :max_attempts])
+
+    case Repo.insert_unique_job(new(args, job_opts)) do
+      {:ok, job} -> {:ok, job}
+      {:duplicate, _job} -> {:error, :duplicate_job}
+      error -> error
+    end
+  end
+
+  @doc """
+  Performs a scheduled or manual scan.
+
+  Scheduled work is disabled by default through `channel_discovery_enabled`.
+  """
+  @impl Oban.Worker
+  def perform(%Oban.Job{args: %{"manual" => true}}) do
+    run_scan(manual: true)
+  end
+
+  def perform(%Oban.Job{}) do
+    if Settings.get!(:channel_discovery_enabled) do
+      run_scan(manual: false)
+    else
+      Discovery.broadcast_completion(%{status: :disabled, candidate_count: 0, validated_count: 0, inserted_count: 0})
+      {:cancel, "Scheduled channel discovery is disabled"}
+    end
+  end
+
+  defp run_scan(opts) do
+    case Discovery.scan(Keyword.put(opts, :broadcast, true)) do
+      {:ok, _result} -> :ok
+      {:error, _reason} -> {:error, :discovery_scan_failed}
+    end
+  end
+end

--- a/lib/pinchflat/settings/setting.ex
+++ b/lib/pinchflat/settings/setting.ex
@@ -30,7 +30,10 @@ defmodule Pinchflat.Settings.Setting do
     :time_format,
     :yt_dlp_download_worker_concurrency,
     :yt_dlp_index_worker_concurrency,
-    :yt_dlp_remote_metadata_worker_concurrency
+    :yt_dlp_remote_metadata_worker_concurrency,
+    :channel_discovery_enabled,
+    :channel_discovery_mentions_enabled,
+    :channel_discovery_featured_enabled
   ]
 
   @time_formats ~w(24h 12h)
@@ -74,6 +77,11 @@ defmodule Pinchflat.Settings.Setting do
     field :yt_dlp_download_worker_concurrency, :integer
     field :yt_dlp_index_worker_concurrency, :integer
     field :yt_dlp_remote_metadata_worker_concurrency, :integer
+
+    # Channel discovery is opt-in at both the feature and generator level.
+    field :channel_discovery_enabled, :boolean, default: false
+    field :channel_discovery_mentions_enabled, :boolean, default: false
+    field :channel_discovery_featured_enabled, :boolean, default: false
 
     field :video_codec_preference, :string
     field :audio_codec_preference, :string

--- a/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
+++ b/lib/pinchflat_web/components/layouts/partials/sidebar.html.heex
@@ -61,6 +61,12 @@
           <.sidebar_item icon="hero-home" text="Home" href={~p"/"} current_path={current_path} />
           <.sidebar_item icon="hero-tv" text="Sources" href={~p"/sources"} current_path={current_path} />
           <.sidebar_item
+            icon="hero-magnifying-glass"
+            text="Channel Discovery"
+            href={~p"/discovery"}
+            current_path={current_path}
+          />
+          <.sidebar_item
             icon="hero-adjustments-vertical"
             text="Media Profiles"
             href={~p"/media_profiles"}

--- a/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
@@ -127,6 +127,38 @@
     />
   </section>
 
+  <section class="theme-surface-raised px-5 py-5 sm:px-7.5" x-show="match(groups.discovery)">
+    <h3 class="text-2xl text-theme-on-surface">Channel Discovery</h3>
+
+    <p class="mt-2 max-w-prose text-sm text-theme-on-surface-muted">
+      Find channel suggestions from your locally stored metadata and subscribed channels.
+    </p>
+
+    <div x-data={"{ channelDiscoveryEnabled: #{f[:channel_discovery_enabled].value} }"}>
+      <.input
+        field={f[:channel_discovery_enabled]}
+        type="toggle"
+        label="Enable Channel Discovery"
+        help="Opt in to scheduled channel discovery scans. This is disabled by default and only runs after you enable it."
+        x-model="channelDiscoveryEnabled"
+      />
+      <.input
+        field={f[:channel_discovery_mentions_enabled]}
+        type="toggle"
+        label="Discover Channels from Mentions"
+        help="Scan locally stored descriptions and metadata for channel references. Only applies when Channel Discovery is enabled."
+        x-bind:disabled="!channelDiscoveryEnabled"
+      />
+      <.input
+        field={f[:channel_discovery_featured_enabled]}
+        type="toggle"
+        label="Discover Featured Channels"
+        help="Look for channels featured by your existing subscriptions. Only applies when Channel Discovery is enabled."
+        x-bind:disabled="!channelDiscoveryEnabled"
+      />
+    </div>
+  </section>
+
   <section class="theme-surface-raised px-5 py-5 sm:px-7.5" x-show="match(groups.ytdlp)">
     <h3 class="text-2xl text-theme-on-surface">yt-dlp</h3>
 
@@ -186,7 +218,7 @@
     class="w-full sm:w-auto"
     rounding="rounded-m3-sm"
     form="settings-form"
-    x-show="match(groups.notifications) || match(groups.extractor) || match(groups.ytdlp) || ((advancedMode || query.trim()) && match(groups.codec))"
+    x-show="match(groups.notifications) || match(groups.extractor) || match(groups.discovery) || match(groups.ytdlp) || ((advancedMode || query.trim()) && match(groups.codec))"
   >
     Save Settings
   </.button>
@@ -195,7 +227,7 @@
 <p
   class="theme-surface-raised px-5 py-8 text-center text-sm text-theme-on-surface-muted sm:px-7.5"
   x-cloak
-  x-show="!match(groups.notifications) && !match(groups.extractor) && !match(groups.ytdlp) && !match(groups.cookies) && !((advancedMode || query.trim()) && match(groups.codec))"
+  x-show="!match(groups.notifications) && !match(groups.extractor) && !match(groups.discovery) && !match(groups.ytdlp) && !match(groups.cookies) && !((advancedMode || query.trim()) && match(groups.codec))"
 >
   No settings match "<span x-text="query.trim()"></span>".
 </p>

--- a/lib/pinchflat_web/controllers/sources/source_controller.ex
+++ b/lib/pinchflat_web/controllers/sources/source_controller.ex
@@ -77,7 +77,7 @@ defmodule PinchflatWeb.Sources.SourceController do
                 original_url: nil,
                 marked_for_deletion_at: nil
             }
-            |> Sources.change_source()
+            |> Sources.change_source(prefill_source_attrs(params))
             |> maybe_default_cookie_behaviour()
         ],
         cookie_file_assigns()
@@ -678,6 +678,30 @@ defmodule PinchflatWeb.Sources.SourceController do
       changeset
     end
   end
+
+  defp prefill_source_attrs(params) do
+    %{}
+    |> maybe_put_prefill("original_url", params["original_url"])
+    |> maybe_put_prefill("custom_name", params["custom_name"])
+    |> maybe_put_source_type_prefill(params["source_type"])
+  end
+
+  defp maybe_put_prefill(attrs, key, value) when is_binary(value) and value != "" do
+    Map.put(attrs, key, value)
+  end
+
+  defp maybe_put_prefill(attrs, _key, _value), do: attrs
+
+  defp maybe_put_source_type_prefill(attrs, source_type) when is_binary(source_type) do
+    case Enum.find_value(Source.source_type_options(), fn {_label, option} ->
+           if Atom.to_string(option) == source_type, do: option
+         end) do
+      nil -> attrs
+      option -> Map.put(attrs, "source_type", option)
+    end
+  end
+
+  defp maybe_put_source_type_prefill(attrs, _source_type), do: attrs
 
   defp tab_param(params, allowed_tabs, default_tab) do
     tab = params["tab"]

--- a/lib/pinchflat_web/discovery_live.ex
+++ b/lib/pinchflat_web/discovery_live.ex
@@ -1,0 +1,477 @@
+defmodule PinchflatWeb.DiscoveryLive do
+  @moduledoc """
+  LiveView for channel discovery suggestions.
+  """
+
+  use PinchflatWeb, :live_view
+
+  alias Pinchflat.Discovery
+  alias Pinchflat.Discovery.Suggestion
+  alias Pinchflat.Discovery.Worker
+
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(
+        visible_suggestions: [],
+        suggestions: [],
+        dismissed_suggestions: [],
+        discovery_enabled: Settings.get!(:channel_discovery_enabled),
+        mentions_enabled: Settings.get!(:channel_discovery_mentions_enabled),
+        featured_enabled: Settings.get!(:channel_discovery_featured_enabled),
+        scan_busy: false,
+        scan_status: :idle,
+        notice: nil
+      )
+      |> refresh_suggestions()
+
+    if connected?(socket), do: Discovery.subscribe()
+
+    {:ok, socket}
+  end
+
+  def handle_event("refresh", _params, socket) do
+    {:noreply,
+     socket
+     |> refresh_suggestions()
+     |> assign(notice: "Suggestions refreshed.")}
+  end
+
+  def handle_event("scan", _params, %{assigns: %{scan_busy: true}} = socket) do
+    {:noreply,
+     assign(socket,
+       scan_status: :busy,
+       notice: "A discovery scan is already queued or running."
+     )}
+  end
+
+  def handle_event("scan", _params, socket) do
+    case Worker.kickoff() do
+      {:ok, _job} ->
+        {:noreply,
+         assign(socket,
+           scan_busy: true,
+           scan_status: :queued,
+           notice: "Discovery scan queued. Suggestions will refresh when it completes."
+         )}
+
+      {:error, :duplicate_job} ->
+        {:noreply,
+         assign(socket,
+           scan_busy: true,
+           scan_status: :duplicate,
+           notice: "A discovery scan is already queued or running."
+         )}
+
+      {:error, _reason} ->
+        {:noreply,
+         assign(socket,
+           scan_busy: false,
+           scan_status: :error,
+           notice: "Discovery scan could not be queued."
+         )}
+    end
+  end
+
+  def handle_event("accept", params, socket) do
+    case suggestion_from_params(params) do
+      %Suggestion{} = suggestion ->
+        case Discovery.accept_suggestion(suggestion) do
+          {:ok, accepted_suggestion} ->
+            {:noreply, push_navigate(socket, to: source_new_path(accepted_suggestion))}
+
+          {:error, _changeset} ->
+            {:noreply, assign(socket, notice: "This suggestion could not be accepted.")}
+        end
+
+      nil ->
+        {:noreply, assign(socket, notice: "This suggestion is no longer available.")}
+    end
+  end
+
+  def handle_event("dismiss", params, socket) do
+    update_suggestion(socket, params, &Discovery.dismiss_suggestion/1, "Suggestion dismissed.")
+  end
+
+  def handle_event("restore", params, socket) do
+    update_suggestion(socket, params, &Discovery.restore_suggestion/1, "Suggestion restored.")
+  end
+
+  def handle_info(%Phoenix.Socket.Broadcast{topic: topic, event: event, payload: payload}, socket) do
+    if topic == Discovery.completion_topic() and event == Discovery.completion_event() do
+      {:noreply,
+       socket
+       |> refresh_suggestions()
+       |> assign(
+         scan_busy: false,
+         scan_status: completion_status(payload),
+         notice: completion_notice(payload)
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_info(_message, socket), do: {:noreply, socket}
+
+  def render(assigns) do
+    ~H"""
+    <div id="discovery-page" class="space-y-6" data-view="channel-discovery">
+      <header id="discovery-header" class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 class="text-2xl font-semibold text-theme-on-surface">Channel Discovery</h1>
+          <p class="mt-2 max-w-2xl text-sm text-theme-on-surface-muted">
+            Find channels from local metadata and your existing subscriptions.
+          </p>
+        </div>
+
+        <div class="flex flex-wrap gap-2" role="group" aria-label="Discovery actions">
+          <button
+            id="discovery-refresh"
+            type="button"
+            class="theme-outline-button inline-flex items-center gap-2 rounded-m3-sm px-4 py-2 text-sm font-medium"
+            phx-click="refresh"
+            data-action="refresh"
+          >
+            <.icon name="hero-arrow-path" class="h-4 w-4" aria-hidden="true" /> Refresh
+          </button>
+          <button
+            id="discovery-scan"
+            type="button"
+            class="theme-primary-button inline-flex items-center gap-2 rounded-m3-sm px-4 py-2 text-sm font-medium disabled:cursor-not-allowed disabled:opacity-50"
+            phx-click="scan"
+            data-action="scan"
+            data-scan-state={to_string(@scan_status)}
+            disabled={@scan_busy}
+          >
+            <.icon name="hero-magnifying-glass" class="h-4 w-4" aria-hidden="true" />
+            {scan_button_label(@scan_busy, @scan_status)}
+          </button>
+        </div>
+      </header>
+
+      <section
+        id="discovery-status-panel"
+        class="theme-surface-raised p-5"
+        aria-labelledby="discovery-status-heading"
+        data-discovery-enabled={to_string(@discovery_enabled)}
+      >
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <h2 id="discovery-status-heading" class="text-lg font-semibold text-theme-on-surface">Discovery status</h2>
+          <span
+            id="discovery-scan-status"
+            class={["text-sm font-medium", scan_status_class(@scan_status)]}
+            role="status"
+            aria-live="polite"
+            data-status={to_string(@scan_status)}
+          >
+            {scan_status_label(@scan_status)}
+          </span>
+        </div>
+
+        <p id="discovery-status" class="mt-2 text-sm text-theme-on-surface-muted" role="status" aria-live="polite">
+          {@notice || "Ready to scan."}
+        </p>
+
+        <dl id="discovery-settings" class="mt-5 grid gap-3 sm:grid-cols-3">
+          <div class="theme-surface-accent p-3" data-setting="channel_discovery_enabled">
+            <dt class="text-xs font-medium uppercase tracking-wide text-theme-on-surface-muted">Scheduled scans</dt>
+            <dd class="mt-1">
+              <span class={[
+                "inline-flex rounded-full px-2 py-1 text-xs font-medium",
+                setting_badge_class(@discovery_enabled)
+              ]}>
+                {setting_label(@discovery_enabled)}
+              </span>
+            </dd>
+          </div>
+          <div class="theme-surface-accent p-3" data-setting="channel_discovery_mentions_enabled">
+            <dt class="text-xs font-medium uppercase tracking-wide text-theme-on-surface-muted">Mention discovery</dt>
+            <dd class="mt-1">
+              <span class={[
+                "inline-flex rounded-full px-2 py-1 text-xs font-medium",
+                setting_badge_class(@mentions_enabled)
+              ]}>
+                {setting_label(@mentions_enabled)}
+              </span>
+            </dd>
+          </div>
+          <div class="theme-surface-accent p-3" data-setting="channel_discovery_featured_enabled">
+            <dt class="text-xs font-medium uppercase tracking-wide text-theme-on-surface-muted">Featured discovery</dt>
+            <dd class="mt-1">
+              <span class={[
+                "inline-flex rounded-full px-2 py-1 text-xs font-medium",
+                setting_badge_class(@featured_enabled)
+              ]}>
+                {setting_label(@featured_enabled)}
+              </span>
+            </dd>
+          </div>
+        </dl>
+
+        <p class="mt-4 text-sm text-theme-on-surface-muted">
+          Scheduled discovery is controlled in <.link
+            href={~p"/settings"}
+            class="font-medium text-theme-primary hover:underline"
+          >Settings</.link>.
+          Manual scans remain available when scheduled scans are disabled.
+        </p>
+      </section>
+
+      <section id="discovery-suggestions" aria-labelledby="discovery-suggestions-heading">
+        <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 id="discovery-suggestions-heading" class="text-xl font-semibold text-theme-on-surface">Suggestions</h2>
+            <p class="mt-1 text-sm text-theme-on-surface-muted">Review channels before adding them as sources.</p>
+          </div>
+          <span class="text-sm text-theme-on-surface-muted" data-visible-count={to_string(length(@visible_suggestions))}>
+            {length(@visible_suggestions)} visible
+          </span>
+        </div>
+
+        <div
+          :if={@visible_suggestions == []}
+          id="discovery-empty"
+          class="theme-surface-accent p-8 text-center"
+          role="status"
+        >
+          <h3 id="discovery-empty-heading" class="text-lg font-semibold text-theme-on-surface">
+            No channel suggestions yet
+          </h3>
+          <p class="mx-auto mt-2 max-w-xl text-sm text-theme-on-surface-muted">
+            Refresh the sample or run a scan to look for validated channel suggestions.
+          </p>
+        </div>
+
+        <div
+          :if={@visible_suggestions != []}
+          id="discovery-suggestion-list"
+          class="grid gap-4 md:grid-cols-2 xl:grid-cols-3"
+          data-suggestion-count={to_string(length(@visible_suggestions))}
+        >
+          <article
+            :for={suggestion <- @visible_suggestions}
+            id={suggestion_dom_id(suggestion)}
+            class="theme-surface-raised flex flex-col gap-4 p-5"
+            data-suggestion-id={suggestion_external_id(suggestion)}
+            data-suggestion-state="validated"
+          >
+            <div class="flex min-w-0 items-start gap-3">
+              <img
+                :if={suggestion_artwork_url(suggestion)}
+                src={suggestion_artwork_url(suggestion)}
+                alt={"Artwork for #{suggestion_name(suggestion)}"}
+                class="h-14 w-14 shrink-0 rounded-m3-sm object-cover"
+                loading="lazy"
+              />
+              <div class="min-w-0">
+                <h3 class="break-words text-lg font-semibold text-theme-on-surface">{suggestion_name(suggestion)}</h3>
+                <.link
+                  href={suggestion.canonical_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  class="mt-1 block break-all text-sm text-theme-primary hover:underline"
+                >
+                  {suggestion.canonical_url}
+                </.link>
+              </div>
+            </div>
+
+            <div class="flex items-center justify-between gap-3 text-sm">
+              <span class="text-theme-on-surface-muted">Discovery score</span>
+              <span class="theme-badge-success rounded-full px-2 py-1 font-medium" data-score={to_string(suggestion.score)}>
+                {suggestion.score}
+              </span>
+            </div>
+
+            <dl class="theme-surface-accent p-3 text-sm">
+              <dt class="text-xs font-medium uppercase tracking-wide text-theme-on-surface-muted">Evidence</dt>
+              <dd class="mt-1 break-words text-theme-on-surface">{suggestion.evidence}</dd>
+            </dl>
+
+            <div class="mt-auto flex flex-wrap gap-2 border-t border-theme-outline/60 pt-4">
+              <button
+                id={"accept-suggestion-#{suggestion_external_id(suggestion)}"}
+                type="button"
+                class="theme-primary-button rounded-m3-sm px-4 py-2 text-sm font-medium"
+                phx-click="accept"
+                phx-value-external_channel_id={suggestion_external_id(suggestion)}
+                data-action="accept"
+                aria-label={"Accept #{suggestion_name(suggestion)}"}
+              >
+                Accept
+              </button>
+              <button
+                id={"dismiss-suggestion-#{suggestion_external_id(suggestion)}"}
+                type="button"
+                class="theme-outline-button rounded-m3-sm px-4 py-2 text-sm font-medium"
+                phx-click="dismiss"
+                phx-value-external_channel_id={suggestion_external_id(suggestion)}
+                data-action="dismiss"
+                aria-label={"Dismiss #{suggestion_name(suggestion)}"}
+              >
+                Dismiss
+              </button>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section id="discovery-dismissed" aria-labelledby="discovery-dismissed-heading" class="theme-surface-raised p-5">
+        <div class="flex flex-wrap items-end justify-between gap-3">
+          <div>
+            <h2 id="discovery-dismissed-heading" class="text-xl font-semibold text-theme-on-surface">
+              Dismissed suggestions
+            </h2>
+            <p class="mt-1 text-sm text-theme-on-surface-muted">
+              Restore a dismissed channel if you want to review it again.
+            </p>
+          </div>
+          <span class="text-sm text-theme-on-surface-muted" data-dismissed-count={to_string(length(@dismissed_suggestions))}>
+            {length(@dismissed_suggestions)} dismissed
+          </span>
+        </div>
+
+        <p
+          :if={@dismissed_suggestions == []}
+          id="discovery-dismissed-empty"
+          class="mt-4 text-sm text-theme-on-surface-muted"
+          role="status"
+        >
+          No dismissed suggestions.
+        </p>
+
+        <ul :if={@dismissed_suggestions != []} id="discovery-dismissed-list" class="mt-4 space-y-3">
+          <li
+            :for={suggestion <- @dismissed_suggestions}
+            id={"dismissed-#{suggestion_external_id(suggestion)}"}
+            class="flex flex-wrap items-center justify-between gap-3 border-t border-theme-outline/60 pt-3"
+            data-suggestion-id={suggestion_external_id(suggestion)}
+            data-suggestion-state="dismissed"
+          >
+            <div class="min-w-0">
+              <p class="break-words font-medium text-theme-on-surface">{suggestion_name(suggestion)}</p>
+              <p class="break-all text-sm text-theme-on-surface-muted">{suggestion.canonical_url}</p>
+            </div>
+            <button
+              id={"restore-suggestion-#{suggestion_external_id(suggestion)}"}
+              type="button"
+              class="theme-outline-button rounded-m3-sm px-4 py-2 text-sm font-medium"
+              phx-click="restore"
+              phx-value-external_channel_id={suggestion_external_id(suggestion)}
+              data-action="restore"
+              aria-label={"Restore #{suggestion_name(suggestion)}"}
+            >
+              Restore
+            </button>
+          </li>
+        </ul>
+      </section>
+    </div>
+    """
+  end
+
+  defp refresh_suggestions(socket) do
+    visible_suggestions = Discovery.sample_suggestions()
+
+    assign(socket,
+      visible_suggestions: visible_suggestions,
+      suggestions: visible_suggestions,
+      dismissed_suggestions: Discovery.list_dismissed_suggestions()
+    )
+  end
+
+  defp suggestion_from_params(%{"external_channel_id" => external_channel_id})
+       when is_binary(external_channel_id) do
+    Discovery.get_suggestion_by_external_channel_id(external_channel_id)
+  end
+
+  defp suggestion_from_params(%{"suggestion_id" => suggestion_id}), do: Discovery.get_suggestion(suggestion_id)
+  defp suggestion_from_params(%{"id" => suggestion_id}), do: Discovery.get_suggestion(suggestion_id)
+  defp suggestion_from_params(_params), do: nil
+
+  defp update_suggestion(socket, params, update_fun, success_message) do
+    case suggestion_from_params(params) do
+      %Suggestion{} = suggestion ->
+        case update_fun.(suggestion) do
+          {:ok, _updated_suggestion} ->
+            {:noreply,
+             socket
+             |> refresh_suggestions()
+             |> assign(notice: success_message)}
+
+          {:error, _changeset} ->
+            {:noreply, assign(socket, notice: "The suggestion could not be updated.")}
+        end
+
+      nil ->
+        {:noreply, assign(socket, notice: "This suggestion is no longer available.")}
+    end
+  end
+
+  defp source_new_path(%Suggestion{} = suggestion) do
+    ~p"/sources/new?#{[original_url: suggestion.canonical_url || "", custom_name: suggestion.channel_name || "", source_type: "channel"]}"
+  end
+
+  defp suggestion_external_id(%{external_channel_id: external_channel_id}), do: external_channel_id
+
+  defp suggestion_name(%{channel_name: channel_name}) when is_binary(channel_name) and channel_name != "",
+    do: channel_name
+
+  defp suggestion_name(%{external_channel_id: external_channel_id}), do: external_channel_id
+
+  defp suggestion_artwork_url(%{artwork_url: artwork_url}) when is_binary(artwork_url) and artwork_url != "",
+    do: artwork_url
+
+  defp suggestion_artwork_url(_suggestion), do: nil
+
+  defp suggestion_dom_id(suggestion), do: "discovery-suggestion-#{suggestion_external_id(suggestion)}"
+
+  defp setting_label(true), do: "Enabled"
+  defp setting_label(false), do: "Disabled"
+  defp setting_label(_value), do: "Unknown"
+
+  defp setting_badge_class(true), do: "theme-badge-success"
+  defp setting_badge_class(false), do: "theme-badge-warning"
+  defp setting_badge_class(_value), do: "theme-badge-warning"
+
+  defp scan_button_label(true, :duplicate), do: "Scan already queued"
+  defp scan_button_label(true, _status), do: "Scan queued"
+  defp scan_button_label(false, _status), do: "Scan now"
+
+  defp scan_status_label(:idle), do: "Ready to scan."
+  defp scan_status_label(:queued), do: "Scan queued."
+  defp scan_status_label(:busy), do: "Scan in progress."
+  defp scan_status_label(:duplicate), do: "A scan is already queued or running."
+  defp scan_status_label(:completed), do: "Scan completed."
+  defp scan_status_label(:disabled), do: "Scheduled discovery is disabled."
+  defp scan_status_label(:error), do: "Scan could not be queued."
+  defp scan_status_label(_status), do: "Discovery status unavailable."
+
+  defp scan_status_class(status) when status in [:queued, :busy], do: "theme-status-info"
+  defp scan_status_class(:completed), do: "theme-status-success"
+  defp scan_status_class(status) when status in [:duplicate, :disabled], do: "theme-status-warning"
+  defp scan_status_class(:error), do: "theme-status-error"
+  defp scan_status_class(_status), do: "text-theme-on-surface-muted"
+
+  defp completion_status(%{status: :disabled}), do: :disabled
+  defp completion_status(%{"status" => "disabled"}), do: :disabled
+  defp completion_status(%{status: :failed}), do: :error
+  defp completion_status(%{"status" => "failed"}), do: :error
+  defp completion_status(_payload), do: :completed
+
+  defp completion_notice(%{status: :disabled}),
+    do: "Discovery is disabled in Settings. Manual scans remain available."
+
+  defp completion_notice(%{"status" => "disabled"}),
+    do: "Discovery is disabled in Settings. Manual scans remain available."
+
+  defp completion_notice(%{status: :failed}), do: "Discovery scan failed. Try again when ready."
+  defp completion_notice(%{"status" => "failed"}), do: "Discovery scan failed. Try again when ready."
+
+  defp completion_notice(%{inserted_count: inserted_count}) when is_integer(inserted_count) do
+    "Scan completed. #{inserted_count} new suggestion(s) added."
+  end
+
+  defp completion_notice(_payload), do: "Discovery scan completed. Suggestions refreshed."
+end

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -66,6 +66,7 @@ defmodule PinchflatWeb.Router do
     pipe_through :browser
 
     get "/", Pages.PageController, :home
+    live "/discovery", DiscoveryLive
     post "/sources/cookies/upload", Sources.SourceController, :upload_cookies
     post "/sources/cookies/save", Sources.SourceController, :save_cookies
 

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   },
   "scripts": {
     "create-erd": "sqleton -o priv/repo/erd.png priv/repo/pinchflat_dev.db",
-    "lint:check": "prettier . --check --config=.prettierrc.js --ignore-path=.prettierignore --ignore-path=.gitignore",
-    "lint:fix": "prettier . --write --config=.prettierrc.js --ignore-path=.prettierignore --ignore-path=.gitignore",
+    "lint:check": "prettier . '!**/.agents/**' --check --config=.prettierrc.js --ignore-path=.prettierignore --ignore-path=.gitignore",
+    "lint:fix": "prettier . '!**/.agents/**' --write --config=.prettierrc.js --ignore-path=.prettierignore --ignore-path=.gitignore",
     "ui:check-theme": "powershell -ExecutionPolicy Bypass -File scripts/check-ui-theme.ps1"
   },
   "private": true

--- a/priv/repo/migrations/20260910180000_create_channel_discovery_suggestions.exs
+++ b/priv/repo/migrations/20260910180000_create_channel_discovery_suggestions.exs
@@ -1,0 +1,21 @@
+defmodule Pinchflat.Repo.Migrations.CreateChannelDiscoverySuggestions do
+  use Ecto.Migration
+
+  def change do
+    create table(:channel_discovery_suggestions) do
+      add :external_channel_id, :string, null: false
+      add :canonical_url, :string, null: false
+      add :channel_name, :string, null: false
+      add :artwork_url, :string
+      add :evidence, :string, null: false, default: ""
+      add :score, :integer, null: false, default: 0
+      add :validated_at, :utc_datetime
+      add :state, :string, null: false, default: "validated"
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create unique_index(:channel_discovery_suggestions, [:external_channel_id])
+    create index(:channel_discovery_suggestions, [:state, :score])
+  end
+end

--- a/priv/repo/migrations/20260910181000_add_channel_discovery_settings.exs
+++ b/priv/repo/migrations/20260910181000_add_channel_discovery_settings.exs
@@ -1,0 +1,11 @@
+defmodule Pinchflat.Repo.Migrations.AddChannelDiscoverySettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:settings) do
+      add :channel_discovery_enabled, :boolean, default: false, null: false
+      add :channel_discovery_mentions_enabled, :boolean, default: false, null: false
+      add :channel_discovery_featured_enabled, :boolean, default: false, null: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260910182000_add_generators_to_channel_discovery_suggestions.exs
+++ b/priv/repo/migrations/20260910182000_add_generators_to_channel_discovery_suggestions.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddGeneratorsToChannelDiscoverySuggestions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:channel_discovery_suggestions) do
+      add :generators, :string, null: false, default: ""
+    end
+  end
+end

--- a/test/pinchflat/discovery/candidate_scoring_sample_test.exs
+++ b/test/pinchflat/discovery/candidate_scoring_sample_test.exs
@@ -1,0 +1,54 @@
+defmodule Pinchflat.Discovery.CandidateScoringSampleTest do
+  use ExUnit.Case, async: true
+
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.Sample
+  alias Pinchflat.Discovery.Scoring
+
+  @channel_id "UC" <> String.duplicate("a", 22)
+
+  test "deduplicates evidence deterministically" do
+    reference = %{
+      kind: :handle,
+      key: "handle:example",
+      handle: "example",
+      external_channel_id: nil,
+      canonical_url: "https://www.youtube.com/@example"
+    }
+
+    first = Candidate.from_reference(reference, :mention)
+    second = Candidate.from_reference(reference, :featured, %{channel_name: "Example"})
+
+    assert [%Candidate{generators: ["featured", "mention"], mentions: 1, channel_name: "Example"}] =
+             Candidate.deduplicate([second, first])
+  end
+
+  test "scores evidence without randomness" do
+    candidate = %Candidate{
+      external_channel_id: @channel_id,
+      channel_name: "Example",
+      generators: ["mention", "featured", "mention"],
+      mentions: 9
+    }
+
+    assert Scoring.score(candidate) == 17
+    assert Scoring.score(candidate) == Scoring.score(candidate)
+  end
+
+  test "selects a bounded random sample from a bounded pool" do
+    candidates =
+      for index <- 1..100 do
+        %Candidate{
+          external_channel_id: @channel_id <> Integer.to_string(index),
+          channel_name: "Channel #{index}",
+          generators: ["featured"]
+        }
+      end
+
+    random_fun = fn pool, size -> Enum.take(pool, size) end
+    sample = Sample.select(candidates, 100, max_pool: 7, random_fun: random_fun)
+
+    assert length(sample) == 7
+    assert length(Enum.uniq_by(sample, &Candidate.key/1)) == 7
+  end
+end

--- a/test/pinchflat/discovery/generator_test.exs
+++ b/test/pinchflat/discovery/generator_test.exs
@@ -1,0 +1,138 @@
+defmodule Pinchflat.Discovery.GeneratorTest do
+  use Pinchflat.DataCase
+
+  import Mox
+
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.FeaturedGenerator
+  alias Pinchflat.Discovery.MentionGenerator
+  alias Pinchflat.Discovery.Normalizer
+
+  defmodule TimeoutRunner do
+    @moduledoc false
+
+    def run(url, :channel_discovery_featured, _command_opts, _output_template, _addl_opts) do
+      if String.contains?(url, "UCaaaaaaaaaaaaaaaaaaaaaa") do
+        Process.sleep(100)
+      end
+
+      channel_id = url |> String.split("/channel/") |> List.last() |> String.trim_trailing("/featured")
+      {:ok, Jason.encode!(%{"entries" => [%{"id" => channel_id}]})}
+    end
+  end
+
+  @channel_id "UC" <> String.duplicate("a", 22)
+  @other_channel_id "UC" <> String.duplicate("b", 22)
+
+  describe "MentionGenerator" do
+    test "mines bounded local descriptions and stored metadata without retaining text" do
+      metadata_path = Path.join(Application.get_env(:pinchflat, :tmpfile_directory), "discovery-metadata.json.gz")
+      File.mkdir_p!(Path.dirname(metadata_path))
+
+      File.open!(metadata_path, [:write, :compressed, :binary], fn device ->
+        :ok = IO.binwrite(device, Phoenix.json_library().encode!(%{"description" => "See @metadata_channel"}))
+      end)
+
+      on_exit(fn -> File.rm(metadata_path) end)
+
+      source = %{
+        id: 1,
+        collection_id: @channel_id,
+        original_url: "https://www.youtube.com/channel/#{@channel_id}",
+        description: "See https://www.youtube.com/@description_channel",
+        metadata_filepath: metadata_path
+      }
+
+      assert {:ok, candidates} = MentionGenerator.generate(sources: [source], max_sources: 1, max_candidates: 2)
+      assert Enum.map(candidates, & &1.reference.key) == ["handle:description_channel", "handle:metadata_channel"]
+      refute Enum.any?(candidates, &String.contains?(inspect(&1), "See"))
+    end
+
+    test "bounds the number of sources and candidates" do
+      sources =
+        for index <- 1..4 do
+          %{id: index, collection_id: nil, original_url: nil, description: "@channel_#{index}"}
+        end
+
+      assert {:ok, candidates} = MentionGenerator.generate(sources: sources, max_sources: 2, max_candidates: 1)
+      assert length(candidates) == 1
+    end
+  end
+
+  describe "FeaturedGenerator" do
+    test "keeps valid candidates when one subscribed channel fails" do
+      sources = [
+        %{id: 1, collection_id: @channel_id, original_url: "https://www.youtube.com/channel/#{@channel_id}"},
+        %{id: 2, collection_id: @other_channel_id, original_url: "https://www.youtube.com/channel/#{@other_channel_id}"}
+      ]
+
+      fetch_fun = fn
+        %{id: 1}, _opts -> {:error, :runner_failed}
+        %{id: 2}, _opts -> [Normalizer.normalize_reference("@featured_channel") |> Candidate.from_reference(:featured)]
+      end
+
+      result = FeaturedGenerator.generate_with_errors(sources: sources, fetch_fun: fetch_fun, max_sources: 2)
+
+      assert [%Candidate{}] = result.candidates
+      assert [%{source_id: 1, reason: :runner_failed}] = result.errors
+    end
+
+    test "uses the configured runner without cookies and parses bounded output" do
+      source = %{
+        id: 1,
+        collection_id: @channel_id,
+        original_url: "https://www.youtube.com/channel/#{@channel_id}"
+      }
+
+      expect(YtDlpRunnerMock, :run, fn url, :channel_discovery_featured, command_opts, "playlist:%()j", addl_opts ->
+        assert url == "https://www.youtube.com/channel/#{@channel_id}/featured"
+        assert :skip_download in command_opts
+        assert Keyword.get(addl_opts, :use_cookies) == false
+        assert Keyword.get(addl_opts, :timeout) == 15_000
+        refute Keyword.has_key?(addl_opts, :cookies)
+
+        {:ok,
+         Phoenix.json_library().encode!(%{
+           "entries" => [%{"id" => @other_channel_id, "title" => "Featured channel"}]
+         })}
+      end)
+
+      assert {:ok, [%Candidate{external_channel_id: @other_channel_id, channel_name: "Featured channel"}]} =
+               FeaturedGenerator.generate(sources: [source], max_entries: 1)
+    end
+
+    test "rejects malformed or oversized runner responses without returning output" do
+      source = %{id: 1, collection_id: @channel_id, original_url: "https://www.youtube.com/channel/#{@channel_id}"}
+
+      assert {:error, :featured_unavailable} =
+               FeaturedGenerator.generate(
+                 sources: [source],
+                 fetch_fun: fn _source, _opts -> {:error, String.duplicate("secret-output", 100)} end
+               )
+
+      assert %{candidates: [], errors: [%{reason: :runner_failed}]} =
+               FeaturedGenerator.generate_with_errors(
+                 sources: [source],
+                 fetch_fun: fn _source, _opts -> {:error, String.duplicate("secret-output", 100)} end
+               )
+    end
+
+    test "times out the default fetch per source and keeps later partial results" do
+      sources = [
+        %{id: 1, collection_id: @channel_id, original_url: "https://www.youtube.com/channel/#{@channel_id}"},
+        %{id: 2, collection_id: @other_channel_id, original_url: "https://www.youtube.com/channel/#{@other_channel_id}"}
+      ]
+
+      assert %{
+               candidates: [%Candidate{external_channel_id: @other_channel_id}],
+               errors: [%{source_id: 1, reason: :timeout}]
+             } =
+               FeaturedGenerator.generate_with_errors(
+                 sources: sources,
+                 timeout: 25,
+                 max_sources: 2,
+                 runner: TimeoutRunner
+               )
+    end
+  end
+end

--- a/test/pinchflat/discovery/normalizer_test.exs
+++ b/test/pinchflat/discovery/normalizer_test.exs
@@ -1,0 +1,54 @@
+defmodule Pinchflat.Discovery.NormalizerTest do
+  use ExUnit.Case, async: true
+
+  alias Pinchflat.Discovery.Normalizer
+
+  @channel_id "UC" <> String.duplicate("a", 22)
+
+  test "normalizes channel IDs, handles, URLs, and duplicate references" do
+    text =
+      """
+      https://www.youtube.com/@Mixed_Handle/videos,
+      https://youtube.com/@mixed_handle
+      https://www.youtube.com/channel/#{@channel_id}
+      #{@channel_id}
+      """
+
+    references = Normalizer.normalize(text)
+
+    assert Enum.map(references, & &1.key) == ["handle:mixed_handle", "channel_id:#{@channel_id}"]
+
+    assert Enum.find(references, &(&1.kind == :handle)).canonical_url ==
+             "https://www.youtube.com/@mixed_handle"
+  end
+
+  test "rejects malformed references and video URLs" do
+    text =
+      "https://youtu.be/video-id https://www.youtube.com/watch?v=video-id " <>
+        "https://www.youtube.com/channel/UCshort https://www.youtube.com/@a " <>
+        "https://www.youtube.com/featured"
+
+    assert Normalizer.normalize(text) == []
+    assert is_nil(Normalizer.normalize_reference(%{key: "not-a-reference"}))
+    assert Normalizer.normalize(nil) == []
+  end
+
+  test "rejects overlong channel IDs" do
+    overlong_channel_id = "UC" <> String.duplicate("a", 23)
+
+    refute Normalizer.valid_channel_id?(overlong_channel_id)
+    assert Normalizer.normalize(overlong_channel_id) == []
+    assert is_nil(Normalizer.normalize_reference(overlong_channel_id))
+  end
+
+  test "removes self references by ID, handle, or URL" do
+    text = "#{@channel_id} https://www.youtube.com/@Other_Handle @other_handle @third_channel"
+
+    assert [%{key: "handle:third_channel"}] =
+             Normalizer.normalize(text, self_references: [@channel_id, "@other_handle"])
+  end
+
+  test "does not treat email-like text as a handle mention" do
+    assert Normalizer.normalize("contact person@example.com for details") == []
+  end
+end

--- a/test/pinchflat/discovery/scan_test.exs
+++ b/test/pinchflat/discovery/scan_test.exs
@@ -1,0 +1,139 @@
+defmodule Pinchflat.Discovery.ScanTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.SourcesFixtures
+
+  alias Pinchflat.Discovery
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.Normalizer
+  alias Pinchflat.Discovery.Suggestion
+  alias Pinchflat.Repo
+  alias Pinchflat.Settings
+
+  @channel_id "UC" <> String.duplicate("a", 22)
+  @existing_id "UC" <> String.duplicate("b", 22)
+  @dismissed_id "UC" <> String.duplicate("c", 22)
+
+  test "deduplicates and excludes existing sources and dismissed suggestions" do
+    source_fixture(%{
+      collection_type: :channel,
+      collection_id: @existing_id,
+      original_url: "https://www.youtube.com/channel/#{@existing_id}"
+    })
+
+    {:ok, dismissed} = Discovery.upsert_suggestion(suggestion_attrs(@dismissed_id))
+    {:ok, _dismissed} = Discovery.dismiss_suggestion(dismissed)
+
+    candidates = [
+      candidate(@existing_id, :featured),
+      candidate(@dismissed_id, :featured),
+      candidate(@channel_id, :mention),
+      candidate(@channel_id, :featured)
+    ]
+
+    assert [%Candidate{external_channel_id: @channel_id, generators: ["featured", "mention"]}] =
+             candidates
+             |> Candidate.deduplicate()
+             |> Discovery.exclude_candidates()
+  end
+
+  test "persists a validated suggestion idempotently" do
+    assert [%Candidate{generators: ["featured", "mention"]} = candidate] =
+             Candidate.deduplicate([candidate(@channel_id, :mention), candidate(@channel_id, :featured)])
+
+    assert {:ok, [first]} = Discovery.persist_suggestions([candidate], now: ~U[2026-09-10 00:00:00Z])
+    assert {:ok, [second]} = Discovery.persist_suggestions([candidate], now: ~U[2026-09-10 00:01:00Z])
+
+    assert first.id == second.id
+    assert first.generators == "featured,mention"
+    assert Repo.get!(Suggestion, first.id).generators == "featured,mention"
+    assert Repo.aggregate(Suggestion, :count, :id) == 1
+    assert Repo.get!(Suggestion, first.id).state == :validated
+  end
+
+  test "does not revalidate a recently validated suggestion" do
+    validated_at = ~U[2026-09-10 00:00:00Z]
+    candidate = candidate(@channel_id, :mention)
+    assert {:ok, [_suggestion]} = Discovery.persist_suggestions([candidate], now: validated_at)
+
+    parent = self()
+
+    assert {:ok, result} =
+             Discovery.scan(
+               enabled: true,
+               mentions_enabled: true,
+               featured_enabled: false,
+               now: ~U[2026-09-10 01:00:00Z],
+               generator_funs: %{mention: fn _opts -> [candidate] end},
+               validation_opts: [
+                 validate_fun: fn _candidate ->
+                   send(parent, :unexpected_validation)
+                   {:ok, %{channel_id: @channel_id, channel_name: "Channel"}}
+                 end
+               ]
+             )
+
+    assert result.candidate_count == 0
+    assert result.validated_count == 0
+    assert result.inserted_count == 0
+    refute_received :unexpected_validation
+  end
+
+  test "a failed generator does not erase candidates from another generator" do
+    Settings.set(channel_discovery_enabled: false)
+
+    valid_candidate = candidate(@channel_id, :featured)
+
+    assert {:ok, result} =
+             Discovery.scan(
+               manual: true,
+               mentions_enabled: true,
+               featured_enabled: true,
+               generator_funs: %{
+                 mention: fn _opts -> {:error, :generator_failed} end,
+                 featured: fn _opts -> [valid_candidate] end
+               },
+               validation_opts: [
+                 max_results: 10,
+                 validate_fun: fn _candidate -> {:ok, %{channel_id: @channel_id, channel_name: "Featured"}} end
+               ]
+             )
+
+    assert result.inserted_count == 1
+    assert [%{generator: :mention, reason: :generator_failed}] = result.generator_errors
+    assert [%Suggestion{external_channel_id: @channel_id}] = Repo.all(Suggestion)
+  end
+
+  test "publishes a bounded completion payload" do
+    assert :ok = Discovery.subscribe()
+
+    assert {:ok, %{status: :completed}} =
+             Discovery.scan(
+               enabled: true,
+               mentions_enabled: false,
+               featured_enabled: false,
+               broadcast: true
+             )
+
+    assert_receive %Phoenix.Socket.Broadcast{
+      topic: "channel_discovery",
+      event: "scan_completed",
+      payload: %{status: :completed, candidate_count: 0, inserted_count: 0}
+    }
+  end
+
+  defp candidate(channel_id, generator) do
+    reference = Normalizer.normalize_reference(channel_id)
+    Candidate.from_reference(reference, generator, %{channel_name: "Channel #{channel_id}"})
+  end
+
+  defp suggestion_attrs(channel_id) do
+    %{
+      external_channel_id: channel_id,
+      canonical_url: "https://www.youtube.com/channel/#{channel_id}",
+      channel_name: "Suggestion #{channel_id}",
+      evidence: "Mentioned in local metadata",
+      score: 8
+    }
+  end
+end

--- a/test/pinchflat/discovery/validator_test.exs
+++ b/test/pinchflat/discovery/validator_test.exs
@@ -1,0 +1,51 @@
+defmodule Pinchflat.Discovery.ValidatorTest do
+  use ExUnit.Case, async: true
+
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.Normalizer
+  alias Pinchflat.Discovery.Validator
+
+  @channel_id "UC" <> String.duplicate("a", 22)
+
+  test "returns validation success, missing, timeout, and malformed outcomes" do
+    candidates = Enum.map(~w(good missing slow malformed), &candidate/1)
+
+    validate_fun = fn %Candidate{reference: %{handle: handle}} ->
+      case handle do
+        "good" -> {:ok, %{channel_id: @channel_id, channel_name: "Good channel"}}
+        "missing" -> {:error, :missing}
+        "slow" -> :timeout
+        "malformed" -> {:ok, %{channel_id: "not-a-channel"}}
+      end
+    end
+
+    result = Validator.validate(candidates, max_results: 4, max_concurrency: 2, validate_fun: validate_fun)
+
+    assert [%Candidate{external_channel_id: @channel_id, channel_name: "Good channel"}] = result.validated
+    assert Enum.sort(Enum.map(result.rejected, & &1.reason)) == [:malformed, :missing, :timeout]
+    refute Enum.any?(result.rejected, &is_binary(&1.reason))
+  end
+
+  test "enforces the validation timeout and result bound" do
+    candidates = Enum.map(~w(first second third), &candidate/1)
+    parent = self()
+
+    validate_fun = fn candidate ->
+      send(parent, {:validated, candidate.reference.handle})
+      Process.sleep(40)
+      {:ok, %{channel_id: @channel_id, channel_name: candidate.reference.handle}}
+    end
+
+    result = Validator.validate(candidates, max_results: 2, max_concurrency: 1, timeout: 5, validate_fun: validate_fun)
+
+    assert result.validated == []
+    assert length(result.rejected) == 2
+    assert Enum.all?(result.rejected, &(&1.reason == :timeout))
+    refute_received {:validated, "third"}
+  end
+
+  defp candidate(handle) do
+    reference = Normalizer.normalize_reference("@#{handle}")
+    Candidate.from_reference(reference, :mention)
+  end
+end

--- a/test/pinchflat/discovery/worker_test.exs
+++ b/test/pinchflat/discovery/worker_test.exs
@@ -1,0 +1,40 @@
+defmodule Pinchflat.Discovery.WorkerTest do
+  use Pinchflat.DataCase
+
+  alias Pinchflat.Discovery
+  alias Pinchflat.Discovery.Worker
+  alias Pinchflat.Settings
+
+  describe "kickoff/0" do
+    test "deduplicates manual scans across repeated kickoffs" do
+      assert {:ok, %Oban.Job{}} = Worker.kickoff()
+      assert {:error, :duplicate_job} = Worker.kickoff()
+      assert [_job] = all_enqueued(worker: Worker)
+    end
+  end
+
+  describe "perform/1 scheduled gate" do
+    test "is registered daily and cancels safely while disabled" do
+      plugins = Application.get_env(:pinchflat, Oban)[:plugins]
+      assert {Oban.Plugins.Cron, [crontab: crontab]} = Enum.find(plugins, &match?({Oban.Plugins.Cron, _}, &1))
+      assert {"0 3 * * *", Worker} in crontab
+
+      Settings.set(channel_discovery_enabled: false)
+      Discovery.subscribe()
+
+      assert {:cancel, "Scheduled channel discovery is disabled"} = perform_job(Worker, %{})
+
+      assert_receive %Phoenix.Socket.Broadcast{
+        topic: "channel_discovery",
+        event: "scan_completed",
+        payload: %{status: :disabled}
+      }
+    end
+
+    test "manual scans are allowed through the scheduled gate" do
+      Settings.set(channel_discovery_enabled: false)
+
+      assert :ok = perform_job(Worker, %{"manual" => true})
+    end
+  end
+end

--- a/test/pinchflat/discovery_test.exs
+++ b/test/pinchflat/discovery_test.exs
@@ -1,0 +1,107 @@
+defmodule Pinchflat.DiscoveryTest do
+  use Pinchflat.DataCase
+
+  import Pinchflat.SourcesFixtures
+
+  alias Pinchflat.Discovery
+  alias Pinchflat.Discovery.Candidate
+  alias Pinchflat.Discovery.Suggestion
+  alias Pinchflat.Repo
+
+  @channel_id "UC" <> String.duplicate("a", 22)
+  @other_channel_id "UC" <> String.duplicate("b", 22)
+
+  describe "list_suggestions/1" do
+    test "excludes dismissed and accepted suggestions by default" do
+      {:ok, visible} = Discovery.upsert_suggestion(suggestion_attrs(@channel_id))
+      {:ok, dismissed} = Discovery.upsert_suggestion(suggestion_attrs(@other_channel_id))
+      {:ok, dismissed} = Discovery.dismiss_suggestion(dismissed)
+
+      accepted_id = "UC" <> String.duplicate("c", 22)
+      {:ok, accepted} = Discovery.upsert_suggestion(suggestion_attrs(accepted_id))
+      {:ok, accepted} = Discovery.accept_suggestion(accepted)
+
+      assert [visible] == Discovery.list_suggestions()
+
+      assert Enum.map(Discovery.list_suggestions(include_terminal: true), & &1.id) ==
+               Enum.sort([visible.id, dismissed.id, accepted.id])
+    end
+  end
+
+  describe "upsert_suggestion/1" do
+    test "is idempotent by external channel ID and bounds persisted values" do
+      attrs = Map.put(suggestion_attrs(@channel_id), :generators, [:mention, :featured])
+
+      assert {:ok, first} =
+               Discovery.upsert_suggestion(Map.merge(attrs, %{score: 999, evidence: String.duplicate("x", 600)}))
+
+      assert {:ok, second} =
+               Discovery.upsert_suggestion(%{
+                 external_channel_id: @channel_id,
+                 canonical_url: attrs.canonical_url,
+                 channel_name: "Updated name",
+                 evidence: "updated evidence",
+                 score: 4
+               })
+
+      assert second.id == first.id
+      assert second.channel_name == "Updated name"
+      assert second.evidence == "updated evidence"
+      assert second.generators == "featured,mention"
+      assert second.score == 4
+      assert second.validated_at
+      assert Repo.aggregate(Suggestion, :count, :id) == 1
+    end
+
+    test "bounds generator provenance and carries it through sampled candidates" do
+      attrs = Map.put(suggestion_attrs(@channel_id), :generators, Enum.map(1..100, &"generator-#{&1}"))
+
+      assert {:ok, suggestion} = Discovery.upsert_suggestion(attrs)
+      assert String.length(suggestion.generators) <= Discovery.max_generators_length()
+
+      attrs = Map.put(suggestion_attrs(@other_channel_id), :generators, [:mention, :featured])
+      assert {:ok, persisted} = Discovery.upsert_suggestion(attrs)
+      assert persisted.generators == "featured,mention"
+
+      assert [%Candidate{generators: ["featured", "mention"]}] =
+               Discovery.sample_suggestions(sample_size: 2, pool_size: 2, random_fun: fn pool, _size -> pool end)
+               |> Enum.filter(&(&1.external_channel_id == @other_channel_id))
+    end
+  end
+
+  describe "excluded_channel_ids/0" do
+    test "includes subscribed channel sources and terminal suggestions" do
+      source_id = "UC" <> String.duplicate("d", 22)
+
+      source_fixture(%{
+        collection_type: :channel,
+        collection_id: source_id,
+        original_url: "https://www.youtube.com/channel/#{source_id}"
+      })
+
+      {:ok, suggestion} = Discovery.upsert_suggestion(suggestion_attrs(@channel_id))
+      {:ok, _suggestion} = Discovery.dismiss_suggestion(suggestion)
+
+      excluded = Discovery.excluded_channel_ids()
+      assert source_id in excluded
+      assert @channel_id in excluded
+    end
+
+    test "does not persist a suggestion for an existing channel source" do
+      source_fixture(%{collection_type: :channel, collection_id: @channel_id})
+
+      assert {:error, :existing_source} = Discovery.upsert_suggestion(suggestion_attrs(@channel_id))
+      assert Repo.aggregate(Suggestion, :count, :id) == 0
+    end
+  end
+
+  defp suggestion_attrs(external_channel_id) do
+    %{
+      external_channel_id: external_channel_id,
+      canonical_url: "https://www.youtube.com/channel/#{external_channel_id}",
+      channel_name: "Suggested #{external_channel_id}",
+      evidence: "Mentioned in local metadata",
+      score: 8
+    }
+  end
+end

--- a/test/pinchflat_web/controllers/auth_controller_test.exs
+++ b/test/pinchflat_web/controllers/auth_controller_test.exs
@@ -241,6 +241,14 @@ defmodule PinchflatWeb.AuthControllerTest do
       assert redirected_to(conn) == "/auth/login?redirect_to=%2F"
     end
 
+    test "the channel discovery route requires an SSO session when enabled", %{conn: conn} do
+      Application.put_env(:pinchflat, :oidc, @oidc_config)
+
+      conn = get(conn, ~p"/discovery")
+
+      assert redirected_to(conn) == "/auth/login?redirect_to=%2Fdiscovery"
+    end
+
     test "the login flow returns the user to the page that triggered it", %{session_conn: conn} do
       Application.put_env(:pinchflat, :oidc, @oidc_config)
 

--- a/test/pinchflat_web/controllers/discovery_live_test.exs
+++ b/test/pinchflat_web/controllers/discovery_live_test.exs
@@ -1,0 +1,156 @@
+defmodule PinchflatWeb.DiscoveryLiveTest do
+  use PinchflatWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+  import Pinchflat.ProfilesFixtures
+
+  alias Pinchflat.Discovery
+  alias Pinchflat.Discovery.Suggestion
+  alias Pinchflat.Settings
+  alias PinchflatWeb.DiscoveryLive
+
+  @channel_id "UC" <> String.duplicate("a", 22)
+
+  test "renders Channel Discovery and the empty state when connected", %{conn: conn} do
+    {:ok, view, html} = live(conn, "/discovery")
+
+    assert is_pid(view.pid)
+    assert html =~ "Channel Discovery"
+    assert html =~ "No channel suggestions yet"
+  end
+
+  test "renders the explicit disabled scheduled state", %{conn: conn} do
+    assert {:ok, false} = Settings.set(channel_discovery_enabled: false)
+
+    {:ok, view, _html} = live_isolated(conn, DiscoveryLive, session: %{})
+
+    assert has_element?(view, ~s(#discovery-status-panel[data-discovery-enabled="false"]))
+    assert has_element?(view, ~s([data-setting="channel_discovery_enabled"]), "Disabled")
+  end
+
+  test "refreshes suggestions created after mount", %{conn: conn} do
+    {:ok, view, _html} = live_isolated(conn, DiscoveryLive, session: %{})
+
+    assert has_element?(view, "#discovery-empty")
+
+    suggestion = suggestion_fixture()
+
+    view
+    |> element("#discovery-refresh")
+    |> render_click()
+
+    assert has_element?(view, "#discovery-suggestion-#{suggestion.external_channel_id}")
+    assert has_element?(view, "#discovery-suggestion-#{suggestion.external_channel_id} dd", "Fixture evidence")
+  end
+
+  test "dismisses and restores a validated suggestion through the live view", %{conn: conn} do
+    suggestion = suggestion_fixture()
+    {:ok, view, _html} = live_isolated(conn, DiscoveryLive, session: %{})
+
+    assert has_element?(view, "#discovery-suggestion-#{suggestion.external_channel_id}")
+    assert has_element?(view, "#discovery-suggestion-#{suggestion.external_channel_id} dd", "Fixture evidence")
+
+    view
+    |> element("#dismiss-suggestion-#{suggestion.external_channel_id}")
+    |> render_click()
+
+    refute has_element?(view, "#discovery-suggestion-#{suggestion.external_channel_id}")
+    assert has_element?(view, "#dismissed-#{suggestion.external_channel_id}")
+
+    view
+    |> element("#restore-suggestion-#{suggestion.external_channel_id}")
+    |> render_click()
+
+    assert has_element?(view, "#discovery-suggestion-#{suggestion.external_channel_id}")
+    refute has_element?(view, "#dismissed-#{suggestion.external_channel_id}")
+  end
+
+  test "accepting a suggestion redirects to a channel source form", %{conn: conn} do
+    original_url = "https://www.youtube.com/channel/#{@channel_id}"
+    suggestion = suggestion_fixture(%{canonical_url: original_url})
+    {:ok, view, _html} = live_isolated(conn, DiscoveryLive, session: %{})
+
+    assert {:error, {:live_redirect, %{to: to}}} =
+             view
+             |> element("#accept-suggestion-#{suggestion.external_channel_id}")
+             |> render_click()
+
+    uri = URI.parse(to)
+    assert uri.path == "/sources/new"
+    assert %{"original_url" => ^original_url, "source_type" => "channel"} = URI.decode_query(uri.query || "")
+  end
+
+  test "accepting an invalid prefill still uses normal source validation", %{conn: conn} do
+    invalid_url = "https://www.youtube.com/watch"
+    suggestion = suggestion_fixture(%{canonical_url: invalid_url})
+    {:ok, view, _html} = live_isolated(conn, DiscoveryLive, session: %{})
+
+    assert {:error, {:live_redirect, %{to: to}}} =
+             view
+             |> element("#accept-suggestion-#{suggestion.external_channel_id}")
+             |> render_click()
+
+    assert html_response(get(conn, to), 200) =~ invalid_url
+
+    response =
+      post(conn, ~p"/sources",
+        source: %{
+          original_url: invalid_url,
+          source_type: "channel",
+          media_profile_id: media_profile_fixture().id
+        }
+      )
+      |> html_response(200)
+
+    assert response =~ "must be a channel, playlist, or single video URL"
+    assert response =~ invalid_url
+  end
+
+  test "queues a scan without running external commands", %{conn: conn} do
+    deny(YtDlpRunnerMock, :run, 5)
+
+    {:ok, view, _html} = live_isolated(conn, DiscoveryLive, session: %{})
+
+    html = view |> element("#discovery-scan") |> render_click()
+
+    assert html =~ ~s(data-status="queued")
+    assert html =~ "Scan queued."
+    assert [%Oban.Job{state: "available"}] = all_enqueued(worker: Pinchflat.Discovery.Worker)
+
+    html = render_click(view, "scan")
+    assert html =~ ~s(data-status="busy")
+    assert html =~ "Scan in progress."
+  end
+
+  test "updates suggestions and status from a channel discovery completion broadcast", %{conn: conn} do
+    {:ok, view, _html} = live_isolated(conn, DiscoveryLive, session: %{})
+
+    suggestion = suggestion_fixture(%{channel_name: "Broadcast fixture"})
+    refute has_element?(view, "#discovery-suggestion-#{suggestion.external_channel_id}")
+
+    assert :ok = Discovery.broadcast_completion(%{status: :completed, inserted_count: 1})
+
+    html = render(view)
+    assert html =~ ~s(data-status="completed")
+    assert html =~ "Scan completed. 1 new suggestion(s) added."
+    assert has_element?(view, "#discovery-suggestion-#{suggestion.external_channel_id}", "Broadcast fixture")
+  end
+
+  defp suggestion_fixture(attrs \\ %{}) do
+    {:ok, %Suggestion{} = suggestion} =
+      Discovery.upsert_suggestion(
+        Map.merge(
+          %{
+            external_channel_id: @channel_id,
+            canonical_url: "https://www.youtube.com/channel/#{@channel_id}",
+            channel_name: "Fixture channel",
+            evidence: "Fixture evidence",
+            score: 8
+          },
+          attrs
+        )
+      )
+
+    suggestion
+  end
+end

--- a/test/pinchflat_web/controllers/source_controller_test.exs
+++ b/test/pinchflat_web/controllers/source_controller_test.exs
@@ -90,6 +90,13 @@ defmodule PinchflatWeb.SourceControllerTest do
       assert response =~ "Delete Deletable Source? This deletes the source only and does not delete files."
       assert response =~ "Delete source"
     end
+
+    test "renders channel discovery in the sidebar", %{conn: conn} do
+      response = conn |> get(~p"/sources") |> html_response(200)
+
+      assert response =~ ~s(href="/discovery")
+      assert response =~ "Channel Discovery"
+    end
   end
 
   describe "new source" do
@@ -120,6 +127,34 @@ defmodule PinchflatWeb.SourceControllerTest do
       assert response =~ "Members-only media may fail without cookies"
       assert response =~ "How source folders work"
       assert response =~ "Insert media profile template"
+    end
+
+    test "prefills the source form from discovery query params", %{conn: conn} do
+      original_url = "https://www.youtube.com/@pinchflattest"
+      custom_name = "A discovered channel"
+
+      response =
+        conn
+        |> get(~p"/sources/new", %{
+          "original_url" => original_url,
+          "custom_name" => custom_name,
+          "source_type" => "channel"
+        })
+        |> html_response(200)
+
+      assert response =~ ~s(value="#{original_url}")
+      assert response =~ ~s(value="#{custom_name}")
+      assert response =~ "sourceType: &#39;channel&#39;"
+    end
+
+    test "ignores an invalid source type prefill", %{conn: conn} do
+      response =
+        conn
+        |> get(~p"/sources/new", %{"source_type" => "not-a-source-type"})
+        |> html_response(200)
+
+      assert response =~ "sourceType: &#39;automatic&#39;"
+      refute response =~ "not-a-source-type"
     end
 
     test "renders source folder picker options from existing media directories", %{conn: conn} do


### PR DESCRIPTION
## Summary
- Add bounded local mention and featured-channel discovery with normalization, validation, scoring, sampling, persistence, dismissal, restore, and accept flows.
- Add disabled-by-default settings, Oban worker scheduling, PubSub completion updates, Discovery LiveView, and safe source-form prefill.
- Add migrations, UI, and regression coverage including auth, cron gating, invalid prefill validation, timeout/partial-failure behavior, and connected LiveView flows.

## Verification
- docker compose run --rm phx mix check (1,725 tests)
- docker compose run --rm phx mix compile --warnings-as-errors
- docker compose run --rm phx yarn run lint:check
- docker compose run --rm phx yarn run ui:check-theme
- git diff --check

Browser automation was unavailable in this environment; connected LiveView coverage is included.