### PR TITLE
feat: add PostgreSQL in-app backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,37 @@ volumes:
 The PostgreSQL image creates and migrates its own schema, but it does not copy data from an existing SQLite database.
 Keep using `latest` for an existing SQLite installation until you have migrated its data separately.
 
+#### PostgreSQL database backups
+
+The PostgreSQL image includes pg_dump. Authenticated users can create a custom-format database backup from
+Settings -> PostgreSQL Backups. Credentials are taken from the running app's DATABASE_URL; PinchYT passes them to
+pg_dump through PostgreSQL's PG* environment variables, never as command-line arguments or rendered UI text.
+
+Completed dumps are stored in the persistent configuration volume at /config/extras/backups by default. The
+Backups to Keep setting controls retention (1-100 completed dumps, with 7 as the default). A failed or cancelled
+dump is written to a temporary .partial file and is removed before the request finishes; stale partial files are
+also cleaned up before a later backup. The optional POSTGRES_BACKUP_PATH variable can point the backup directory at
+another persistent path.
+
+Generated filenames use a UTC timestamp through microsecond precision, in the form
+`pinchyt-postgres-YYYYMMDD-HHMMSS-ffffff-<id>.dump`. The high-resolution component keeps retention ordering
+deterministic when the filesystem reports equal modification times. Existing second-precision filenames remain
+strictly validated and can still be downloaded.
+
+These backups contain PostgreSQL database state only. They do not contain downloaded media, the /config runtime
+secrets, or the PostgreSQL server's own volume. PinchYT does not restore a dump automatically and does not convert a
+SQLite database to PostgreSQL.
+
+To restore, stop PinchYT first, provision a compatible PostgreSQL database, and use the matching PG* connection
+environment (or a protected .pgpass file) with pg_restore:
+
+    pg_restore --clean --if-exists --no-owner --no-privileges \
+      --dbname="$PGDATABASE" /config/extras/backups/pinchyt-postgres-YYYYMMDD-HHMMSS-ffffff-<id>.dump
+
+Restore into a database that is not being used by a running PinchYT instance. Review the target and migration
+compatibility before using --clean; restore the database first, then start PinchYT so its normal migration check can
+run. Restore the downloaded media files separately from your media backup.
+
 ### Optional PO-token provider
 
 The default compose above keeps the provider disabled. If YouTube presents SABR or authentication problems, add the

