### PR TITLE
chore: make PostgreSQL 18 the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ services:
     restart: unless-stopped
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_DB: pinchyt
       POSTGRES_PASSWORD: change-me
@@ -81,7 +81,7 @@ services:
       timeout: 5s
       retries: 10
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     restart: unless-stopped
 
 volumes:
@@ -89,7 +89,10 @@ volumes:
 ```
 
 The PostgreSQL image creates and migrates its own schema, but it does not copy data from an existing SQLite database.
-Keep using `latest` for an existing SQLite installation until you have migrated its data separately.
+This PostgreSQL 18 example is intended for a fresh installation. PostgreSQL 16 or earlier volumes are not
+compatible with the PostgreSQL 18 server as-is; use an explicit PostgreSQL upgrade or `pg_dump`/`pg_restore`
+procedure before reusing existing PostgreSQL data. Keep using `latest` for an existing SQLite installation until
+you have migrated its data separately.
 
 #### PostgreSQL database backups
 

--- a/docker/dev.Dockerfile
+++ b/docker/dev.Dockerfile
@@ -30,7 +30,7 @@ RUN set -eux; \
     . /etc/os-release; \
     echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
       > /etc/apt/sources.list.d/pgdg.list; \
-    DATABASE_CLIENT_PACKAGE="postgresql-client-16"; \
+    DATABASE_CLIENT_PACKAGE="postgresql-client-18"; \
   else \
     DATABASE_CLIENT_PACKAGE=""; \
   fi; \

--- a/docker/docker-compose.postgres.ci.yml
+++ b/docker/docker-compose.postgres.ci.yml
@@ -23,7 +23,7 @@ services:
     command: tail -F /dev/null
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_DB: pinchflat_test
       POSTGRES_PASSWORD: postgres
@@ -34,4 +34,4 @@ services:
       timeout: 5s
       retries: 15
     tmpfs:
-      - /var/lib/postgresql/data
+      - /var/lib/postgresql

--- a/docker/docker-compose.postgres.migrations.yml
+++ b/docker/docker-compose.postgres.migrations.yml
@@ -21,7 +21,7 @@ services:
     command: tail -F /dev/null
 
   postgres:
-    image: postgres:16-alpine
+    image: postgres:18-alpine
     environment:
       POSTGRES_DB: pinchflat_migrations_test
       POSTGRES_PASSWORD: postgres
@@ -32,4 +32,4 @@ services:
       timeout: 5s
       retries: 15
     tmpfs:
-      - /var/lib/postgresql/data
+      - /var/lib/postgresql

--- a/docker/selfhosted.Dockerfile
+++ b/docker/selfhosted.Dockerfile
@@ -111,7 +111,7 @@ RUN set -eux; \
       . /etc/os-release; \
       echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt ${VERSION_CODENAME}-pgdg main" \
         > /etc/apt/sources.list.d/pgdg.list; \
-      DATABASE_CLIENT_PACKAGE="postgresql-client-16"; \
+      DATABASE_CLIENT_PACKAGE="postgresql-client-18"; \
     else \
       DATABASE_CLIENT_PACKAGE=""; \
     fi; \


### PR DESCRIPTION
## Summary

- Update default PostgreSQL image in README and CI/migration compose definitions from \postgres:16-alpine\ to \postgres:18-alpine\.
- Update client package installation in \dev.Dockerfile\ and \selfhosted.Dockerfile\ to \postgresql-client-18\.
- Update data volume mount path in compose/README to \/var/lib/postgresql\ to match PostgreSQL 18 data directory layout.
- Document upgrade considerations in README noting fresh installation intent and existing volume incompatibility.