--- a/assets/js/alpine_helpers.js
+++ b/assets/js/alpine_helpers.js
@@ -46,6 +46,7 @@ window.settingsPage = () => ({
       'extractor youtube api key sleep interval throughput download workers indexing metadata concurrency restrict filenames ascii ignore unavailable members-only private time format 12h 24h clock database compaction vacuum sqlite',
     discovery:
       'discovery channel suggestions scheduled scan mention mentions metadata featured subscribed',
+    backups: 'postgresql postgres backup backups database dump restore retention keep files',
     ytdlp:
       'yt-dlp ytdlp youtube-dl update nightly stable pinned version base config force-ipv4 retries fragment-retries socket-timeout ipv4',
     codec: 'codec video audio avc m4a remux preference mp4',

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,6 +32,8 @@ config :pinchflat,
   # The user may or may not store metadata for their needs, but the app will always store its copy
   metadata_directory: "/config/metadata",
   extras_directory: "/config/extras",
+  postgres_backup_directory: nil,
+  pg_dump_executable: nil,
   tmpfile_directory: Path.join([System.tmp_dir!(), "pinchflat", "data"]),
   # Setting BASIC_AUTH_USERNAME and BASIC_AUTH_PASSWORD implies you want to use basic auth.
   # If either is unset, basic auth will not be used.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -197,6 +197,7 @@ if config_env() == :prod do
   log_path = System.get_env("LOG_PATH", Path.join([config_path, "logs", "pinchflat.log"]))
   metadata_path = System.get_env("METADATA_PATH", Path.join([config_path, "metadata"]))
   extras_path = System.get_env("EXTRAS_PATH", Path.join([config_path, "extras"]))
+  postgres_backup_path = System.get_env("POSTGRES_BACKUP_PATH", Path.join([extras_path, "backups"]))
   tmpfile_path = System.get_env("TMPFILE_PATH", Path.join([System.tmp_dir!(), "pinchflat", "data"]))
   # This one can be changed if you want
   tz_data_path = System.get_env("TZ_DATA_PATH", Path.join([extras_path, "elixir_tz_data"]))
@@ -215,6 +216,7 @@ if config_env() == :prod do
     media_directory: media_path,
     metadata_directory: metadata_path,
     extras_directory: extras_path,
+    postgres_backup_directory: postgres_backup_path,
     tmpfile_directory: tmpfile_path,
     dns_cluster_query: System.get_env("DNS_CLUSTER_QUERY"),
     expose_feed_endpoints: expose_feed_endpoints,

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -20,6 +20,20 @@ COPY --from=node /usr/local/ /usr/local/
 
 # Install debian packages
 RUN set -eux; \
+  if [ "${DATABASE_ADAPTER}" = "postgres" ]; then \
+    apt-get -o Acquire::Retries=5 update -qq; \
+    apt-get install -y --no-install-recommends ca-certificates curl; \
+    install -d -m 0755 /usr/share/postgresql-common/pgdg; \
+    curl -4 -fsSL --retry 5 --retry-all-errors \
+      "https://www.postgresql.org/media/keys/ACCC4CF8.asc" \
+      -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc; \
+    . /etc/os-release; \
+    echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+      > /etc/apt/sources.list.d/pgdg.list; \
+    DATABASE_CLIENT_PACKAGE="postgresql-client-16"; \
+  else \
+    DATABASE_CLIENT_PACKAGE=""; \
+  fi; \
   for attempt in 1 2 3 4 5; do \
     rm -rf /var/lib/apt/lists/*; \
     apt-get clean; \
@@ -31,7 +45,8 @@ RUN set -eux; \
       update -qq && \
       apt-get install -y --no-install-recommends inotify-tools curl git openssh-client jq \
         python3 python3-setuptools python3-wheel python3-dev pipx \
-        python3-mutagen locales procps build-essential graphviz zsh unzip; then \
+        python3-mutagen locales procps build-essential graphviz zsh unzip \
+        ${DATABASE_CLIENT_PACKAGE}; then \
       break; \
     fi; \
     if [ "$attempt" -eq 5 ]; then exit 1; fi; \

--- a/docker/selfhosted.Dockerfile
+++ b/docker/selfhosted.Dockerfile
@@ -101,6 +101,20 @@ COPY --from=builder ./usr/local/bin/ffmpeg /usr/bin/ffmpeg
 COPY --from=builder ./usr/local/bin/ffprobe /usr/bin/ffprobe
 
 RUN set -eux; \
+    if [ "${DATABASE_ADAPTER}" = "postgres" ]; then \
+      apt-get -o Acquire::Retries=5 update -qq; \
+      apt-get install -y --no-install-recommends ca-certificates curl; \
+      install -d -m 0755 /usr/share/postgresql-common/pgdg; \
+      curl -4 -fsSL --retry 5 --retry-all-errors \
+        "https://www.postgresql.org/media/keys/ACCC4CF8.asc" \
+        -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc; \
+      . /etc/os-release; \
+      echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
+        > /etc/apt/sources.list.d/pgdg.list; \
+      DATABASE_CLIENT_PACKAGE="postgresql-client-16"; \
+    else \
+      DATABASE_CLIENT_PACKAGE=""; \
+    fi; \
     for attempt in 1 2 3 4 5; do \
       rm -rf /var/lib/apt/lists/*; \
       apt-get clean; \
@@ -125,7 +139,8 @@ RUN set -eux; \
           pipx \
           jq \
           unzip \
-          procps; then \
+          procps \
+          ${DATABASE_CLIENT_PACKAGE}; then \
         break; \
       fi; \
       if [ "$attempt" -eq 5 ]; then exit 1; fi; \

--- a/lib/pinchflat/backups.ex
+++ b/lib/pinchflat/backups.ex
@@ -1,0 +1,323 @@
+defmodule Pinchflat.Backups do
+  @moduledoc """
+  PostgreSQL database backup management.
+
+  Backups are custom-format `pg_dump` files stored under the persistent
+  configuration directory. SQLite builds expose an explicit unavailable state
+  and never attempt to invoke PostgreSQL tooling.
+  """
+
+  require Logger
+
+  alias Pinchflat.Backups.Connection
+  alias Pinchflat.Backups.PgDumpRunner
+  alias Pinchflat.Database
+  alias Pinchflat.Settings
+
+  @default_retention_count 7
+  @partial_stale_after_seconds 60 * 60
+  @backup_prefix "pinchyt-postgres-"
+  @backup_extension ".dump"
+  @partial_extension ".partial"
+  @filename_pattern ~r/\Apinchyt-postgres-(\d{8})-(\d{6})-(\d{6})-([a-f0-9]{16})\.dump\z/
+  @legacy_filename_pattern ~r/\Apinchyt-postgres-(\d{8})-(\d{6})-([a-f0-9]{16})\.dump\z/
+
+  @type backup :: %{
+          filename: String.t(),
+          modified_at: DateTime.t(),
+          path: String.t(),
+          size: non_neg_integer()
+        }
+
+  @doc "Returns the PostgreSQL backup capability and current retained files."
+  @spec status() :: map()
+  def status do
+    if Database.postgres?() do
+      %{
+        available: true,
+        backups: list_backups(),
+        retention_count: retention_count()
+      }
+    else
+      %{available: false, backups: [], reason: :sqlite}
+    end
+  end
+
+  @doc "Returns true when this build can create PostgreSQL backups."
+  @spec available?() :: boolean()
+  def available?, do: Database.postgres?()
+
+  @doc "Returns the persistent directory used for successful backup files."
+  @spec backup_directory() :: String.t()
+  def backup_directory do
+    Application.get_env(:pinchflat, :postgres_backup_directory) ||
+      Path.join(Application.fetch_env!(:pinchflat, :extras_directory), "backups")
+  end
+
+  @doc "Returns successful backups ordered newest first."
+  @spec list_backups(keyword()) :: [backup()]
+  def list_backups(opts \\ []) do
+    directory = Keyword.get(opts, :directory, backup_directory())
+
+    case File.ls(directory) do
+      {:ok, filenames} ->
+        filenames
+        |> Enum.filter(&backup_filename?/1)
+        |> Enum.map(&backup_metadata(directory, &1))
+        |> Enum.reject(&is_nil/1)
+        |> Enum.sort(&newer_backup?/2)
+
+      {:error, :enoent} ->
+        []
+
+      {:error, reason} ->
+        Logger.warning("Unable to list PostgreSQL backups: #{inspect(reason)}")
+        []
+    end
+  end
+
+  @doc """
+  Creates one PostgreSQL custom-format backup and prunes older successful
+  backups according to the configured retention count.
+
+  A `runner` option is accepted for focused tests; production callers use the
+  cancellation-aware `PgDumpRunner` implementation.
+  """
+  @spec create_backup(keyword()) :: {:ok, backup()} | {:error, atom()}
+  def create_backup(opts \\ []) do
+    if available?() do
+      :global.trans({__MODULE__, :create_backup}, fn -> do_create_backup(opts) end)
+    else
+      {:error, :unavailable}
+    end
+  end
+
+  @doc "Returns a validated path for an authorized backup download."
+  @spec download_path(String.t()) :: {:ok, String.t()} | {:error, atom()}
+  def download_path(filename) when is_binary(filename) do
+    if available?() and backup_filename?(filename) do
+      path = Path.join(backup_directory(), filename)
+
+      case File.lstat(path) do
+        {:ok, %File.Stat{type: :regular}} -> {:ok, path}
+        {:ok, _stat} -> {:error, :not_found}
+        {:error, _reason} -> {:error, :not_found}
+      end
+    else
+      if available?(), do: {:error, :invalid_filename}, else: {:error, :unavailable}
+    end
+  end
+
+  def download_path(_filename), do: if(available?(), do: {:error, :invalid_filename}, else: {:error, :unavailable})
+
+  @doc "Prunes a directory to the requested number of successful backups."
+  @spec prune_backups(keyword()) :: {:ok, non_neg_integer()}
+  def prune_backups(opts \\ []) do
+    directory = Keyword.get(opts, :directory, backup_directory())
+    keep = Keyword.get(opts, :retention_count, retention_count())
+    backups = list_backups(directory: directory)
+
+    backups
+    |> Enum.drop(keep)
+    |> Enum.reduce_while(0, fn backup, removed ->
+      case File.rm(backup.path) do
+        :ok ->
+          {:cont, removed + 1}
+
+        {:error, :enoent} ->
+          {:cont, removed}
+
+        {:error, reason} ->
+          Logger.warning("Unable to prune PostgreSQL backup #{backup.filename}: #{inspect(reason)}")
+          {:halt, removed}
+      end
+    end)
+    |> then(&{:ok, &1})
+  end
+
+  @doc "Removes partial files older than the safety grace period."
+  @spec cleanup_partial_files(keyword()) :: :ok
+  def cleanup_partial_files(opts \\ []) do
+    directory = Keyword.get(opts, :directory, backup_directory())
+    now = Keyword.get(opts, :now, DateTime.utc_now())
+
+    with {:ok, filenames} <- File.ls(directory) do
+      Enum.each(filenames, fn filename ->
+        if String.starts_with?(filename, @backup_prefix) and String.ends_with?(filename, @partial_extension) do
+          path = Path.join(directory, filename)
+
+          with {:ok, %File.Stat{type: :regular, mtime: mtime}} <- File.lstat(path),
+               {:ok, modified_at} <- datetime_from_erl(mtime),
+               true <- DateTime.diff(now, modified_at, :second) >= @partial_stale_after_seconds do
+            _ = File.rm(path)
+          end
+        end
+      end)
+    end
+
+    :ok
+  end
+
+  @doc "Returns the configured number of successful backups to retain."
+  @spec retention_count() :: pos_integer()
+  def retention_count do
+    case Settings.get(:postgres_backup_retention_count) do
+      {:ok, count} when is_integer(count) and count > 0 -> count
+      _ -> @default_retention_count
+    end
+  end
+
+  @doc false
+  def backup_filename?(filename) when is_binary(filename) do
+    Regex.match?(@filename_pattern, filename) or Regex.match?(@legacy_filename_pattern, filename)
+  end
+
+  def backup_filename?(_filename), do: false
+
+  defp do_create_backup(opts) do
+    directory = backup_directory()
+    :ok = File.mkdir_p(directory)
+    cleanup_partial_files(directory: directory)
+
+    with {:ok, connection} <- Connection.configured(),
+         {:ok, executable} <- executable(opts),
+         {:ok, retention} <- requested_retention(opts) do
+      filename = backup_filename()
+      final_path = Path.join(directory, filename)
+      partial_path = final_path <> @partial_extension
+      runner = Keyword.get(opts, :runner, &PgDumpRunner.run/4)
+      args = PgDumpRunner.args(partial_path, connection.database)
+
+      try do
+        {output, status} = runner.(executable, args, connection.env, directory)
+
+        cond do
+          status != 0 ->
+            log_failure(status, output, connection)
+            {:error, :pg_dump_failed}
+
+          not valid_dump_file?(partial_path) ->
+            Logger.error("PostgreSQL backup completed without producing a usable dump")
+            {:error, :empty_backup}
+
+          true ->
+            case File.rename(partial_path, final_path) do
+              :ok ->
+                case backup_metadata(final_path) do
+                  nil ->
+                    Logger.error("Finalized PostgreSQL backup could not be inspected")
+                    {:error, :finalize_failed}
+
+                  backup ->
+                    _ = prune_backups(directory: directory, retention_count: retention)
+                    {:ok, backup}
+                end
+
+              {:error, reason} ->
+                Logger.error("Unable to finalize PostgreSQL backup: #{inspect(reason)}")
+                {:error, :finalize_failed}
+            end
+        end
+      after
+        _ = File.rm(partial_path)
+      end
+    else
+      {:error, reason} ->
+        Logger.error("PostgreSQL backup unavailable: #{backup_error_message(reason)}")
+        {:error, reason}
+    end
+  end
+
+  defp executable(opts) do
+    case Keyword.get(opts, :executable, PgDumpRunner.executable()) do
+      executable when is_binary(executable) and executable != "" -> {:ok, executable}
+      _ -> {:error, :pg_dump_unavailable}
+    end
+  end
+
+  defp requested_retention(opts) do
+    retention = Keyword.get(opts, :retention_count, retention_count())
+
+    if is_integer(retention) and retention > 0 do
+      {:ok, retention}
+    else
+      {:error, :invalid_retention}
+    end
+  end
+
+  defp backup_filename do
+    timestamp = DateTime.utc_now()
+    calendar_timestamp = Calendar.strftime(timestamp, "%Y%m%d-%H%M%S")
+    {microseconds, _precision} = timestamp.microsecond
+    microsecond_timestamp = microseconds |> Integer.to_string() |> String.pad_leading(6, "0")
+    suffix = :crypto.strong_rand_bytes(8) |> Base.encode16(case: :lower)
+
+    @backup_prefix <> calendar_timestamp <> "-" <> microsecond_timestamp <> "-" <> suffix <> @backup_extension
+  end
+
+  defp valid_dump_file?(path) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :regular, size: size}} when size > 0 -> true
+      _ -> false
+    end
+  end
+
+  defp backup_metadata(directory, filename) do
+    backup_metadata(Path.join(directory, filename))
+  end
+
+  defp backup_metadata(path) do
+    with {:ok, %File.Stat{type: :regular, size: size, mtime: mtime}} <- File.lstat(path),
+         {:ok, modified_at} <- datetime_from_erl(mtime) do
+      %{
+        filename: Path.basename(path),
+        modified_at: modified_at,
+        path: path,
+        size: size
+      }
+    else
+      _ -> nil
+    end
+  end
+
+  defp newer_backup?(left, right) do
+    case DateTime.compare(left.modified_at, right.modified_at) do
+      :gt -> true
+      :lt -> false
+      :eq -> filename_order_key(left.filename) > filename_order_key(right.filename)
+    end
+  end
+
+  defp filename_order_key(filename) do
+    case Regex.run(@filename_pattern, filename, capture: :all_but_first) do
+      [date, time, microseconds, suffix] -> {date <> time <> microseconds, suffix, 1}
+      _ -> legacy_filename_order_key(filename)
+    end
+  end
+
+  defp legacy_filename_order_key(filename) do
+    case Regex.run(@legacy_filename_pattern, filename, capture: :all_but_first) do
+      [date, time, suffix] -> {date <> time <> "000000", suffix, 0}
+      _ -> {"", "", -1}
+    end
+  end
+
+  defp datetime_from_erl({date, time}) do
+    NaiveDateTime.from_erl({date, time})
+    |> case do
+      {:ok, naive} -> {:ok, DateTime.from_naive!(naive, "Etc/UTC")}
+      error -> error
+    end
+  end
+
+  defp log_failure(status, output, connection) do
+    safe_output = output |> to_string() |> Connection.redact(connection) |> String.slice(0, 1_000)
+    Logger.error("PostgreSQL backup failed with status #{status}: #{safe_output}")
+  end
+
+  defp backup_error_message(:database_url_missing), do: "DATABASE_URL is not configured"
+  defp backup_error_message(:pg_dump_unavailable), do: "pg_dump is not installed"
+  defp backup_error_message(:unsupported_database_url), do: "DATABASE_URL is not a PostgreSQL URL"
+  defp backup_error_message(:database_name_missing), do: "DATABASE_URL does not contain a database name"
+  defp backup_error_message(reason), do: inspect(reason)
+end

--- a/lib/pinchflat/backups/connection.ex
+++ b/lib/pinchflat/backups/connection.ex
@@ -1,0 +1,116 @@
+defmodule Pinchflat.Backups.Connection do
+  @moduledoc """
+  Builds the environment used by `pg_dump` from the configured database URL.
+
+  PostgreSQL's client tools read connection details from the standard `PG*`
+  environment variables. Keeping the password there avoids putting a
+  `DATABASE_URL` on the process command line or in command logs.
+  """
+
+  @type connection :: %{
+          database: String.t(),
+          env: [{String.t(), String.t()}],
+          secrets: [String.t()]
+        }
+
+  @doc """
+  Parses a PostgreSQL or Ecto database URL into `pg_dump` environment values.
+
+  Returns `{:ok, connection}` or `{:error, reason}`. The returned connection
+  contains the password only in the environment list and secret-redaction
+  metadata; callers must not render or log it.
+  """
+  @spec from_url(String.t() | nil) :: {:ok, connection()} | {:error, atom()}
+  def from_url(url) when is_binary(url) do
+    uri = URI.parse(url)
+
+    with true <- uri.scheme in ["ecto", "postgres", "postgresql"],
+         {:ok, database} <- database_name(uri),
+         {:ok, user, password} <- userinfo(uri) do
+      env =
+        [
+          optional_env("PGHOST", uri.host),
+          optional_env("PGPORT", uri.port),
+          optional_env("PGUSER", user),
+          optional_env("PGPASSWORD", password),
+          {:ok, {"PGDATABASE", database}},
+          sslmode_env(uri)
+        ]
+        |> Enum.flat_map(fn
+          {:ok, value} -> [value]
+          :skip -> []
+        end)
+
+      secrets =
+        [password, url]
+        |> Enum.filter(&(is_binary(&1) and &1 != ""))
+
+      {:ok, %{database: database, env: env, secrets: secrets}}
+    else
+      false -> {:error, :unsupported_database_url}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  def from_url(_url), do: {:error, :database_url_missing}
+
+  @doc "Returns the configured `DATABASE_URL` without exposing it to callers."
+  @spec configured_url() :: String.t() | nil
+  def configured_url do
+    System.get_env("DATABASE_URL") ||
+      Application.get_env(:pinchflat, Pinchflat.Repo, [])[:url]
+  end
+
+  @doc "Builds connection details from the configured database URL."
+  @spec configured() :: {:ok, connection()} | {:error, atom()}
+  def configured, do: from_url(configured_url())
+
+  @doc "Redacts configured connection secrets from command output."
+  @spec redact(String.t(), connection()) :: String.t()
+  def redact(output, %{secrets: secrets}) when is_binary(output) do
+    output
+    |> redact_uri_password()
+    |> then(&Enum.reduce(secrets, &1, fn secret, acc -> String.replace(acc, secret, "[REDACTED]") end))
+  end
+
+  def redact(output, _connection), do: output
+
+  defp database_name(%URI{path: path}) when is_binary(path) do
+    database = path |> String.trim_leading("/") |> URI.decode()
+
+    if database == "", do: {:error, :database_name_missing}, else: {:ok, database}
+  end
+
+  defp database_name(_uri), do: {:error, :database_name_missing}
+
+  defp userinfo(%URI{userinfo: nil}), do: {:ok, nil, nil}
+
+  defp userinfo(%URI{userinfo: userinfo}) do
+    case String.split(userinfo, ":", parts: 2) do
+      [user] -> {:ok, URI.decode(user), nil}
+      [user, password] -> {:ok, URI.decode(user), URI.decode(password)}
+    end
+  end
+
+  defp optional_env(_name, nil), do: :skip
+  defp optional_env(_name, ""), do: :skip
+  defp optional_env(name, value), do: {:ok, {name, to_string(value)}}
+
+  defp sslmode_env(%URI{query: nil}), do: :skip
+
+  defp sslmode_env(%URI{query: query}) do
+    case URI.decode_query(query)["sslmode"] do
+      nil -> :skip
+      "" -> :skip
+      sslmode -> {:ok, {"PGSSLMODE", sslmode}}
+    end
+  end
+
+  defp redact_uri_password(output) do
+    Regex.replace(
+      ~r/(?<scheme>ecto|postgres|postgresql):\/\/(?<user>[^:\/\s]+):(?<password>[^@\/\s]+)@/,
+      output,
+      fn _, scheme, user, _password -> "#{scheme}://#{user}:[REDACTED]@" end
+    )
+  end
+end

--- a/lib/pinchflat/backups/pg_dump_runner.ex
+++ b/lib/pinchflat/backups/pg_dump_runner.ex
@@ -1,0 +1,55 @@
+defmodule Pinchflat.Backups.PgDumpRunner do
+  @moduledoc """
+  Runs `pg_dump` through PinchYT's cancellation-aware command wrapper.
+
+  This module deliberately does not log command arguments, environment values,
+  or command output. The caller is responsible for logging a redacted summary
+  when a dump fails.
+  """
+
+  require Logger
+
+  @doc "Returns the configured `pg_dump` executable, if installed."
+  @spec executable() :: String.t() | nil
+  def executable do
+    Application.get_env(:pinchflat, :pg_dump_executable) || System.find_executable("pg_dump")
+  end
+
+  @doc "Returns the fixed, non-secret pg_dump arguments."
+  @spec args(String.t(), String.t()) :: [String.t()]
+  def args(partial_path, database) do
+    [
+      "--format=custom",
+      "--no-owner",
+      "--no-privileges",
+      "--no-password",
+      "--file",
+      partial_path,
+      "--dbname",
+      database
+    ]
+  end
+
+  @doc """
+  Runs pg_dump with connection values supplied through `PG*` environment
+  variables. The wrapper terminates the child when its owning process closes
+  stdin, which lets cancellation leave no live pg_dump process behind.
+  """
+  @spec run(String.t(), [String.t()], [{String.t(), String.t()}], String.t()) ::
+          {String.t(), non_neg_integer()}
+  def run(executable, args, env, working_directory) do
+    wrapper = Path.join(:code.priv_dir(:pinchflat), "cmd_wrapper.sh")
+
+    {output, status} =
+      System.cmd(wrapper, [executable | args],
+        cd: working_directory,
+        env: env,
+        stderr_to_stdout: true
+      )
+
+    Logger.debug("PostgreSQL pg_dump exited with status #{status}")
+    {output, status}
+  rescue
+    _error -> {"pg_dump could not be started", 127}
+  end
+end

--- a/lib/pinchflat/settings/setting.ex
+++ b/lib/pinchflat/settings/setting.ex
@@ -33,7 +33,8 @@ defmodule Pinchflat.Settings.Setting do
     :yt_dlp_remote_metadata_worker_concurrency,
     :channel_discovery_enabled,
     :channel_discovery_mentions_enabled,
-    :channel_discovery_featured_enabled
+    :channel_discovery_featured_enabled,
+    :postgres_backup_retention_count
   ]
 
   @time_formats ~w(24h 12h)
@@ -82,6 +83,7 @@ defmodule Pinchflat.Settings.Setting do
     field :channel_discovery_enabled, :boolean, default: false
     field :channel_discovery_mentions_enabled, :boolean, default: false
     field :channel_discovery_featured_enabled, :boolean, default: false
+    field :postgres_backup_retention_count, :integer, default: 7
 
     field :video_codec_preference, :string
     field :audio_codec_preference, :string
@@ -103,6 +105,7 @@ defmodule Pinchflat.Settings.Setting do
       greater_than_or_equal_to: 1,
       less_than_or_equal_to: 20
     )
+    |> validate_number(:postgres_backup_retention_count, greater_than_or_equal_to: 1, less_than_or_equal_to: 100)
   end
 
   @doc """

--- a/lib/pinchflat_web/controllers/settings/backup_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/backup_controller.ex
@@ -1,0 +1,62 @@
+defmodule PinchflatWeb.Settings.BackupController do
+  @moduledoc """
+  Creates and serves PostgreSQL database backups from the authenticated UI.
+  """
+
+  use PinchflatWeb, :controller
+
+  alias Pinchflat.Backups
+
+  @doc """
+  Creates a PostgreSQL backup and streams the completed dump to the browser.
+  """
+  def create(conn, _params) do
+    case Backups.create_backup() do
+      {:ok, %{path: path, filename: filename}} ->
+        send_download(conn, {:file, path},
+          filename: filename,
+          content_type: "application/octet-stream"
+        )
+
+      {:error, :unavailable} ->
+        unavailable(conn)
+
+      {:error, :pg_dump_unavailable} ->
+        failure(conn, "PostgreSQL backup tooling is not available in this image.")
+
+      {:error, _reason} ->
+        failure(conn, "The PostgreSQL backup could not be created. Check the application logs.")
+    end
+  end
+
+  @doc """
+  Streams a previously completed backup after validating its generated name
+  and regular-file type.
+  """
+  def download(conn, %{"filename" => filename}) do
+    case Backups.download_path(filename) do
+      {:ok, path} ->
+        send_download(conn, {:file, path},
+          filename: filename,
+          content_type: "application/octet-stream"
+        )
+
+      {:error, _reason} ->
+        conn
+        |> put_flash(:error, "That PostgreSQL backup is no longer available.")
+        |> redirect(to: ~p"/settings")
+    end
+  end
+
+  defp unavailable(conn) do
+    conn
+    |> put_flash(:error, "PostgreSQL backups are unavailable when PinchYT uses SQLite.")
+    |> redirect(to: ~p"/settings")
+  end
+
+  defp failure(conn, message) do
+    conn
+    |> put_flash(:error, message)
+    |> redirect(to: ~p"/settings")
+  end
+end

--- a/lib/pinchflat_web/controllers/settings/setting_controller.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_controller.ex
@@ -1,6 +1,7 @@
 defmodule PinchflatWeb.Settings.SettingController do
   use PinchflatWeb, :controller
 
+  alias Pinchflat.Backups
   alias Pinchflat.Settings
   alias Pinchflat.Reconciliation
   alias Pinchflat.Settings.CookieFile
@@ -13,7 +14,11 @@ defmodule PinchflatWeb.Settings.SettingController do
     setting = Settings.record()
     changeset = Settings.change_setting(setting, QueueConcurrency.form_attrs(setting))
 
-    render(conn, "show.html", changeset: changeset, concurrency_fields: QueueConcurrency.field_states(setting))
+    render(conn, "show.html",
+      changeset: changeset,
+      concurrency_fields: QueueConcurrency.field_states(setting),
+      backup_status: Backups.status()
+    )
   end
 
   def update(conn, %{"setting" => setting_params}) do
@@ -34,7 +39,8 @@ defmodule PinchflatWeb.Settings.SettingController do
       {:error, %Ecto.Changeset{} = changeset} ->
         render(conn, "show.html",
           changeset: changeset,
-          concurrency_fields: QueueConcurrency.field_states(setting)
+          concurrency_fields: QueueConcurrency.field_states(setting),
+          backup_status: Backups.status()
         )
     end
   end

--- a/lib/pinchflat_web/controllers/settings/setting_html.ex
+++ b/lib/pinchflat_web/controllers/settings/setting_html.ex
@@ -10,6 +10,7 @@ defmodule PinchflatWeb.Settings.SettingHTML do
   attr :changeset, Ecto.Changeset, required: true
   attr :action, :string, required: true
   attr :concurrency_fields, :map, required: true
+  attr :backup_status, :map, required: true
 
   def setting_form(assigns)
 
@@ -44,6 +45,19 @@ defmodule PinchflatWeb.Settings.SettingHTML do
   end
 
   def concurrency_help(%{locked: false}, unlocked_help), do: unlocked_help
+
+  def format_backup_size(bytes) when is_integer(bytes) and bytes < 1024, do: "#{bytes} B"
+
+  def format_backup_size(bytes) when is_integer(bytes) and bytes < 1024 * 1024 do
+    "#{Float.round(bytes / 1024, 1)} KB"
+  end
+
+  def format_backup_size(bytes) when is_integer(bytes) do
+    "#{Float.round(bytes / (1024 * 1024), 1)} MB"
+  end
+
+  def format_backup_datetime(%DateTime{} = datetime), do: Calendar.strftime(datetime, "%Y-%m-%d %H:%M:%S UTC")
+  def format_backup_datetime(_datetime), do: "-"
 
   defp download_workers_help do
     "How many videos can download at once. Each 1080p job opens two network streams, so start at 1–2 if you see timeouts or 'Network is unreachable'. Takes effect immediately."

--- a/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/setting_form.html.heex
@@ -127,6 +127,24 @@
     />
   </section>
 
+  <section class="theme-surface-raised px-5 py-5 sm:px-7.5" x-show="match(groups.backups)">
+    <h3 class="text-2xl text-theme-on-surface">PostgreSQL Backups</h3>
+    <%= if @backup_status.available do %>
+      <.input
+        field={f[:postgres_backup_retention_count]}
+        type="number"
+        min="1"
+        max="100"
+        label="Backups to Keep"
+        help="After each successful backup, PinchYT keeps this many completed PostgreSQL dumps and removes older ones. Failed or partial dumps are never retained."
+      />
+    <% else %>
+      <p id="postgres-backups-unavailable" class="mt-2 text-sm theme-status-warning">
+        PostgreSQL backups are unavailable in the SQLite image. Use the PostgreSQL image to create database dumps.
+      </p>
+    <% end %>
+  </section>
+
   <section class="theme-surface-raised px-5 py-5 sm:px-7.5" x-show="match(groups.discovery)">
     <h3 class="text-2xl text-theme-on-surface">Channel Discovery</h3>
 
@@ -213,12 +231,66 @@
   {live_render(@conn, Pinchflat.Settings.DefaultCookieBehaviourLive, id: "default-cookie-behaviour-live")}
 </section>
 
+<section id="postgres-backups" class="theme-surface-raised px-5 py-5 sm:px-7.5" x-show="match(groups.backups)">
+  <h3 class="text-2xl text-theme-on-surface">PostgreSQL Backup Files</h3>
+  <%= if @backup_status.available do %>
+    <div class="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <p class="text-sm text-theme-on-surface-muted">
+        Dumps are stored in PinchYT's persistent configuration volume and are available only through this authenticated UI.
+      </p>
+      <.link href={~p"/settings/backups"} method="post" class="w-full shrink-0 sm:w-auto">
+        <.button color="theme-primary-button" rounding="rounded-m3-sm" class="w-full text-sm sm:w-auto">
+          <.icon name="hero-circle-stack" class="mr-1 h-4 w-4" /> Create and Download Backup
+        </.button>
+      </.link>
+    </div>
+
+    <%= if @backup_status.backups == [] do %>
+      <p class="mt-4 text-sm text-theme-on-surface-muted">No completed PostgreSQL backups are available yet.</p>
+    <% else %>
+      <div class="mt-4 overflow-x-auto">
+        <table class="w-full text-sm">
+          <thead>
+            <tr class="border-b border-theme-outline">
+              <th class="py-2 text-left text-theme-on-surface-muted">Backup</th>
+              <th class="py-2 text-left text-theme-on-surface-muted">Created</th>
+              <th class="py-2 text-left text-theme-on-surface-muted">Size</th>
+              <th class="py-2 text-left text-theme-on-surface-muted">Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= for backup <- @backup_status.backups do %>
+              <tr class="border-b border-theme-outline/50">
+                <td class="py-2 font-mono text-xs text-theme-on-surface">{backup.filename}</td>
+                <td class="py-2 text-theme-on-surface">{format_backup_datetime(backup.modified_at)}</td>
+                <td class="py-2 text-theme-on-surface">{format_backup_size(backup.size)}</td>
+                <td class="py-2">
+                  <.link
+                    href={~p"/settings/backups/#{backup.filename}"}
+                    class="text-theme-primary hover:underline"
+                  >
+                    Download
+                  </.link>
+                </td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% end %>
+  <% else %>
+    <p class="mt-2 text-sm theme-status-warning">
+      PostgreSQL backup files are unavailable because this installation uses SQLite.
+    </p>
+  <% end %>
+</section>
+
 <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
   <.button
     class="w-full sm:w-auto"
     rounding="rounded-m3-sm"
     form="settings-form"
-    x-show="match(groups.notifications) || match(groups.extractor) || match(groups.discovery) || match(groups.ytdlp) || ((advancedMode || query.trim()) && match(groups.codec))"
+    x-show="match(groups.notifications) || match(groups.extractor) || match(groups.backups) || match(groups.discovery) || match(groups.ytdlp) || ((advancedMode || query.trim()) && match(groups.codec))"
   >
     Save Settings
   </.button>
@@ -227,7 +299,7 @@
 <p
   class="theme-surface-raised px-5 py-8 text-center text-sm text-theme-on-surface-muted sm:px-7.5"
   x-cloak
-  x-show="!match(groups.notifications) && !match(groups.extractor) && !match(groups.discovery) && !match(groups.ytdlp) && !match(groups.cookies) && !((advancedMode || query.trim()) && match(groups.codec))"
+  x-show="!match(groups.notifications) && !match(groups.extractor) && !match(groups.discovery) && !match(groups.ytdlp) && !match(groups.cookies) && !match(groups.backups) && !((advancedMode || query.trim()) && match(groups.codec))"
 >
   No settings match "<span x-text="query.trim()"></span>".
 </p>

--- a/lib/pinchflat_web/controllers/settings/setting_html/show.html.heex
+++ b/lib/pinchflat_web/controllers/settings/setting_html/show.html.heex
@@ -33,5 +33,6 @@
     changeset={@changeset}
     action={~p"/settings"}
     concurrency_fields={@concurrency_fields}
+    backup_status={@backup_status}
   />
 </div>

--- a/lib/pinchflat_web/router.ex
+++ b/lib/pinchflat_web/router.ex
@@ -74,6 +74,8 @@ defmodule PinchflatWeb.Router do
     resources "/search", Searches.SearchController, only: [:show], singleton: true
 
     resources "/settings", Settings.SettingController, only: [:show, :update], singleton: true
+    post "/settings/backups", Settings.BackupController, :create
+    get "/settings/backups/:filename", Settings.BackupController, :download
     get "/settings/cookies", Settings.SettingController, :download_cookies
     get "/download_logs", Settings.SettingController, :download_logs
 

--- a/priv/repo/migrations/20260911110000_add_postgres_backup_retention_to_settings.exs
+++ b/priv/repo/migrations/20260911110000_add_postgres_backup_retention_to_settings.exs
@@ -1,0 +1,9 @@
+defmodule Pinchflat.Repo.Migrations.AddPostgresBackupRetentionToSettings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:settings) do
+      add :postgres_backup_retention_count, :integer, default: 7, null: false
+    end
+  end
+end

--- a/test/pinchflat/backups/postgres_integration_test.exs
+++ b/test/pinchflat/backups/postgres_integration_test.exs
@@ -1,0 +1,58 @@
+defmodule Pinchflat.Backups.PostgresIntegrationTest do
+  use Pinchflat.DataCase
+
+  @moduletag :postgres_only
+
+  alias Pinchflat.Backups
+
+  setup do
+    directory =
+      Path.join([
+        System.tmp_dir!(),
+        "pinchyt-postgres-backups",
+        Integer.to_string(:erlang.unique_integer([:positive]))
+      ])
+
+    original_directory = Application.get_env(:pinchflat, :postgres_backup_directory)
+    Application.put_env(:pinchflat, :postgres_backup_directory, directory)
+    File.mkdir_p!(directory)
+
+    on_exit(fn ->
+      Application.put_env(:pinchflat, :postgres_backup_directory, original_directory)
+      File.rm_rf!(directory)
+    end)
+
+    {:ok, directory: directory}
+  end
+
+  test "pg_dump creates a restorable custom-format backup", %{directory: directory} do
+    assert {:ok, %{filename: filename, path: path, size: size}} = Backups.create_backup()
+    assert Backups.backup_filename?(filename)
+    assert size > 0
+    assert File.exists?(path)
+    assert Path.dirname(path) == directory
+
+    {output, status} = System.cmd("pg_restore", ["--list", path], stderr_to_stdout: true)
+
+    assert status == 0
+    assert output =~ "TABLE"
+  end
+
+  test "cleans failed pg_dump output and redacts credentials from logs", %{directory: directory} do
+    runner = fn _executable, args, _env, _working_directory ->
+      partial_path = args |> Enum.drop_while(&(&1 != "--file")) |> Enum.at(1)
+      File.write!(partial_path, "incomplete")
+      {"connection password postgres should never be logged", 1}
+    end
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert {:error, :pg_dump_failed} =
+                 Backups.create_backup(runner: runner, executable: "pg_dump")
+      end)
+
+    assert File.ls!(directory) == []
+    refute log =~ "connection password postgres"
+    refute log =~ "ecto://postgres:postgres"
+  end
+end

--- a/test/pinchflat/backups_test.exs
+++ b/test/pinchflat/backups_test.exs
@@ -1,0 +1,201 @@
+defmodule Pinchflat.BackupsTest do
+  use Pinchflat.DataCase
+
+  import ExUnit.CaptureLog
+
+  alias Pinchflat.Backups
+  alias Pinchflat.Backups.Connection
+
+  describe "connection details" do
+    test "maps DATABASE_URL values to pg_dump environment variables without a command-line URL" do
+      url = "ecto://backup-user:s3cr3t%21@postgres:5433/pinchflat?sslmode=require"
+
+      assert {:ok, connection} = Connection.from_url(url)
+      assert connection.database == "pinchflat"
+      assert {"PGHOST", "postgres"} in connection.env
+      assert {"PGPORT", "5433"} in connection.env
+      assert {"PGUSER", "backup-user"} in connection.env
+      assert {"PGPASSWORD", "s3cr3t!"} in connection.env
+      assert {"PGDATABASE", "pinchflat"} in connection.env
+      assert {"PGSSLMODE", "require"} in connection.env
+
+      args = Pinchflat.Backups.PgDumpRunner.args("/config/extras/backups/file.partial", connection.database)
+      refute Enum.any?(args, &String.contains?(&1, "s3cr3t"))
+    end
+
+    test "redacts both URI passwords and configured password values" do
+      url = "postgresql://user:secret@postgres/pinchflat"
+      {:ok, connection} = Connection.from_url(url)
+
+      redacted = Connection.redact("url=#{url} password=secret", connection)
+
+      refute redacted =~ "secret"
+      assert redacted =~ "[REDACTED]"
+    end
+  end
+
+  describe "backup files" do
+    setup do
+      directory =
+        Path.join([
+          System.tmp_dir!(),
+          "pinchyt-backups-test",
+          Integer.to_string(:erlang.unique_integer([:positive]))
+        ])
+
+      File.mkdir_p!(directory)
+      on_exit(fn -> File.rm_rf!(directory) end)
+      {:ok, directory: directory}
+    end
+
+    test "prunes only generated backup files and retains the newest requested count", %{directory: directory} do
+      filenames = [
+        "pinchyt-postgres-20260911-120000-000001-0000000000000001.dump",
+        "pinchyt-postgres-20260911-120001-000002-0000000000000002.dump",
+        "pinchyt-postgres-20260911-120002-000003-0000000000000003.dump"
+      ]
+
+      Enum.each(filenames, fn filename -> File.write!(Path.join(directory, filename), "dump") end)
+      File.write!(Path.join(directory, "not-a-backup.txt"), "keep")
+
+      assert {:ok, 1} = Backups.prune_backups(directory: directory, retention_count: 2)
+
+      assert Enum.map(Backups.list_backups(directory: directory), & &1.filename) ==
+               Enum.take(Enum.reverse(filenames), 2)
+
+      assert File.exists?(Path.join(directory, "not-a-backup.txt"))
+    end
+
+    test "retains the newest generated filename when filesystem mtimes tie", %{directory: directory} do
+      filenames = [
+        "pinchyt-postgres-20260911-120000-000001-0000000000000001.dump",
+        "pinchyt-postgres-20260911-120001-000002-0000000000000002.dump",
+        "pinchyt-postgres-20260911-120002-000003-0000000000000003.dump"
+      ]
+
+      tied_time = {{2026, 9, 11}, {12, 0, 0}}
+
+      Enum.each(filenames, fn filename ->
+        path = Path.join(directory, filename)
+        File.write!(path, "dump")
+        :ok = File.touch(path, tied_time)
+      end)
+
+      assert {:ok, 2} = Backups.prune_backups(directory: directory, retention_count: 1)
+
+      assert Enum.map(Backups.list_backups(directory: directory), & &1.filename) == [List.last(filenames)]
+
+      Enum.each(Enum.drop(filenames, -1), fn filename ->
+        refute File.exists?(Path.join(directory, filename))
+      end)
+    end
+
+    test "retains the newer same-second backup before comparing random suffixes", %{directory: directory} do
+      older = "pinchyt-postgres-20260911-120000-100000-ffffffffffffffff.dump"
+      newer = "pinchyt-postgres-20260911-120000-900000-0000000000000000.dump"
+      tied_time = {{2026, 9, 11}, {12, 0, 0}}
+
+      Enum.each([older, newer], fn filename ->
+        path = Path.join(directory, filename)
+        File.write!(path, "dump")
+        :ok = File.touch(path, tied_time)
+      end)
+
+      assert {:ok, 1} = Backups.prune_backups(directory: directory, retention_count: 1)
+      assert Enum.map(Backups.list_backups(directory: directory), & &1.filename) == [newer]
+      refute File.exists?(Path.join(directory, older))
+    end
+
+    test "accepts legacy second-precision backup filenames" do
+      assert Backups.backup_filename?("pinchyt-postgres-20260911-120000-0000000000000001.dump")
+      refute Backups.backup_filename?("pinchyt-postgres-20260911-120000-0000000000000001.dump.partial")
+      refute Backups.backup_filename?("../pinchyt-postgres-20260911-120000-0000000000000001.dump")
+    end
+
+    test "removes stale partial files but leaves recent partial files", %{directory: directory} do
+      stale = Path.join(directory, "pinchyt-postgres-old.dump.partial")
+      recent = Path.join(directory, "pinchyt-postgres-recent.dump.partial")
+      File.write!(stale, "partial")
+      File.write!(recent, "partial")
+
+      old_time = {{2020, 1, 1}, {0, 0, 0}}
+      :ok = File.touch(stale, old_time)
+
+      assert :ok =
+               Backups.cleanup_partial_files(
+                 directory: directory,
+                 now: ~U[2026-09-11 00:00:00Z]
+               )
+
+      refute File.exists?(stale)
+      assert File.exists?(recent)
+    end
+  end
+
+  describe "SQLite behavior" do
+    @describetag :sqlite_only
+
+    test "reports an explicit unavailable state" do
+      assert %{available: false, reason: :sqlite, backups: []} = Backups.status()
+      assert {:error, :unavailable} = Backups.create_backup()
+
+      assert {:error, :unavailable} =
+               Backups.download_path("pinchyt-postgres-20260911-120000-000001-0000000000000001.dump")
+    end
+  end
+
+  describe "failure logging" do
+    @describetag :postgres_only
+
+    setup do
+      directory =
+        Path.join([
+          System.tmp_dir!(),
+          "pinchyt-backups-failure-test",
+          Integer.to_string(:erlang.unique_integer([:positive]))
+        ])
+
+      original_directory = Application.get_env(:pinchflat, :postgres_backup_directory)
+      Application.put_env(:pinchflat, :postgres_backup_directory, directory)
+      File.mkdir_p!(directory)
+
+      on_exit(fn ->
+        Application.put_env(:pinchflat, :postgres_backup_directory, original_directory)
+        File.rm_rf!(directory)
+      end)
+
+      :ok
+    end
+
+    test "cleans a partial file and redacts command output when pg_dump fails" do
+      runner = fn _executable, args, _env, _directory ->
+        partial_path = args |> Enum.drop_while(&(&1 != "--file")) |> Enum.at(1)
+        File.write!(partial_path, "partial dump")
+        {"password=postgres", 1}
+      end
+
+      log =
+        capture_log(fn ->
+          assert {:error, :pg_dump_failed} =
+                   Backups.create_backup(runner: runner, executable: "pg_dump")
+        end)
+
+      assert File.ls!(Backups.backup_directory()) == []
+      refute log =~ "password=postgres"
+    end
+
+    test "cleans a partial file when the runner exits unexpectedly" do
+      runner = fn _executable, args, _env, _directory ->
+        partial_path = args |> Enum.drop_while(&(&1 != "--file")) |> Enum.at(1)
+        File.write!(partial_path, "cancelled dump")
+        raise "cancelled"
+      end
+
+      assert_raise RuntimeError, "cancelled", fn ->
+        Backups.create_backup(runner: runner, executable: "pg_dump")
+      end
+
+      assert File.ls!(Backups.backup_directory()) == []
+    end
+  end
+end

--- a/test/pinchflat/database/channel_discovery_migration_postgres_test.exs
+++ b/test/pinchflat/database/channel_discovery_migration_postgres_test.exs
@@ -21,6 +21,10 @@ defmodule Pinchflat.Database.ChannelDiscoveryMigrationPostgresTest do
 
   @text_columns ~w(canonical_url artwork_url evidence generators)
   @external_prefix "migration-test-"
+  @channel_discovery_migration {
+    20_260_911_100_000,
+    Pinchflat.Repo.Migrations.WidenChannelDiscoveryTextColumns
+  }
 
   setup_all do
     Ecto.Adapters.SQL.Sandbox.mode(Repo, :auto)
@@ -73,14 +77,12 @@ defmodule Pinchflat.Database.ChannelDiscoveryMigrationPostgresTest do
   end
 
   defp migrate_down do
-    assert [20_260_911_100_000] = Ecto.Migrator.run(Repo, migrations_path(), :down, step: 1)
+    assert [20_260_911_100_000] = Ecto.Migrator.run(Repo, [@channel_discovery_migration], :down, step: 1)
   end
 
   defp migrate_up do
-    assert [20_260_911_100_000] = Ecto.Migrator.run(Repo, migrations_path(), :up, step: 1)
+    assert [20_260_911_100_000] = Ecto.Migrator.run(Repo, [@channel_discovery_migration], :up, step: 1)
   end
-
-  defp migrations_path, do: Path.join(File.cwd!(), "priv/repo/migrations")
 
   defp insert_suggestion(attrs) do
     attrs =

--- a/test/pinchflat/settings_test.exs
+++ b/test/pinchflat/settings_test.exs
@@ -119,6 +119,22 @@ defmodule Pinchflat.SettingsTest do
                Settings.change_setting(setting, %{yt_dlp_download_worker_concurrency: 21})
     end
 
+    test "requires PostgreSQL backup retention to be between 1 and 100" do
+      setting = Settings.record()
+
+      assert %Ecto.Changeset{valid?: true} =
+               Settings.change_setting(setting, %{postgres_backup_retention_count: 1})
+
+      assert %Ecto.Changeset{valid?: true} =
+               Settings.change_setting(setting, %{postgres_backup_retention_count: 100})
+
+      assert %Ecto.Changeset{valid?: false} =
+               Settings.change_setting(setting, %{postgres_backup_retention_count: 0})
+
+      assert %Ecto.Changeset{valid?: false} =
+               Settings.change_setting(setting, %{postgres_backup_retention_count: 101})
+    end
+
     test "requires a pinned version when the policy is pinned" do
       setting = Settings.record()
 

--- a/test/pinchflat_web/controllers/setting_controller_test.exs
+++ b/test/pinchflat_web/controllers/setting_controller_test.exs
@@ -14,6 +14,11 @@ defmodule PinchflatWeb.SettingControllerTest do
       assert html =~ "Extractor Settings"
       assert html =~ "Cookies"
       assert html =~ "Base yt-dlp Config"
+      assert html =~ "PostgreSQL Backups"
+
+      if Pinchflat.Database.sqlite?() do
+        assert html =~ "PostgreSQL backups are unavailable in the SQLite image"
+      end
     end
   end
 
@@ -131,6 +136,17 @@ defmodule PinchflatWeb.SettingControllerTest do
 
       assert redirected_to(conn) == ~p"/diagnostics"
       assert conn.assigns[:flash]["error"] == "Log file couldn't be found"
+    end
+  end
+
+  describe "postgresql backups" do
+    @tag :sqlite_only
+
+    test "reports that backup creation is unavailable for SQLite", %{conn: conn} do
+      conn = post(conn, ~p"/settings/backups")
+
+      assert redirected_to(conn) == ~p"/settings"
+      assert conn.assigns[:flash]["error"] =~ "unavailable when PinchYT uses SQLite"
     end
   end
 end

--- a/test/pinchflat_web/controllers/settings/backup_controller_test.exs
+++ b/test/pinchflat_web/controllers/settings/backup_controller_test.exs
@@ -1,0 +1,32 @@
+defmodule PinchflatWeb.Settings.BackupControllerTest do
+  use PinchflatWeb.ConnCase
+
+  @moduletag :sqlite_only
+
+  describe "authorization boundary" do
+    setup do
+      original_username = Application.get_env(:pinchflat, :basic_auth_username)
+      original_password = Application.get_env(:pinchflat, :basic_auth_password)
+
+      Application.put_env(:pinchflat, :basic_auth_username, "backup-user")
+      Application.put_env(:pinchflat, :basic_auth_password, "backup-password")
+
+      on_exit(fn ->
+        Application.put_env(:pinchflat, :basic_auth_username, original_username)
+        Application.put_env(:pinchflat, :basic_auth_password, original_password)
+      end)
+
+      :ok
+    end
+
+    test "uses the authenticated browser pipeline", %{conn: conn} do
+      conn =
+        get(
+          conn,
+          ~p"/settings/backups/pinchyt-postgres-20260911-120000-000001-0000000000000001.dump"
+        )
+
+      assert response(conn, 401) == "Unauthorized"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add PostgreSQL-only in-app backups using custom-format pg_dump.
- Pass DATABASE_URL credentials through PG* environment variables without exposing them in command arguments or logs.
- Add authenticated backup creation and download routes, retention settings, atomic partial-file cleanup, and deterministic microsecond-based filenames.
- Install PostgreSQL 16 client tools in development and PostgreSQL release images.
- Show an explicit unavailable state in SQLite images and document pg_restore expectations.

## Verification

- PostgreSQL full mix check: 1,745 passed, 0 failures.
- SQLite full mix check: 1,745 passed, 0 failures.
- PostgreSQL repeat seed 12345: 1,745 passed, 0 failures.
- Isolated PostgreSQL migration tests: 3 passed, 0 failures.
- Focused backup tests, real dump/restore, cleanup, authentication, and retention checks passed.
- Fresh development and release images contain pg_dump and pg_restore 16.15.
- Compose validation, theme check, formatting, Credo, Sobelow, compiler, Prettier, and git diff --check passed.

Actionlint and interactive browser verification were unavailable in the environment; workflow formatting and controller/render tests passed.